### PR TITLE
Feature - #25 Working with Persona inside extension

### DIFF
--- a/packages/sanes-chrome-extension/src/context/PersonaProvider.tsx
+++ b/packages/sanes-chrome-extension/src/context/PersonaProvider.tsx
@@ -1,0 +1,48 @@
+import { Amount } from '@iov/bcp';
+import * as React from 'react';
+
+type Accounts = ReadonlyArray<string>;
+type Balances = Map<string, ReadonlyArray<Amount>>;
+
+export interface PersonaContextInterface {
+  readonly accountNames: Accounts;
+  readonly balances: Balances;
+  readonly update: (
+    accountNames: Accounts,
+    balances: Map<string, ReadonlyArray<Amount>>
+  ) => void;
+}
+
+export const PersonaContext = React.createContext<PersonaContextInterface>({
+  accountNames: [],
+  balances: new Map(),
+  update: (): void => {},
+});
+
+interface Props {
+  readonly children: React.ReactNode;
+}
+
+export const ToastProvider = ({ children }: Props): JSX.Element => {
+  const [accountNames, setAccountNames] = React.useState<Accounts>([]);
+  const [balances, setBalances] = React.useState<Balances>(new Map());
+  const loadPersona = (
+    accountNames: Accounts,
+    balances: Map<string, ReadonlyArray<Amount>>
+  ): void => {
+    setAccountNames(accountNames);
+    setBalances(balances);
+  };
+
+  const personaContextValue = {
+    accountNames,
+    balances,
+    update: loadPersona,
+  };
+
+  return (
+    <PersonaContext.Provider value={personaContextValue}>
+      {children}
+    </PersonaContext.Provider>
+  );
+};

--- a/packages/sanes-chrome-extension/src/logic/index.ts
+++ b/packages/sanes-chrome-extension/src/logic/index.ts
@@ -6,6 +6,7 @@ import { createUserProfile } from './user';
 import { getConfig } from './blockchain/chainsConfig';
 import Persona from './persona';
 import { getDb } from './user/profile';
+import PersonaFactory from './personaFactory';
 
 // This method should be called by the "Create New Persona onSubmit fn"
 const buildPersona = async (password: string): Promise<Persona> => {
@@ -16,7 +17,7 @@ const buildPersona = async (password: string): Promise<Persona> => {
   // Remove the faucetSpect type because for creating a profile is not needed.
   const derivationInfo = config.chains.map(x => x.chainSpec);
 
-  const persona = new Persona(baseProfile, derivationInfo);
+  const persona = PersonaFactory.createPersona(baseProfile, derivationInfo);
   const derivation = 0;
   await persona.generateAccount(derivation);
   const db = await getDb();
@@ -27,5 +28,4 @@ const buildPersona = async (password: string): Promise<Persona> => {
 
 export const createPersona = singleton<typeof buildPersona>(buildPersona);
 
-export const getPersona = (): ReturnType<typeof buildPersona> =>
-  createPersona('');
+export const getPersona = (): Persona => PersonaFactory.getPersona();

--- a/packages/sanes-chrome-extension/src/logic/index.ts
+++ b/packages/sanes-chrome-extension/src/logic/index.ts
@@ -22,9 +22,6 @@ const buildPersona = async (password: string): Promise<Persona> => {
   const db = await getDb();
   baseProfile.storeIn(db, password);
 
-  // const ethanProfile = new ProfileWithAccounts(baseProfile, derivationInfo);
-  // const ethanAccount = await profile.ensureAccount(0, accountName);
-
   return persona;
 };
 

--- a/packages/sanes-chrome-extension/src/logic/persona.ts
+++ b/packages/sanes-chrome-extension/src/logic/persona.ts
@@ -5,10 +5,10 @@ import {
   PublicIdentity,
 } from '@iov/bcp';
 import { UserProfile, WalletId, MultiChainSigner } from '@iov/core';
-import { EnhancedChainSpec } from '../blockchain/chainsConfig';
+import { EnhancedChainSpec } from './blockchain/chainsConfig';
 import { Slip10RawIndex } from '@iov/crypto';
 import { ReadonlyWallet } from '@iov/keycontrol/types/wallet';
-import { chainConnector, codecFromString } from '../blockchain/connection';
+import { chainConnector, codecFromString } from './blockchain/connection';
 
 export interface AccountInfo {
   name: string;

--- a/packages/sanes-chrome-extension/src/logic/personaFactory.ts
+++ b/packages/sanes-chrome-extension/src/logic/personaFactory.ts
@@ -1,0 +1,25 @@
+import { UserProfile } from '@iov/core';
+import { EnhancedChainSpec } from './blockchain/chainsConfig';
+import Persona from './persona';
+
+class PersonaFactory {
+  // For now we only support one persona
+  // private static _personas = new Map<string, Persona>();
+  private static _persona: Persona;
+
+  public static createPersona(
+    userProfile: UserProfile,
+    chains: EnhancedChainSpec[]
+  ): Persona {
+    const persona = new Persona(userProfile, chains);
+    this._persona = persona;
+
+    return persona;
+  }
+
+  public static getPersona(): Persona {
+    return this._persona;
+  }
+}
+
+export default PersonaFactory;

--- a/packages/sanes-chrome-extension/src/routes/account/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/index.tsx
@@ -25,7 +25,7 @@ const AccountView = (): JSX.Element => {
 
   React.useEffect(() => {
     async function fetchMyAccounts(): Promise<void> {
-      const storedPersona = await getPersona();
+      const storedPersona = getPersona();
       persona.current = storedPersona;
       let actualItems: Item[] = [];
       Object.keys(persona.current.accounts).forEach((acc: string) =>


### PR DESCRIPTION
**Description**
This PR targets the Persona domain entity inside the React views/components. Making the logic of the existing views finished.

**Steps**
- [x] Adding Persona Context Provider for feeding React's context tree.
- [x] Creates PersonaFactory for accessing to memory persona variable.
- [ ] Ensure recovery-phrase logic is connected to Pesona.
- [ ] Ensure signup creates and handles correctly Persona
- [ ] Ensure account creates and handles correctly Persona

