### PR TITLE
Feature #16 - Share identity accept view

### DIFF
--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/AcceptRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/AcceptRequest.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import Button from 'medulas-react-components/lib/components/Button';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import Block from 'medulas-react-components/lib/components/Block';
+import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Back from 'medulas-react-components/lib/components/Button/Back';
+
+interface Props {
+  readonly onAcceptRequest: () => void;
+  readonly onBack: () => void;
+}
+
+const Layout = ({ onBack, onAcceptRequest }: Props): JSX.Element => (
+  <PageLayout primaryTitle="Share" title="Identity">
+    <Block textAlign="center">
+      <Typography variant="body1">The following site:</Typography>
+      <Typography variant="body1" color="primary">
+        http://finex.com
+      </Typography>
+      <Typography variant="body1" inline color="primary">
+        will be able to see
+      </Typography>
+      <Typography variant="body1" inline>
+        {' '}
+        your identity on
+      </Typography>
+      <Typography variant="body1" inline color="primary">
+        {' '}
+        BTC
+      </Typography>
+    </Block>
+    <Block marginTop={10} />
+    <Button variant="contained" fullWidth onClick={onAcceptRequest}>
+      Confirm
+    </Button>
+    <Block marginTop={2} />
+    <Back fullWidth onClick={onBack}>
+      Back
+    </Back>
+  </PageLayout>
+);
+
+export default Layout;

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/AcceptRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/AcceptRequest.tsx
@@ -26,7 +26,7 @@ const Layout = ({ onBack, onAcceptRequest }: Props): JSX.Element => (
       </Typography>
       <Typography variant="body1" inline color="primary">
         {' '}
-        BTC
+        ETH
       </Typography>
     </Block>
     <Block marginTop={10} />

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
@@ -17,9 +17,10 @@ const Layout = ({ showAcceptView }: Props): JSX.Element => (
       </Typography>
       <Typography variant="body1" inline>
         wants to see your identity on
-      </Typography>{' '}
+      </Typography>
       <Typography variant="body1" inline color="primary">
-        BTC
+        {' '}
+        ETH
       </Typography>
     </Block>
     <Block marginTop={10} />

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
@@ -4,22 +4,26 @@ import Typography from 'medulas-react-components/lib/components/Typography';
 import Block from 'medulas-react-components/lib/components/Block';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 
-const Layout = (): JSX.Element => (
-  <PageLayout primaryTitle="Share" title="identity">
+interface Props {
+  readonly showAcceptView: () => void;
+}
+
+const Layout = ({ showAcceptView }: Props): JSX.Element => (
+  <PageLayout primaryTitle="Share" title="Identity">
     <Block textAlign="center">
       <Typography variant="body1">The following site:</Typography>
       <Typography variant="body1" color="primary">
         http://finex.com
       </Typography>
       <Typography variant="body1" inline>
-        wants to see you identity on
+        wants to see your identity on
       </Typography>{' '}
       <Typography variant="body1" inline color="primary">
         BTC
       </Typography>
     </Block>
     <Block marginTop={10} />
-    <Button variant="contained" fullWidth>
+    <Button variant="contained" fullWidth onClick={showAcceptView}>
       Accept
     </Button>
     <Block marginTop={2} />

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
@@ -1,13 +1,24 @@
 import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
-import Layout from './index';
+import ShowRequest from './components/ShowRequest';
+import AcceptRequest from './components/AcceptRequest';
+import { action } from '@storybook/addon-actions';
 
-storiesOf('Extension', module).add(
-  'Share Identity page',
-  (): JSX.Element => (
-    <Storybook>
-      <Layout />
-    </Storybook>
+storiesOf('Routes/Share Identity', module)
+  .add(
+    'Show Request page',
+    (): JSX.Element => (
+      <Storybook>
+        <ShowRequest showAcceptView={action('showAcceptView')} />
+      </Storybook>
+    )
   )
-);
+  .add(
+    'Accept Request page',
+    (): JSX.Element => (
+      <Storybook>
+        <AcceptRequest onBack={action('onBack')} onAcceptRequest={action('onAcceptRequest')} />
+      </Storybook>
+    )
+  );

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
@@ -5,7 +5,7 @@ import ShowRequest from './components/ShowRequest';
 import AcceptRequest from './components/AcceptRequest';
 import { action } from '@storybook/addon-actions';
 
-storiesOf('Routes/Share Identity', module)
+storiesOf('Extension/Share Identity', module)
   .add(
     'Show Request page',
     (): JSX.Element => (

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
@@ -1,6 +1,23 @@
 import * as React from 'react';
-import Layout from './components';
+import AcceptRequest from './components/AcceptRequest';
+import ShowRequest from './components/ShowRequest';
 
-const Welcome = (): JSX.Element => <Layout />;
+const ShareIdentity = (): JSX.Element => {
+  const [action, setAction] = React.useState<'show' | 'accept'>('show');
 
-export default Welcome;
+  const showRequestView = (): void => setAction('show');
+  const showAcceptView = (): void => setAction('accept');
+
+  const onAcceptRequest = (): void => {
+    console.log('Accept request');
+  };
+
+  return (
+    <React.Fragment>
+      {action === 'show' && <ShowRequest showAcceptView={showAcceptView} />}
+      {action === 'accept' && <AcceptRequest onBack={showRequestView} onAcceptRequest={onAcceptRequest} />}
+    </React.Fragment>
+  );
+};
+
+export default ShareIdentity;

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2842,22 +2842,22 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
   id="/signup1"
 >
   <div
-    className="MuiBox-root-1301 MuiBox-root-1303"
+    className="MuiBox-root MuiBox-root-1303"
   >
     <h4
-      className="MuiTypography-root-1308 MuiTypography-h4-1316 MuiTypography-colorPrimary-1331 makeStyles-weight-1306 makeStyles-weight-1307 makeStyles-inline-1304"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1306 makeStyles-weight-1307 makeStyles-inline-1304"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root-1308 MuiTypography-h4-1316 makeStyles-weight-1306 makeStyles-weight-1338 makeStyles-inline-1304"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1306 makeStyles-weight-1338 makeStyles-inline-1304"
     >
 
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root-1301 MuiBox-root-1339"
+    className="MuiBox-root MuiBox-root-1339"
   >
     <form
       onSubmit={[Function]}

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2730,7 +2730,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1546 makeStyles-weight-1547 makeStyles-inline-1544"
     >
-      New
+      Share
     </h4>
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1546 makeStyles-weight-1578 makeStyles-inline-1544"
@@ -2741,6 +2741,122 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
   </div>
   <div
     className="MuiBox-root MuiBox-root-1579"
+  >
+    <div
+      className="MuiBox-root-1134 MuiBox-root-1173"
+    >
+      <p
+        className="MuiTypography-root-1141 MuiTypography-body1-1143 makeStyles-weight-1139 makeStyles-weight-1174"
+      >
+        The following site:
+      </p>
+      <p
+        className="MuiTypography-root-1141 MuiTypography-body1-1143 MuiTypography-colorPrimary-1164 makeStyles-weight-1139 makeStyles-weight-1175"
+      >
+        http://finex.com
+      </p>
+      <p
+        className="MuiTypography-root-1141 MuiTypography-body1-1143 makeStyles-weight-1139 makeStyles-weight-1176 makeStyles-inline-1137"
+      >
+        wants to see you identity on
+      </p>
+
+      <p
+        className="MuiTypography-root-1141 MuiTypography-body1-1143 MuiTypography-colorPrimary-1164 makeStyles-weight-1139 makeStyles-weight-1177 makeStyles-inline-1137"
+      >
+        BTC
+      </p>
+    </div>
+    <div
+      className="MuiBox-root-1134 MuiBox-root-1178"
+    />
+    <button
+      className="MuiButtonBase-root-1196 MuiButton-root-1179 MuiButton-contained-1187 MuiButton-containedPrimary-1188 MuiButton-fullWidth-1195"
+      disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiButton-label-1180"
+      >
+        Accept
+      </span>
+    </button>
+    <div
+      className="MuiBox-root-1134 MuiBox-root-1199"
+    />
+    <button
+      className="MuiButtonBase-root-1196 MuiButton-root-1179 MuiButton-contained-1187 MuiButton-containedSecondary-1189 MuiButton-fullWidth-1195"
+      disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiButton-label-1180"
+      >
+        Reject
+      </span>
+    </button>
+  </div>
+  <div
+    className="MuiBox-root-1134 MuiBox-root-1200"
+  />
+  <div
+    className="MuiBox-root-1134 MuiBox-root-1201"
+  >
+    <img
+      alt="IOV logo"
+      className="makeStyles-root-1202"
+      height={39}
+      src="iov-logo.png"
+      width={84}
+    />
+  </div>
+</div>
+`;
+
+exports[`Storyshots Routes/Signup New account page 1`] = `
+<div
+  className="MuiBox-root-1217 MuiBox-root-1218"
+  id="/signup1"
+>
+  <div
+    className="MuiBox-root-1217 MuiBox-root-1219"
+  >
+    <h4
+      className="MuiTypography-root-1224 MuiTypography-h4-1232 MuiTypography-colorPrimary-1247 makeStyles-weight-1222 makeStyles-weight-1223 makeStyles-inline-1220"
+    >
+      New
+    </h4>
+    <h4
+      className="MuiTypography-root-1224 MuiTypography-h4-1232 makeStyles-weight-1222 makeStyles-weight-1254 makeStyles-inline-1220"
+    >
+
+      Account
+    </h4>
+  </div>
+  <div
+    className="MuiBox-root-1217 MuiBox-root-1255"
   >
     <form
       onSubmit={[Function]}

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2482,7 +2482,7 @@ exports[`Storyshots Extension Share Identity page 1`] = `
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1383 makeStyles-weight-1415 makeStyles-inline-1381"
     >
 
-      identity
+      Identity
     </h4>
   </div>
   <div
@@ -2504,7 +2504,7 @@ exports[`Storyshots Extension Share Identity page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1383 makeStyles-weight-1420 makeStyles-inline-1381"
       >
-        wants to see you identity on
+        wants to see your identity on
       </p>
 
       <p
@@ -2520,6 +2520,7 @@ exports[`Storyshots Extension Share Identity page 1`] = `
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
       disabled={false}
       onBlur={[Function]}
+      onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
@@ -2850,14 +2851,14 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1306 makeStyles-weight-1338 makeStyles-inline-1304"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1550 makeStyles-weight-1582 makeStyles-inline-1548"
     >
 
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1339"
+    className="MuiBox-root MuiBox-root-1583"
   >
     <form
       onSubmit={[Function]}
@@ -3466,11 +3467,11 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
     className="MuiBox-root MuiBox-root-1897"
   />
   <div
-    className="MuiBox-root MuiBox-root-1898"
+    className="MuiBox-root MuiBox-root-1982"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1899"
+      className="makeStyles-root-1983"
       height={39}
       src="iov-logo.png"
       width={84}

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -142,9 +142,9 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
           <h6
             className="MuiTypography-root-45 MuiTypography-subtitle2-57 MuiTypography-colorTextSecondary-71 makeStyles-weight-43 makeStyles-weight-126"
           >
-            balance: 
+            balance:
             24
-             
+
             IOV
           </h6>
         </div>
@@ -771,7 +771,7 @@ exports[`Storyshots Components Layout 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-394 makeStyles-weight-426 makeStyles-inline-392"
     >
-       
+
       storybook
     </h4>
   </div>
@@ -1358,7 +1358,7 @@ Array [
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-558 makeStyles-weight-604 makeStyles-inline-556"
   >
-    First part of the text. 
+    First part of the text.
   </h6>,
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-558 makeStyles-weight-605 makeStyles-inline-556"
@@ -1819,7 +1819,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-941 makeStyles-weight-973 makeStyles-inline-939"
     >
-       
+
       Status
     </h4>
   </div>
@@ -2017,7 +2017,7 @@ exports[`Storyshots Extension Login page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1054 makeStyles-weight-1086 makeStyles-inline-1052"
     >
-       
+
       In
     </h4>
   </div>
@@ -2175,7 +2175,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1165 makeStyles-weight-1197 makeStyles-inline-1163"
     >
-       
+
       phrase
     </h4>
   </div>
@@ -2247,7 +2247,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1165 makeStyles-weight-1228 makeStyles-inline-1163"
       >
-        
+
       </p>
     </div>
     <div
@@ -2318,7 +2318,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1265 makeStyles-weight-1297 makeStyles-inline-1263"
     >
-       
+
       Account
     </h4>
   </div>
@@ -2481,7 +2481,7 @@ exports[`Storyshots Extension Share Identity page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1383 makeStyles-weight-1415 makeStyles-inline-1381"
     >
-       
+
       identity
     </h4>
   </div>
@@ -2506,7 +2506,7 @@ exports[`Storyshots Extension Share Identity page 1`] = `
       >
         wants to see you identity on
       </p>
-       
+
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1383 makeStyles-weight-1421 makeStyles-inline-1381"
       >
@@ -2603,7 +2603,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1466 makeStyles-weight-1498 makeStyles-inline-1464"
     >
-       
+
       to your IOV manager
     </h4>
   </div>
@@ -2735,7 +2735,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1546 makeStyles-weight-1578 makeStyles-inline-1544"
     >
-       
+
       Account
     </h4>
   </div>
@@ -3026,7 +3026,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1684 makeStyles-weight-1716 makeStyles-inline-1682"
     >
-       
+
       Account
     </h4>
   </div>
@@ -3113,7 +3113,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1684 makeStyles-weight-1763 makeStyles-inline-1682"
       >
-        
+
       </p>
     </div>
     <div
@@ -3214,7 +3214,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1801 makeStyles-weight-1833 makeStyles-inline-1799"
     >
-       
+
       Account
     </h4>
   </div>

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2758,7 +2758,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
       <p
         className="MuiTypography-root-1141 MuiTypography-body1-1143 makeStyles-weight-1139 makeStyles-weight-1176 makeStyles-inline-1137"
       >
-        wants to see you identity on
+        wants to see your identity on
       </p>
 
       <p
@@ -2774,6 +2774,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
       className="MuiButtonBase-root-1196 MuiButton-root-1179 MuiButton-contained-1187 MuiButton-containedPrimary-1188 MuiButton-fullWidth-1195"
       disabled={false}
       onBlur={[Function]}
+      onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
@@ -2837,26 +2838,26 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
 
 exports[`Storyshots Routes/Signup New account page 1`] = `
 <div
-  className="MuiBox-root-1217 MuiBox-root-1218"
+  className="MuiBox-root-1301 MuiBox-root-1302"
   id="/signup1"
 >
   <div
-    className="MuiBox-root-1217 MuiBox-root-1219"
+    className="MuiBox-root-1301 MuiBox-root-1303"
   >
     <h4
-      className="MuiTypography-root-1224 MuiTypography-h4-1232 MuiTypography-colorPrimary-1247 makeStyles-weight-1222 makeStyles-weight-1223 makeStyles-inline-1220"
+      className="MuiTypography-root-1308 MuiTypography-h4-1316 MuiTypography-colorPrimary-1331 makeStyles-weight-1306 makeStyles-weight-1307 makeStyles-inline-1304"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root-1224 MuiTypography-h4-1232 makeStyles-weight-1222 makeStyles-weight-1254 makeStyles-inline-1220"
+      className="MuiTypography-root-1308 MuiTypography-h4-1316 makeStyles-weight-1306 makeStyles-weight-1338 makeStyles-inline-1304"
     >
 
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root-1217 MuiBox-root-1255"
+    className="MuiBox-root-1301 MuiBox-root-1339"
   >
     <form
       onSubmit={[Function]}

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -142,9 +142,9 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
           <h6
             className="MuiTypography-root-45 MuiTypography-subtitle2-57 MuiTypography-colorTextSecondary-71 makeStyles-weight-43 makeStyles-weight-126"
           >
-            balance:
+            balance: 
             24
-
+             
             IOV
           </h6>
         </div>
@@ -771,7 +771,7 @@ exports[`Storyshots Components Layout 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-394 makeStyles-weight-426 makeStyles-inline-392"
     >
-
+       
       storybook
     </h4>
   </div>
@@ -1358,7 +1358,7 @@ Array [
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-558 makeStyles-weight-604 makeStyles-inline-556"
   >
-    First part of the text.
+    First part of the text. 
   </h6>,
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-558 makeStyles-weight-605 makeStyles-inline-556"
@@ -1819,7 +1819,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-941 makeStyles-weight-973 makeStyles-inline-939"
     >
-
+       
       Status
     </h4>
   </div>
@@ -2017,7 +2017,7 @@ exports[`Storyshots Extension Login page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1054 makeStyles-weight-1086 makeStyles-inline-1052"
     >
-
+       
       In
     </h4>
   </div>
@@ -2175,7 +2175,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1165 makeStyles-weight-1197 makeStyles-inline-1163"
     >
-
+       
       phrase
     </h4>
   </div>
@@ -2247,7 +2247,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1165 makeStyles-weight-1228 makeStyles-inline-1163"
       >
-
+        
       </p>
     </div>
     <div
@@ -2318,7 +2318,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1265 makeStyles-weight-1297 makeStyles-inline-1263"
     >
-
+       
       Account
     </h4>
   </div>
@@ -2466,9 +2466,10 @@ exports[`Storyshots Extension Restore Account page 1`] = `
 </div>
 `;
 
-exports[`Storyshots Extension Share Identity page 1`] = `
+exports[`Storyshots Extension Welcome page 1`] = `
 <div
   className="MuiBox-root MuiBox-root-1379"
+  id="/welcome"
 >
   <div
     className="MuiBox-root MuiBox-root-1380"
@@ -2476,148 +2477,25 @@ exports[`Storyshots Extension Share Identity page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1383 makeStyles-weight-1384 makeStyles-inline-1381"
     >
-      Share
+      Welcome
     </h4>
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1383 makeStyles-weight-1415 makeStyles-inline-1381"
     >
-
-      Identity
+       
+      to your IOV manager
     </h4>
   </div>
   <div
     className="MuiBox-root MuiBox-root-1416"
   >
-    <div
-      className="MuiBox-root MuiBox-root-1417"
-    >
-      <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1383 makeStyles-weight-1418"
-      >
-        The following site:
-      </p>
-      <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1383 makeStyles-weight-1419"
-      >
-        http://finex.com
-      </p>
-      <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1383 makeStyles-weight-1420 makeStyles-inline-1381"
-      >
-        wants to see your identity on
-      </p>
-
-      <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1383 makeStyles-weight-1421 makeStyles-inline-1381"
-      >
-        BTC
-      </p>
-    </div>
-    <div
-      className="MuiBox-root MuiBox-root-1422"
-    />
-    <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex="0"
-      type="button"
-    >
-      <span
-        className="MuiButton-label"
-      >
-        Accept
-      </span>
-      <span
-        className="MuiTouchRipple-root"
-      />
-    </button>
-    <div
-      className="MuiBox-root MuiBox-root-1443"
-    />
-    <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-fullWidth"
-      disabled={false}
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex="0"
-      type="button"
-    >
-      <span
-        className="MuiButton-label"
-      >
-        Reject
-      </span>
-      <span
-        className="MuiTouchRipple-root"
-      />
-    </button>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-1444"
-  />
-  <div
-    className="MuiBox-root MuiBox-root-1445"
-  >
-    <img
-      alt="IOV logo"
-      className="makeStyles-root-1446"
-      height={39}
-      src="iov-logo.png"
-      width={84}
-    />
-  </div>
-</div>
-`;
-
-exports[`Storyshots Extension Welcome page 1`] = `
-<div
-  className="MuiBox-root MuiBox-root-1462"
-  id="/welcome"
->
-  <div
-    className="MuiBox-root MuiBox-root-1463"
-  >
-    <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1466 makeStyles-weight-1467 makeStyles-inline-1464"
-    >
-      Welcome
-    </h4>
-    <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1466 makeStyles-weight-1498 makeStyles-inline-1464"
-    >
-
-      to your IOV manager
-    </h4>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-1499"
-  >
     <p
-      className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1466 makeStyles-weight-1500 makeStyles-inline-1464"
+      className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1383 makeStyles-weight-1417 makeStyles-inline-1381"
     >
       This plugin lets you manage all your accounts in one place.
     </p>
     <div
-      className="MuiBox-root MuiBox-root-1501"
+      className="MuiBox-root MuiBox-root-1418"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -2646,7 +2524,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
       />
     </button>
     <div
-      className="MuiBox-root MuiBox-root-1522"
+      className="MuiBox-root MuiBox-root-1439"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -2675,7 +2553,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
       />
     </button>
     <div
-      className="MuiBox-root MuiBox-root-1523"
+      className="MuiBox-root MuiBox-root-1440"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -2704,6 +2582,257 @@ exports[`Storyshots Extension Welcome page 1`] = `
     </button>
   </div>
   <div
+    className="MuiBox-root MuiBox-root-1441"
+  />
+  <div
+    className="MuiBox-root MuiBox-root-1442"
+  >
+    <img
+      alt="IOV logo"
+      className="makeStyles-root-1443"
+      height={39}
+      src="iov-logo.png"
+      width={84}
+    />
+  </div>
+</div>
+`;
+
+exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
+<div
+  className="MuiBox-root MuiBox-root-1542"
+>
+  <div
+    className="MuiBox-root MuiBox-root-1543"
+  >
+    <h4
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1546 makeStyles-weight-1547 makeStyles-inline-1544"
+    >
+      Share
+    </h4>
+    <h4
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1546 makeStyles-weight-1578 makeStyles-inline-1544"
+    >
+       
+      Identity
+    </h4>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-1579"
+  >
+    <div
+      className="MuiBox-root MuiBox-root-1580"
+    >
+      <p
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1546 makeStyles-weight-1581"
+      >
+        The following site:
+      </p>
+      <p
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1546 makeStyles-weight-1582"
+      >
+        http://finex.com
+      </p>
+      <p
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1546 makeStyles-weight-1583 makeStyles-inline-1544"
+      >
+        will be able to see
+      </p>
+      <p
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1546 makeStyles-weight-1584 makeStyles-inline-1544"
+      >
+         
+        your identity on
+      </p>
+      <p
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1546 makeStyles-weight-1585 makeStyles-inline-1544"
+      >
+         
+        BTC
+      </p>
+    </div>
+    <div
+      className="MuiBox-root MuiBox-root-1586"
+    />
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Confirm
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+    <div
+      className="MuiBox-root MuiBox-root-1607"
+    />
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Back
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-1608"
+  />
+  <div
+    className="MuiBox-root MuiBox-root-1609"
+  >
+    <img
+      alt="IOV logo"
+      className="makeStyles-root-1610"
+      height={39}
+      src="iov-logo.png"
+      width={84}
+    />
+  </div>
+</div>
+`;
+
+exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
+<div
+  className="MuiBox-root MuiBox-root-1459"
+>
+  <div
+    className="MuiBox-root MuiBox-root-1460"
+  >
+    <h4
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1463 makeStyles-weight-1464 makeStyles-inline-1461"
+    >
+      Share
+    </h4>
+    <h4
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1463 makeStyles-weight-1495 makeStyles-inline-1461"
+    >
+       
+      Identity
+    </h4>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-1496"
+  >
+    <div
+      className="MuiBox-root MuiBox-root-1497"
+    >
+      <p
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1463 makeStyles-weight-1498"
+      >
+        The following site:
+      </p>
+      <p
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1463 makeStyles-weight-1499"
+      >
+        http://finex.com
+      </p>
+      <p
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1463 makeStyles-weight-1500 makeStyles-inline-1461"
+      >
+        wants to see your identity on
+      </p>
+       
+      <p
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1463 makeStyles-weight-1501 makeStyles-inline-1461"
+      >
+        BTC
+      </p>
+    </div>
+    <div
+      className="MuiBox-root MuiBox-root-1502"
+    />
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Accept
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+    <div
+      className="MuiBox-root MuiBox-root-1523"
+    />
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-fullWidth"
+      disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Reject
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+  <div
     className="MuiBox-root MuiBox-root-1524"
   />
   <div
@@ -2722,149 +2851,32 @@ exports[`Storyshots Extension Welcome page 1`] = `
 
 exports[`Storyshots Extension/Signup New Account page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1542"
+  className="MuiBox-root MuiBox-root-1626"
   id="/signup1"
 >
   <div
-    className="MuiBox-root MuiBox-root-1543"
+    className="MuiBox-root MuiBox-root-1627"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1546 makeStyles-weight-1547 makeStyles-inline-1544"
-    >
-      Share
-    </h4>
-    <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1546 makeStyles-weight-1578 makeStyles-inline-1544"
-    >
-
-      Account
-    </h4>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-1579"
-  >
-    <div
-      className="MuiBox-root-1134 MuiBox-root-1173"
-    >
-      <p
-        className="MuiTypography-root-1141 MuiTypography-body1-1143 makeStyles-weight-1139 makeStyles-weight-1174"
-      >
-        The following site:
-      </p>
-      <p
-        className="MuiTypography-root-1141 MuiTypography-body1-1143 MuiTypography-colorPrimary-1164 makeStyles-weight-1139 makeStyles-weight-1175"
-      >
-        http://finex.com
-      </p>
-      <p
-        className="MuiTypography-root-1141 MuiTypography-body1-1143 makeStyles-weight-1139 makeStyles-weight-1176 makeStyles-inline-1137"
-      >
-        wants to see your identity on
-      </p>
-
-      <p
-        className="MuiTypography-root-1141 MuiTypography-body1-1143 MuiTypography-colorPrimary-1164 makeStyles-weight-1139 makeStyles-weight-1177 makeStyles-inline-1137"
-      >
-        BTC
-      </p>
-    </div>
-    <div
-      className="MuiBox-root-1134 MuiBox-root-1178"
-    />
-    <button
-      className="MuiButtonBase-root-1196 MuiButton-root-1179 MuiButton-contained-1187 MuiButton-containedPrimary-1188 MuiButton-fullWidth-1195"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex="0"
-      type="button"
-    >
-      <span
-        className="MuiButton-label-1180"
-      >
-        Accept
-      </span>
-    </button>
-    <div
-      className="MuiBox-root-1134 MuiBox-root-1199"
-    />
-    <button
-      className="MuiButtonBase-root-1196 MuiButton-root-1179 MuiButton-contained-1187 MuiButton-containedSecondary-1189 MuiButton-fullWidth-1195"
-      disabled={false}
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex="0"
-      type="button"
-    >
-      <span
-        className="MuiButton-label-1180"
-      >
-        Reject
-      </span>
-    </button>
-  </div>
-  <div
-    className="MuiBox-root-1134 MuiBox-root-1200"
-  />
-  <div
-    className="MuiBox-root-1134 MuiBox-root-1201"
-  >
-    <img
-      alt="IOV logo"
-      className="makeStyles-root-1202"
-      height={39}
-      src="iov-logo.png"
-      width={84}
-    />
-  </div>
-</div>
-`;
-
-exports[`Storyshots Routes/Signup New account page 1`] = `
-<div
-  className="MuiBox-root-1301 MuiBox-root-1302"
-  id="/signup1"
->
-  <div
-    className="MuiBox-root MuiBox-root-1303"
-  >
-    <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1306 makeStyles-weight-1307 makeStyles-inline-1304"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1630 makeStyles-weight-1631 makeStyles-inline-1628"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1550 makeStyles-weight-1582 makeStyles-inline-1548"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1630 makeStyles-weight-1662 makeStyles-inline-1628"
     >
-
+       
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1583"
+    className="MuiBox-root MuiBox-root-1663"
   >
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-1580"
+        className="MuiBox-root MuiBox-root-1664"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -2926,7 +2938,7 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1637"
+        className="MuiBox-root MuiBox-root-1721"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -2988,7 +3000,7 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1638"
+        className="MuiBox-root MuiBox-root-1722"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3050,10 +3062,10 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1639"
+        className="MuiBox-root MuiBox-root-1723"
       >
         <div
-          className="MuiBox-root MuiBox-root-1640"
+          className="MuiBox-root MuiBox-root-1724"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -3083,7 +3095,7 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
           </button>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-1661"
+          className="MuiBox-root MuiBox-root-1745"
         >
           <button
             className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
@@ -3112,14 +3124,14 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1662"
+    className="MuiBox-root MuiBox-root-1746"
   />
   <div
-    className="MuiBox-root MuiBox-root-1663"
+    className="MuiBox-root MuiBox-root-1747"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1664"
+      className="makeStyles-root-1748"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3130,49 +3142,49 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
 
 exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1680"
+  className="MuiBox-root MuiBox-root-1764"
   id="/signup2"
 >
   <div
-    className="MuiBox-root MuiBox-root-1681"
+    className="MuiBox-root MuiBox-root-1765"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1684 makeStyles-weight-1685 makeStyles-inline-1682"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1768 makeStyles-weight-1769 makeStyles-inline-1766"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1684 makeStyles-weight-1716 makeStyles-inline-1682"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1768 makeStyles-weight-1800 makeStyles-inline-1766"
     >
-
+       
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1717"
+    className="MuiBox-root MuiBox-root-1801"
   >
     <div
-      className="MuiBox-root MuiBox-root-1718"
+      className="MuiBox-root MuiBox-root-1802"
     >
       <div
-        className="MuiBox-root MuiBox-root-1719"
+        className="MuiBox-root MuiBox-root-1803"
       >
         <div
-          className="MuiBox-root MuiBox-root-1720"
+          className="MuiBox-root MuiBox-root-1804"
         >
           <h6
-            className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-1684 makeStyles-weight-1721 makeStyles-inline-1682"
+            className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-1768 makeStyles-weight-1805 makeStyles-inline-1766"
           >
             Activate Recovery Phrase?
           </h6>
         </div>
         <div
-          className="makeStyles-container-1723"
+          className="makeStyles-container-1807"
           onClick={[Function]}
         >
           <img
             alt="Info"
-            className="makeStyles-root-1726"
+            className="makeStyles-root-1810"
             height={16}
             src="info_normal.svg"
             width={16}
@@ -3226,19 +3238,19 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
       </label>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1762"
+      className="MuiBox-root MuiBox-root-1846"
     >
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1684 makeStyles-weight-1763 makeStyles-inline-1682"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1768 makeStyles-weight-1847 makeStyles-inline-1766"
       >
-
+        
       </p>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1764"
+      className="MuiBox-root MuiBox-root-1848"
     >
       <div
-        className="MuiBox-root MuiBox-root-1765"
+        className="MuiBox-root MuiBox-root-1849"
       >
         <button
           className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -3268,7 +3280,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
         </button>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1783"
+        className="MuiBox-root MuiBox-root-1867"
       >
         <button
           className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -3300,14 +3312,14 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1784"
+    className="MuiBox-root MuiBox-root-1868"
   />
   <div
-    className="MuiBox-root MuiBox-root-1785"
+    className="MuiBox-root MuiBox-root-1869"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1726"
+      className="makeStyles-root-1810"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3318,29 +3330,29 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
 
 exports[`Storyshots Extension/Signup Security Hint page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1797"
+  className="MuiBox-root MuiBox-root-1881"
   id="/signup3"
 >
   <div
-    className="MuiBox-root MuiBox-root-1798"
+    className="MuiBox-root MuiBox-root-1882"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1801 makeStyles-weight-1802 makeStyles-inline-1799"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1885 makeStyles-weight-1886 makeStyles-inline-1883"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1801 makeStyles-weight-1833 makeStyles-inline-1799"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1885 makeStyles-weight-1917 makeStyles-inline-1883"
     >
-
+       
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1834"
+    className="MuiBox-root MuiBox-root-1918"
   >
     <h6
-      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-1801 makeStyles-weight-1835 makeStyles-inline-1799"
+      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-1885 makeStyles-weight-1919 makeStyles-inline-1883"
     >
       To help you remember your details in the future please provide a security hint:
     </h6>
@@ -3348,7 +3360,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-1836"
+        className="MuiBox-root MuiBox-root-1920"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3399,10 +3411,10 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1874"
+        className="MuiBox-root MuiBox-root-1958"
       >
         <div
-          className="MuiBox-root MuiBox-root-1875"
+          className="MuiBox-root MuiBox-root-1959"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -3432,7 +3444,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
           </button>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-1896"
+          className="MuiBox-root MuiBox-root-1980"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -3464,7 +3476,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1897"
+    className="MuiBox-root MuiBox-root-1981"
   />
   <div
     className="MuiBox-root MuiBox-root-1982"

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2648,7 +2648,7 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1546 makeStyles-weight-1585 makeStyles-inline-1544"
       >
          
-        BTC
+        ETH
       </p>
     </div>
     <div
@@ -2767,11 +2767,11 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       >
         wants to see your identity on
       </p>
-       
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1463 makeStyles-weight-1501 makeStyles-inline-1461"
       >
-        BTC
+         
+        ETH
       </p>
     </div>
     <div


### PR DESCRIPTION
**Description**
This PR will add Share Identity Accept view and simple logic to the extension. It will implement "Create storybook and view of the Accept screen" part of the #16.

**Before**
N/A

**After**
![accept-request](https://user-images.githubusercontent.com/3502260/57160732-51005400-6df2-11e9-9c71-aee810971fa6.png)
