### PR TITLE
Fix - Solve travis ssh local dependency

### DIFF
--- a/packages/sanes-chrome-extension/package.json
+++ b/packages/sanes-chrome-extension/package.json
@@ -52,7 +52,7 @@
     "@types/encoding-down": "^5.0.0",
     "@types/levelup": "^3.1.0",
     "@types/memdown": "^3.0.0",
-    "cra-build-watch": "ssh://git@github.com:apanizo/cra-build-watch#a768c63d7deb0d56754426b0071a85562d0d9509",
+    "cra-build-watch": "apanizo/cra-build-watch#a768c63d7deb0d56754426b0071a85562d0d9509",
     "puppeteer": "^1.13.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5100,9 +5100,9 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.0.2, cosmiconfig@^5.0.5, cosmiconfig@^5.0.7, 
     js-yaml "^3.13.0"
     parse-json "^4.0.0"
 
-"cra-build-watch@ssh://git@github.com:apanizo/cra-build-watch#a768c63d7deb0d56754426b0071a85562d0d9509":
+cra-build-watch@apanizo/cra-build-watch#a768c63d7deb0d56754426b0071a85562d0d9509:
   version "0.0.0-development"
-  resolved "ssh://git@github.com:apanizo/cra-build-watch#a768c63d7deb0d56754426b0071a85562d0d9509"
+  resolved "https://codeload.github.com/apanizo/cra-build-watch/tar.gz/a768c63d7deb0d56754426b0071a85562d0d9509"
   dependencies:
     cross-spawn "6.0.5"
     fs-extra "5.0.0"


### PR DESCRIPTION
**Description**
For some reason, the `cra-build-watch` dependency was tied to ssh URL causing errors in Travis.