### PR TITLE
Improve local blockchain start scripts

### DIFF
--- a/packages/sanes-chrome-extension/test/scripts/bcpd/genesis_app_state.json
+++ b/packages/sanes-chrome-extension/test/scripts/bcpd/genesis_app_state.json
@@ -36,5 +36,9 @@
       "name": "Another token of this chain",
       "sig_figs": 7
     }
-  ]
+  ],
+  "gconf": {
+    "cash:minimal_fee": {},
+    "cash:collector_address": "0000000000000000000000000000000000000000"
+  }
 }

--- a/packages/sanes-chrome-extension/test/scripts/bcpd/start.sh
+++ b/packages/sanes-chrome-extension/test/scripts/bcpd/start.sh
@@ -5,7 +5,7 @@ command -v shellcheck > /dev/null && shellcheck "$0"
 # Choose from https://hub.docker.com/r/iov1/tendermint/tags/
 export BCPD_TM_VERSION=v0.29.1
 # Choose from https://hub.docker.com/r/iov1/bcpd/tags/
-export BCPD_VERSION=v0.11.0
+export BCPD_VERSION=v0.11.1
 
 docker pull "iov1/tendermint:${BCPD_TM_VERSION}"
 docker pull "iov1/bcpd:${BCPD_VERSION}"

--- a/packages/sanes-chrome-extension/test/scripts/bnsd/genesis_app_state.json
+++ b/packages/sanes-chrome-extension/test/scripts/bnsd/genesis_app_state.json
@@ -36,5 +36,9 @@
       "name": "Quick trading token",
       "sig_figs": 9
     }
-  ]
+  ],
+  "gconf": {
+    "cash:minimal_fee": {},
+    "cash:collector_address": "0000000000000000000000000000000000000000"
+  }
 }

--- a/packages/sanes-chrome-extension/test/scripts/faucet/bcpd_start.sh
+++ b/packages/sanes-chrome-extension/test/scripts/faucet/bcpd_start.sh
@@ -3,7 +3,7 @@ set -o errexit -o nounset -o pipefail
 command -v shellcheck > /dev/null && shellcheck "$0"
 
 # Choose from https://hub.docker.com/r/iov1/iov-faucet/tags/
-FAUCET_VERSION="v0.5.0"
+FAUCET_VERSION="v0.5.2"
 
 TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/faucet_start_bov.XXXXXXXXX")
 LOGFILE="$TMP_DIR/faucet_bov.log"

--- a/packages/sanes-chrome-extension/test/scripts/faucet/bnsd_start.sh
+++ b/packages/sanes-chrome-extension/test/scripts/faucet/bnsd_start.sh
@@ -3,7 +3,7 @@ set -o errexit -o nounset -o pipefail
 command -v shellcheck > /dev/null && shellcheck "$0"
 
 # Choose from https://hub.docker.com/r/iov1/iov-faucet/tags/
-FAUCET_VERSION="v0.5.0"
+FAUCET_VERSION="v0.5.2"
 
 TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/faucet_start.XXXXXXXXX")
 LOGFILE="$TMP_DIR/faucet.log"

--- a/packages/sanes-chrome-extension/test/scripts/faucet/ethereum_start.sh
+++ b/packages/sanes-chrome-extension/test/scripts/faucet/ethereum_start.sh
@@ -3,7 +3,7 @@ set -o errexit -o nounset -o pipefail
 command -v shellcheck > /dev/null && shellcheck "$0"
 
 # Choose from https://hub.docker.com/r/iov1/iov-faucet/tags/
-FAUCET_VERSION="v0.5.0"
+FAUCET_VERSION="v0.5.2"
 
 TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/faucet_start_ethereum.XXXXXXXXX")
 LOGFILE="$TMP_DIR/faucet_ethereum.log"

--- a/packages/sanes-chrome-extension/test/scripts/faucet/lisk_start.sh
+++ b/packages/sanes-chrome-extension/test/scripts/faucet/lisk_start.sh
@@ -3,7 +3,7 @@ set -o errexit -o nounset -o pipefail
 command -v shellcheck > /dev/null && shellcheck "$0"
 
 # Choose from https://hub.docker.com/r/iov1/iov-faucet/tags
-FAUCET_VERSION="v0.5.0"
+FAUCET_VERSION="v0.5.2"
 
 TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/faucet_start_lisk.XXXXXXXXX")
 LOGFILE="$TMP_DIR/faucet_lisk.log"


### PR DESCRIPTION
- Fixes the _panic: cannot load \"cash:minimal_fee\" configuration: not found_ bug
- Updates BCPd to same version as BNSd
- Updates faucet to 0.5.2