### PR TITLE
Fix - Remove BoxProp and lint warnings

### DIFF
--- a/packages/medulas-react-components/src/components/Block/index.tsx
+++ b/packages/medulas-react-components/src/components/Block/index.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import Box, { BoxProps } from '@material-ui/core/Box';
+import Box from '@material-ui/core/Box';
 import { SizingBreakpoint } from '../Grid';
 
 // TODO: Remove those props after BoxProps will be properly implemented.
-interface Props extends BoxProps {
+interface Props {
+  readonly id?: string;
   readonly children?: React.ReactNode;
   readonly display?: string;
   //Flexbox Props

--- a/packages/medulas-react-components/src/components/Button/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Button/index.stories.tsx
@@ -8,8 +8,41 @@ import Grid from '../Grid';
 import GridItem from '../GridItem';
 
 storiesOf('Components /Button', module)
-  .add('Button in phone screen', () => (
-    <div style={{ width: '425px' }}>
+  .add(
+    'Button in phone screen',
+    (): JSX.Element => (
+      <div style={{ width: '425px' }}>
+        <Storybook>
+          <Grid flexWrap="wrap" flexDirection="column">
+            <GridItem marginBottom={4}>
+              <Button onClick={action('clicked')}>Hower</Button>
+            </GridItem>
+            <GridItem marginBottom={4}>
+              <Button onClick={action('clicked')} disabled>
+                Disabled
+              </Button>
+            </GridItem>
+            <GridItem marginBottom={4}>
+              <Button onClick={action('clicked')} color="secondary">
+                Cancel
+              </Button>
+            </GridItem>
+            <GridItem marginBottom={4}>
+              <Back onClick={action('clicked')}>Back</Back>
+            </GridItem>
+            <GridItem marginBottom={4}>
+              <Button onClick={action('clicked')} fullWidth>
+                Full Width
+              </Button>
+            </GridItem>
+          </Grid>
+        </Storybook>
+      </div>
+    )
+  )
+  .add(
+    'Button in desktop screen',
+    (): JSX.Element => (
       <Storybook>
         <Grid flexWrap="wrap" flexDirection="column">
           <GridItem marginBottom={4}>
@@ -35,32 +68,5 @@ storiesOf('Components /Button', module)
           </GridItem>
         </Grid>
       </Storybook>
-    </div>
-  ))
-  .add('Button in desktop screen', () => (
-    <Storybook>
-      <Grid flexWrap="wrap" flexDirection="column">
-        <GridItem marginBottom={4}>
-          <Button onClick={action('clicked')}>Hower</Button>
-        </GridItem>
-        <GridItem marginBottom={4}>
-          <Button onClick={action('clicked')} disabled>
-            Disabled
-          </Button>
-        </GridItem>
-        <GridItem marginBottom={4}>
-          <Button onClick={action('clicked')} color="secondary">
-            Cancel
-          </Button>
-        </GridItem>
-        <GridItem marginBottom={4}>
-          <Back onClick={action('clicked')}>Back</Back>
-        </GridItem>
-        <GridItem marginBottom={4}>
-          <Button onClick={action('clicked')} fullWidth>
-            Full Width
-          </Button>
-        </GridItem>
-      </Grid>
-    </Storybook>
-  ));
+    )
+  );

--- a/packages/medulas-react-components/src/components/Grid/index.tsx
+++ b/packages/medulas-react-components/src/components/Grid/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Box, { BoxProps } from '@material-ui/core/Box';
+import Box from '@material-ui/core/Box';
 
 export interface SizingBreakpoint {
   xs?: string | number;
@@ -10,7 +10,7 @@ export interface SizingBreakpoint {
 }
 
 // TODO: Remove those props after BoxProps will be properly implemented.
-interface Props extends BoxProps {
+interface Props {
   readonly children?: React.ReactNode;
   //Flexbox Props
   readonly flexDirection?:

--- a/packages/medulas-react-components/src/components/GridItem/index.tsx
+++ b/packages/medulas-react-components/src/components/GridItem/index.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import Box, { BoxProps } from '@material-ui/core/Box';
+import Box from '@material-ui/core/Box';
 import { SizingBreakpoint } from '../Grid';
 
 // TODO: Remove those props after BoxProps will be properly implemented.
-interface Props extends BoxProps {
+interface Props {
   readonly children?: React.ReactNode;
   //Flexbox Props
   readonly flexDirection?:

--- a/packages/medulas-react-components/src/components/Image/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Image/index.stories.tsx
@@ -4,8 +4,11 @@ import Image from './index';
 import { Storybook } from '../../utils/storybook';
 import iovLogo from './assets/iov-logo.png';
 
-storiesOf('Components', module).add('Images', () => (
-  <Storybook>
-    <Image src={iovLogo} alt="Iov Logo" />
-  </Storybook>
-));
+storiesOf('Components', module).add(
+  'Images',
+  (): JSX.Element => (
+    <Storybook>
+      <Image src={iovLogo} alt="Iov Logo" />
+    </Storybook>
+  )
+);

--- a/packages/medulas-react-components/src/components/PageLayout/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/PageLayout/index.stories.tsx
@@ -4,10 +4,13 @@ import Typography from '../Typography';
 import PageLayout from './index';
 import { Storybook } from '../../utils/storybook';
 
-storiesOf('Components', module).add('Layout', () => (
-  <Storybook>
-    <PageLayout primaryTitle="Title" title="storybook">
-      <Typography variant="h6">Layout content</Typography>
-    </PageLayout>
-  </Storybook>
-));
+storiesOf('Components', module).add(
+  'Layout',
+  (): JSX.Element => (
+    <Storybook>
+      <PageLayout primaryTitle="Title" title="storybook">
+        <Typography variant="h6">Layout content</Typography>
+      </PageLayout>
+    </Storybook>
+  )
+);

--- a/packages/medulas-react-components/src/components/Switch/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Switch/index.stories.tsx
@@ -4,13 +4,16 @@ import Switch from './index';
 import Block from '../Block';
 import { Storybook } from '../../utils/storybook';
 
-storiesOf('Components', module).add('Switch', () => (
-  <Storybook>
-    <Block>
-      <Switch color="primary" label="With label" />
-    </Block>
-    <Block>
-      <Switch color="primary" />
-    </Block>
-  </Storybook>
-));
+storiesOf('Components', module).add(
+  'Switch',
+  (): JSX.Element => (
+    <Storybook>
+      <Block>
+        <Switch color="primary" label="With label" />
+      </Block>
+      <Block>
+        <Switch color="primary" />
+      </Block>
+    </Storybook>
+  )
+);

--- a/packages/medulas-react-components/src/components/Tooltip/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Tooltip/index.stories.tsx
@@ -5,24 +5,27 @@ import Block from '../Block';
 import Typography from '../Typography';
 import { Storybook } from '../../utils/storybook';
 
-storiesOf('Components', module).add('Tooltip', () => {
-  const tooltipStyle: React.CSSProperties = { marginRight: '4px' };
+storiesOf('Components', module).add(
+  'Tooltip',
+  (): JSX.Element => {
+    const tooltipStyle: React.CSSProperties = { marginRight: '4px' };
 
-  return (
-    <Storybook>
-      <Block marginBottom={4}>
-        <Tooltip>
-          <Typography>Some tooltip text</Typography>
-        </Tooltip>
-      </Block>
-      <Block>
-        <Typography inline style={tooltipStyle}>
-          Loooooooooooooooooooooooooooooooooong text
-        </Typography>
-        <Tooltip>
-          <Typography>Tooltip for long text</Typography>
-        </Tooltip>
-      </Block>
-    </Storybook>
-  );
-});
+    return (
+      <Storybook>
+        <Block marginBottom={4}>
+          <Tooltip>
+            <Typography>Some tooltip text</Typography>
+          </Tooltip>
+        </Block>
+        <Block>
+          <Typography inline style={tooltipStyle}>
+            Loooooooooooooooooooooooooooooooooong text
+          </Typography>
+          <Tooltip>
+            <Typography>Tooltip for long text</Typography>
+          </Tooltip>
+        </Block>
+      </Storybook>
+    );
+  }
+);

--- a/packages/medulas-react-components/src/components/Tooltip/index.tsx
+++ b/packages/medulas-react-components/src/components/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import { Popper, makeStyles } from '@material-ui/core';
+import { Popper, makeStyles, Theme } from '@material-ui/core';
 import Paper from '@material-ui/core/Paper';
 import * as React from 'react';
 import Image from '../Image';
@@ -7,7 +7,8 @@ import theme from '../../theme/utils/mui';
 
 const DEFAULT_HEIGHT = 16;
 
-const useStyles = makeStyles(theme => ({
+//eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const useStyles = makeStyles((theme: Theme) => ({
   paper: {
     padding: theme.spacing(2),
     boxShadow: `0 0 14px 0 #edeff4`,
@@ -92,7 +93,7 @@ interface Props {
 
 const Tooltip = ({ children, maxWidth = 200 }: Props): JSX.Element => {
   const [open, setOpen] = React.useState<boolean>(false);
-  const toggle = (): void => setOpen(open => !open);
+  const toggle = (): void => setOpen(open => !open); //eslint-disable-line @typescript-eslint/explicit-function-return-type
 
   const [arrowRef, setArrowRef] = React.useState<HTMLSpanElement>();
 
@@ -104,7 +105,7 @@ const Tooltip = ({ children, maxWidth = 200 }: Props): JSX.Element => {
     maxWidth,
   };
 
-  const arrowRefCb = React.useCallback((node: HTMLSpanElement | null) => {
+  const arrowRefCb = React.useCallback((node: HTMLSpanElement | null): void => {
     if (node !== null) {
       setArrowRef(node);
     }

--- a/packages/medulas-react-components/src/components/Typography/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Typography/index.stories.tsx
@@ -3,44 +3,47 @@ import React from 'react';
 import Typography from './index';
 import { Storybook } from '../../utils/storybook';
 
-storiesOf('Components', module).add('Typography', () => (
-  <Storybook>
-    <Typography variant="subtitle1" color="primary">
-      H4
-    </Typography>
-    <Typography variant="h4">Main headings</Typography>
-    <Typography variant="subtitle1" color="primary">
-      H5
-    </Typography>
-    <Typography variant="h5">Heading 2</Typography>
-    <Typography variant="subtitle1" color="primary">
-      H6
-    </Typography>
-    <Typography variant="h6">Subheading</Typography>
-    <Typography variant="subtitle1" color="primary">
-      body1
-    </Typography>
-    <Typography variant="body1">Lorem ipsum dolor sit amet</Typography>
-    <Typography variant="subtitle1" color="primary">
-      body2
-    </Typography>
-    <Typography variant="body2">Lorem ipsum dolor sit amet</Typography>
-    <Typography variant="subtitle1" color="primary">
-      subtitle1
-    </Typography>
-    <Typography variant="subtitle1">Text field label</Typography>
-    <Typography variant="subtitle1" color="primary">
-      subtitle2
-    </Typography>
-    <Typography variant="subtitle2">Text field label</Typography>
-    <Typography variant="subtitle1" color="primary">
-      Inline styles
-    </Typography>
-    <Typography variant="subtitle2" color="primary" inline>
-      {'First part of the text. '}
-    </Typography>
-    <Typography variant="subtitle2" inline>
-      Second part of the text.
-    </Typography>
-  </Storybook>
-));
+storiesOf('Components', module).add(
+  'Typography',
+  (): JSX.Element => (
+    <Storybook>
+      <Typography variant="subtitle1" color="primary">
+        H4
+      </Typography>
+      <Typography variant="h4">Main headings</Typography>
+      <Typography variant="subtitle1" color="primary">
+        H5
+      </Typography>
+      <Typography variant="h5">Heading 2</Typography>
+      <Typography variant="subtitle1" color="primary">
+        H6
+      </Typography>
+      <Typography variant="h6">Subheading</Typography>
+      <Typography variant="subtitle1" color="primary">
+        body1
+      </Typography>
+      <Typography variant="body1">Lorem ipsum dolor sit amet</Typography>
+      <Typography variant="subtitle1" color="primary">
+        body2
+      </Typography>
+      <Typography variant="body2">Lorem ipsum dolor sit amet</Typography>
+      <Typography variant="subtitle1" color="primary">
+        subtitle1
+      </Typography>
+      <Typography variant="subtitle1">Text field label</Typography>
+      <Typography variant="subtitle1" color="primary">
+        subtitle2
+      </Typography>
+      <Typography variant="subtitle2">Text field label</Typography>
+      <Typography variant="subtitle1" color="primary">
+        Inline styles
+      </Typography>
+      <Typography variant="subtitle2" color="primary" inline>
+        {'First part of the text. '}
+      </Typography>
+      <Typography variant="subtitle2" inline>
+        Second part of the text.
+      </Typography>
+    </Storybook>
+  )
+);

--- a/packages/medulas-react-components/src/components/forms/Form/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/Form/index.stories.tsx
@@ -47,8 +47,11 @@ const FormStory = (): JSX.Element => {
   );
 };
 
-storiesOf('Components /forms', module).add('Form', () => (
-  <Storybook>
-    <FormStory />
-  </Storybook>
-));
+storiesOf('Components /forms', module).add(
+  'Form',
+  (): JSX.Element => (
+    <Storybook>
+      <FormStory />
+    </Storybook>
+  )
+);

--- a/packages/medulas-react-components/src/components/forms/TextFieldForm/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/TextFieldForm/index.stories.tsx
@@ -51,36 +51,43 @@ const gridItemWidth: SizingBreakpoint = {
   sm: '50%',
 };
 
-storiesOf('Components /TextFieldForm', module).add('Examples', () => (
-  <Storybook>
-    <Grid flexWrap="wrap">
-      <GridItem marginBottom={4} width={gridItemWidth}>
-        <TextField
-          name="field-with-error"
-          label="Error"
-          defaultValue="Standard Error"
-          helperText="This is an error message"
-          error
-        />
-      </GridItem>
-      <GridItem marginBottom={4} width={gridItemWidth}>
-        <TextField name="field-filled" label="Filled" defaultValue="test*iov" />
-      </GridItem>
-      <GridItem marginBottom={4} width={gridItemWidth}>
-        <TextField
-          disabled
-          name="standard-disabled"
-          label="Disabled"
-          defaultValue="Disabled input"
-        />
-      </GridItem>
-      <GridItem marginBottom={4} width={gridItemWidth}>
-        <TextField
-          name="standard-with-placeholder"
-          label="Empty"
-          placeholder="IOV or wallet address"
-        />
-      </GridItem>
-    </Grid>
-  </Storybook>
-));
+storiesOf('Components /TextFieldForm', module).add(
+  'Examples',
+  (): JSX.Element => (
+    <Storybook>
+      <Grid flexWrap="wrap">
+        <GridItem marginBottom={4} width={gridItemWidth}>
+          <TextField
+            name="field-with-error"
+            label="Error"
+            defaultValue="Standard Error"
+            helperText="This is an error message"
+            error
+          />
+        </GridItem>
+        <GridItem marginBottom={4} width={gridItemWidth}>
+          <TextField
+            name="field-filled"
+            label="Filled"
+            defaultValue="test*iov"
+          />
+        </GridItem>
+        <GridItem marginBottom={4} width={gridItemWidth}>
+          <TextField
+            disabled
+            name="standard-disabled"
+            label="Disabled"
+            defaultValue="Disabled input"
+          />
+        </GridItem>
+        <GridItem marginBottom={4} width={gridItemWidth}>
+          <TextField
+            name="standard-with-placeholder"
+            label="Empty"
+            placeholder="IOV or wallet address"
+          />
+        </GridItem>
+      </Grid>
+    </Storybook>
+  )
+);

--- a/packages/sanes-chrome-extension/src/extension/backgroundscript.ts
+++ b/packages/sanes-chrome-extension/src/extension/backgroundscript.ts
@@ -13,7 +13,7 @@ chrome.runtime.onMessage.addListener(
     message: MsgToBackground,
     sender: chrome.runtime.MessageSender,
     sendResponse
-  ) => {
+  ): void => {
     switch (message.msg) {
       case CTB_MSG_HELLO:
         if (sender.tab) {

--- a/packages/sanes-chrome-extension/src/extension/contentscript.ts
+++ b/packages/sanes-chrome-extension/src/extension/contentscript.ts
@@ -2,7 +2,7 @@ import { MsgToBackground } from './utils/types.js';
 import { WTC_MSG_HELLO, CTB_MSG_HELLO } from './utils/messages';
 
 export const main = async (): Promise<void> => {
-  window.addEventListener(WTC_MSG_HELLO, function() {
+  window.addEventListener(WTC_MSG_HELLO, function(): void {
     const data: MsgToBackground = {
       msg: CTB_MSG_HELLO,
       data: undefined,

--- a/packages/sanes-chrome-extension/src/index.tsx
+++ b/packages/sanes-chrome-extension/src/index.tsx
@@ -13,28 +13,33 @@ const store = new Store();
 
 const rootEl = document.getElementById('root');
 
-store.ready().then(() => {
-  history.push(WELCOME_ROUTE);
+store.ready().then(
+  (): void => {
+    history.push(WELCOME_ROUTE);
 
-  const render = (Component: React.ComponentType): void => {
-    ReactDOM.render(
-      <Provider store={store}>
-        <MedulasThemeProvider injectFonts injectStyles={globalStyles}>
-          <ConnectedRouter history={history}>
-            <Component />
-          </ConnectedRouter>
-        </MedulasThemeProvider>
-      </Provider>,
-      rootEl
-    );
-  };
+    const render = (Component: React.ComponentType): void => {
+      ReactDOM.render(
+        <Provider store={store}>
+          <MedulasThemeProvider injectFonts injectStyles={globalStyles}>
+            <ConnectedRouter history={history}>
+              <Component />
+            </ConnectedRouter>
+          </MedulasThemeProvider>
+        </Provider>,
+        rootEl
+      );
+    };
 
-  render(Route);
+    render(Route);
 
-  if (module.hot) {
-    module.hot.accept('./routes', () => {
-      const NextApp = require('./routes').default;
-      render(NextApp);
-    });
+    if (module.hot) {
+      module.hot.accept(
+        './routes',
+        (): void => {
+          const NextApp = require('./routes').default;
+          render(NextApp);
+        }
+      );
+    }
   }
-});
+);

--- a/packages/sanes-chrome-extension/src/logic/blockchain/wallet.ts
+++ b/packages/sanes-chrome-extension/src/logic/blockchain/wallet.ts
@@ -8,6 +8,7 @@ export function walletFrom(
   codec: Codec,
   availableWallets: ValueAndUpdates<ReadonlyArray<WalletInfo>>
 ): WalletId {
+  //eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   const wallets = availableWallets.value.map(i => i.id);
   const [edWallet, secWallet] = wallets;
   switch (codec) {

--- a/packages/sanes-chrome-extension/src/logic/index.test.ts
+++ b/packages/sanes-chrome-extension/src/logic/index.test.ts
@@ -2,18 +2,21 @@ import { getPersona } from './index';
 import Persona from './persona';
 import { mayTestChains } from '../utils/test/testExecutor';
 
-describe('logic', () => {
-  mayTestChains('should get a Persona', async () => {
-    const password = 'test-password';
-    const accountName = 'test-account';
-    const persona: Persona = await getPersona(password, accountName);
-    const accounts = persona.accounts;
-    expect(accounts.has(accountName)).toEqual(true);
-    const account = accounts.get(accountName);
-    if (!account) {
-      throw new Error('Account should not be undefined');
-    }
+describe('logic', (): void => {
+  mayTestChains(
+    'should get a Persona',
+    async (): Promise<void> => {
+      const password = 'test-password';
+      const accountName = 'test-account';
+      const persona: Persona = await getPersona(password, accountName);
+      const accounts = persona.accounts;
+      expect(accounts.has(accountName)).toEqual(true);
+      const account = accounts.get(accountName);
+      if (!account) {
+        throw new Error('Account should not be undefined');
+      }
 
-    expect(account.blockchainAddresses.size).toEqual(4);
-  });
+      expect(account.blockchainAddresses.size).toEqual(4);
+    }
+  );
 });

--- a/packages/sanes-chrome-extension/src/routes/signup/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/signup/index.dom.spec.ts
@@ -10,16 +10,18 @@ import {
 import { travelToSignup } from './test/travelToSignup';
 import { randomString } from '../../utils/test/random';
 
-describe('DOM > Feature > Signup', () => {
+describe('DOM > Feature > Signup', (): void => {
   let store: Store<RootState>;
 
-  beforeEach(() => {
-    store = aNewStore();
-  });
+  beforeEach(
+    (): void => {
+      store = aNewStore();
+    }
+  );
 
   mayTestChains(
     `should finish the signup three steps process`,
-    async () => {
+    async (): Promise<void> => {
       const signupDOM = await travelToSignup(store);
       const accountName = randomString(10);
 

--- a/packages/sanes-chrome-extension/src/routes/signup/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/signup/index.stories.tsx
@@ -7,27 +7,36 @@ import ShowPhraseForm from './components/ShowPhraseForm';
 import SecurityHintForm from './components/SecurityHintForm';
 
 storiesOf('Routes/Signup', module)
-  .add('New account page', () => (
-    <Storybook>
-      <NewAccountForm
-        onBack={action('back in history')}
-        onSignup={action('next step')}
-      />
-    </Storybook>
-  ))
-  .add('Recovery Phrase page', () => (
-    <Storybook>
-      <ShowPhraseForm
-        onBack={action('back in history')}
-        onHintPassword={action('hint step')}
-      />
-    </Storybook>
-  ))
-  .add('Security hint page', () => (
-    <Storybook>
-      <SecurityHintForm
-        onBack={action('back in history')}
-        onSaveHint={action('save hint')}
-      />
-    </Storybook>
-  ));
+  .add(
+    'New account page',
+    (): JSX.Element => (
+      <Storybook>
+        <NewAccountForm
+          onBack={action('back in history')}
+          onSignup={action('next step')}
+        />
+      </Storybook>
+    )
+  )
+  .add(
+    'Recovery Phrase page',
+    (): JSX.Element => (
+      <Storybook>
+        <ShowPhraseForm
+          onBack={action('back in history')}
+          onHintPassword={action('hint step')}
+        />
+      </Storybook>
+    )
+  )
+  .add(
+    'Security hint page',
+    (): JSX.Element => (
+      <Storybook>
+        <SecurityHintForm
+          onBack={action('back in history')}
+          onSaveHint={action('save hint')}
+        />
+      </Storybook>
+    )
+  );

--- a/packages/sanes-chrome-extension/src/routes/signup/test/fillSignupForm.ts
+++ b/packages/sanes-chrome-extension/src/routes/signup/test/fillSignupForm.ts
@@ -25,34 +25,42 @@ export const submitAccountForm = async (
   const passwordField = inputs[1];
   const passwordConfirmField = inputs[2];
 
-  TestUtils.act(() => {
-    TestUtils.Simulate.change(accountNameField, {
-      target: {
-        value: accountName,
-      },
-    } as any); //eslint-disable-line @typescript-eslint/no-explicit-any
-  });
+  TestUtils.act(
+    (): void => {
+      TestUtils.Simulate.change(accountNameField, {
+        target: {
+          value: accountName,
+        },
+      } as any); //eslint-disable-line @typescript-eslint/no-explicit-any
+    }
+  );
 
-  TestUtils.act(() => {
-    TestUtils.Simulate.change(passwordField, {
-      target: { value: password },
-    } as any); //eslint-disable-line @typescript-eslint/no-explicit-any
-  });
+  TestUtils.act(
+    (): void => {
+      TestUtils.Simulate.change(passwordField, {
+        target: { value: password },
+      } as any); //eslint-disable-line @typescript-eslint/no-explicit-any
+    }
+  );
 
-  TestUtils.act(() => {
-    TestUtils.Simulate.change(passwordConfirmField, {
-      target: { value: password },
-    } as any); //eslint-disable-line @typescript-eslint/no-explicit-any
-  });
+  TestUtils.act(
+    (): void => {
+      TestUtils.Simulate.change(passwordConfirmField, {
+        target: { value: password },
+      } as any); //eslint-disable-line @typescript-eslint/no-explicit-any
+    }
+  );
 
   const form = TestUtils.findRenderedDOMComponentWithTag(
     AccountSubmitDom,
     'form'
   );
 
-  TestUtils.act(() => {
-    TestUtils.Simulate.submit(form);
-  });
+  TestUtils.act(
+    (): void => {
+      TestUtils.Simulate.submit(form);
+    }
+  );
 
   await findRenderedDOMComponentWithId(
     AccountSubmitDom,
@@ -68,11 +76,13 @@ export const handlePassPhrase = async (
     'input'
   );
   expect(inputs.length).toBe(1);
-  TestUtils.act(() => {
-    TestUtils.Simulate.change(inputs[0], {
-      target: { checked: true } as any, //eslint-disable-line @typescript-eslint/no-explicit-any
-    });
-  });
+  TestUtils.act(
+    (): void => {
+      TestUtils.Simulate.change(inputs[0], {
+        target: { checked: true } as any, //eslint-disable-line @typescript-eslint/no-explicit-any
+      });
+    }
+  );
 
   await sleep(600);
 
@@ -90,9 +100,11 @@ export const handlePassPhrase = async (
   );
   expect(buttons.length).toBe(2);
   const nextButton = buttons[1];
-  TestUtils.act(() => {
-    TestUtils.Simulate.click(nextButton);
-  });
+  TestUtils.act(
+    (): void => {
+      TestUtils.Simulate.click(nextButton);
+    }
+  );
 
   await findRenderedDOMComponentWithId(
     RecoveryPhraseDom,
@@ -110,20 +122,24 @@ export const handleSecurityHint = async (
     'input'
   );
   expect(inputs.length).toBe(1);
-  TestUtils.act(() => {
-    TestUtils.Simulate.change(inputs[0], {
-      target: { value: 'Dummy Hint' },
-    } as any); //eslint-disable-line @typescript-eslint/no-explicit-any
-  });
+  TestUtils.act(
+    (): void => {
+      TestUtils.Simulate.change(inputs[0], {
+        target: { value: 'Dummy Hint' },
+      } as any); //eslint-disable-line @typescript-eslint/no-explicit-any
+    }
+  );
 
   const form = TestUtils.findRenderedDOMComponentWithTag(
     SecurityHintDom,
     'form'
   );
 
-  TestUtils.act(() => {
-    TestUtils.Simulate.submit(form);
-  });
+  TestUtils.act(
+    (): void => {
+      TestUtils.Simulate.submit(form);
+    }
+  );
 
   await sleep(400);
   const hint = getHintPhrase(accountName);

--- a/packages/sanes-chrome-extension/src/routes/signup/test/travelToSignup.ts
+++ b/packages/sanes-chrome-extension/src/routes/signup/test/travelToSignup.ts
@@ -9,9 +9,11 @@ export const travelToSignup = async (
   store: Store
 ): Promise<React.Component> => {
   const dom = createDom(store);
-  TestUtils.act(() => {
-    history.push(SIGNUP_ROUTE);
-  });
+  TestUtils.act(
+    (): void => {
+      history.push(SIGNUP_ROUTE);
+    }
+  );
   await whenOnNavigatedToRoute(store, SIGNUP_ROUTE);
 
   return dom;

--- a/packages/sanes-chrome-extension/src/routes/welcome/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/welcome/index.dom.spec.ts
@@ -7,24 +7,28 @@ import { aNewStore } from '../../store';
 import { whenOnNavigatedToRoute } from '../../utils/test/navigation';
 import { sleep } from '../../utils/timer';
 
-describe('DOM > Feature > Welcome', () => {
+describe('DOM > Feature > Welcome', (): void => {
   let store: Store<RootState>;
   let dom: React.Component;
 
-  beforeEach(async () => {
-    store = aNewStore();
-    dom = createDom(store);
-    TestUtils.act(() => {
-      history.push(WELCOME_ROUTE);
-    });
-    await sleep(500);
-  });
+  beforeEach(
+    async (): Promise<void> => {
+      store = aNewStore();
+      dom = createDom(store);
+      TestUtils.act(
+        (): void => {
+          history.push(WELCOME_ROUTE);
+        }
+      );
+      await sleep(500);
+    }
+  );
 
-  it(`should create Welcome layout view`, async () => {
+  it(`should create Welcome layout view`, async (): Promise<void> => {
     await whenOnNavigatedToRoute(store, WELCOME_ROUTE);
   }, 55000);
 
-  it(`should create three buttons`, async () => {
+  it(`should create three buttons`, async (): Promise<void> => {
     const buttons = TestUtils.scryRenderedDOMComponentsWithTag(dom, 'button');
 
     expect(buttons.length).toBe(3);

--- a/packages/sanes-chrome-extension/src/routes/welcome/index.e2e.spec.tsx
+++ b/packages/sanes-chrome-extension/src/routes/welcome/index.e2e.spec.tsx
@@ -2,10 +2,10 @@ import puppeteer, { Browser, Page } from 'puppeteer';
 import { EXTENSION_HEIGHT, EXTENSION_WIDTH } from '../../theme/constants';
 import { WELCOME_ROUTE } from '../paths';
 
-describe('DOM > Welcome route', () => {
+describe('DOM > Welcome route', (): void => {
   let browser: Browser;
 
-  beforeEach(async () => {
+  beforeEach(async (): Promise<void> => {
     const CRX_PATH = require('path').join(__dirname, '../../../build');
     browser = await puppeteer.launch({
       headless: false,
@@ -22,18 +22,22 @@ describe('DOM > Welcome route', () => {
     });
   }, 45000);
 
-  afterEach(async () => {
-    await browser.close();
-  });
+  afterEach(
+    async (): Promise<void> => {
+      await browser.close();
+    }
+  );
 
-  it('loads correctly', async () => {
+  it('loads correctly', async (): Promise<void> => {
     const page: Page = await browser.newPage();
     await page.goto(
       'chrome-extension://dafekhlcpidfaopcimocbcpciholgkkb/index.html',
       { waitUntil: 'networkidle2' }
     );
 
-    const inner = await page.evaluate(async (id: string) => {
+    const inner = await page.evaluate(async (id: string): Promise<
+      string | undefined
+    > => {
       const element = document.getElementById(id);
       if (!element) {
         return undefined;

--- a/packages/sanes-chrome-extension/src/routes/welcome/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/welcome/index.stories.tsx
@@ -3,8 +3,11 @@ import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
 import Layout from './index';
 
-storiesOf('Routes/Welcome', module).add('Welcome page', () => (
-  <Storybook>
-    <Layout />
-  </Storybook>
-));
+storiesOf('Routes/Welcome', module).add(
+  'Welcome page',
+  (): void => (
+    <Storybook>
+      <Layout />
+    </Storybook>
+  )
+);

--- a/packages/sanes-chrome-extension/src/store/index.ts
+++ b/packages/sanes-chrome-extension/src/store/index.ts
@@ -26,9 +26,12 @@ export const makeStore = (): Store<RootState> => {
   );
 
   if (process.env.NODE_ENV !== 'production' && module.hot) {
-    module.hot.accept('./reducers', () => {
-      store.replaceReducer(reducer);
-    });
+    module.hot.accept(
+      './reducers',
+      (): void => {
+        store.replaceReducer(reducer);
+      }
+    );
   }
 
   return store;

--- a/packages/sanes-chrome-extension/src/utils/test/navigation.ts
+++ b/packages/sanes-chrome-extension/src/utils/test/navigation.ts
@@ -7,18 +7,20 @@ export const whenOnNavigatedToRoute = (
   refreshStore: Store,
   desiredRoute: string
 ): Promise<void> =>
-  new Promise((resolve, reject) => {
-    let times = 0;
-    const interval = setInterval(() => {
-      if (times >= MAX_TIMES_EXECUTED) {
-        clearInterval(interval);
-        reject();
-      }
-      const actualRoute = refreshStore.getState().router.location.pathname;
-      if (actualRoute === desiredRoute) {
-        clearInterval(interval);
-        resolve();
-      }
-      times += 1;
-    }, INTERVAL);
-  });
+  new Promise(
+    (resolve, reject): void => {
+      let times = 0;
+      const interval = setInterval((): void => {
+        if (times >= MAX_TIMES_EXECUTED) {
+          clearInterval(interval);
+          reject();
+        }
+        const actualRoute = refreshStore.getState().router.location.pathname;
+        if (actualRoute === desiredRoute) {
+          clearInterval(interval);
+          resolve();
+        }
+        times += 1;
+      }, INTERVAL);
+    }
+  );

--- a/packages/sanes-chrome-extension/src/utils/test/reactElemFinder.ts
+++ b/packages/sanes-chrome-extension/src/utils/test/reactElemFinder.ts
@@ -7,26 +7,28 @@ export const findRenderedDOMComponentWithId = (
   tree: React.Component<any>, // eslint-disable-line
   id: string
 ): Promise<React.ReactInstance> =>
-  new Promise((resolve, reject) => {
-    let times = 0;
-    const interval = setInterval(() => {
-      if (times >= MAX_TIMES_EXECUTED) {
-        clearInterval(interval);
-        reject(`Unable to find element with id: ${id}.`);
-      }
-
-      const elementsWithId = TestUtils.findAllInRenderedTree(
-        tree,
-        (inst: React.ReactInstance) => {
-          return TestUtils.isDOMComponent(inst) && inst.id === id;
+  new Promise(
+    (resolve, reject): void => {
+      let times = 0;
+      const interval = setInterval((): void => {
+        if (times >= MAX_TIMES_EXECUTED) {
+          clearInterval(interval);
+          reject(`Unable to find element with id: ${id}.`);
         }
-      );
 
-      if (elementsWithId.length === 1) {
-        clearInterval(interval);
-        resolve(elementsWithId[0]);
-      }
+        const elementsWithId = TestUtils.findAllInRenderedTree(
+          tree,
+          (inst: React.ReactInstance): boolean => {
+            return TestUtils.isDOMComponent(inst) && inst.id === id;
+          }
+        );
 
-      times += 1;
-    }, INTERVAL);
-  });
+        if (elementsWithId.length === 1) {
+          clearInterval(interval);
+          resolve(elementsWithId[0]);
+        }
+
+        times += 1;
+      }, INTERVAL);
+    }
+  );

--- a/packages/sanes-chrome-extension/src/utils/timer.ts
+++ b/packages/sanes-chrome-extension/src/utils/timer.ts
@@ -1,2 +1,2 @@
 export const sleep = (ms: number): Promise<void> =>
-  new Promise(resolve => setTimeout(resolve, ms));
+  new Promise(resolve => setTimeout(resolve, ms)); //eslint-disable-line @typescript-eslint/explicit-function-return-type


### PR DESCRIPTION
This PR should remove `BoxProps` interface from `Block`, `Grid` and `GridItem` components, because it is still raw and doesn't allow to use sizing and spacing properties with breakpoints. Like `width: { xs: '100px', md: '300px' }`