### PR TITLE
Fix – Wait for ethereum node instead of fixed sleep

### DIFF
--- a/packages/sanes-chrome-extension/test/scripts/lisk/load_faucet.sh
+++ b/packages/sanes-chrome-extension/test/scripts/lisk/load_faucet.sh
@@ -5,7 +5,7 @@ command -v shellcheck > /dev/null && shellcheck "$0"
 gnutimeout="$(command -v gtimeout || echo timeout)"
 
 # Wait lisk node to be ready
-"$gnutimeout" 50 bash -c "until curl http://localhost:4000/api/node/status; do sleep 2; done"
+"$gnutimeout" 50 bash -c "until curl -s http://localhost:4000/api/node/status; do sleep 2; done"
 
 curl -sS -X POST \
   -H "Content-type: application/json" \

--- a/packages/sanes-chrome-extension/test/scripts/test_start.sh
+++ b/packages/sanes-chrome-extension/test/scripts/test_start.sh
@@ -6,6 +6,8 @@ command -v shellcheck > /dev/null && shellcheck "$0"
 # (blockchains and faucets).
 # Intended as a convenience script for developers.
 
+gnutimeout="$(command -v gtimeout || echo timeout)"
+
 # get this files directory regardless of pwd when we run it
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -32,9 +34,9 @@ echo
 echo ">>> Starting ethereum (ganache) chain, scraper and faucet..."
 echo
 bash "${SCRIPT_DIR}"/ethereum/start.sh
-sleep 5
+# Wait Ethereum node to be ready
+"$gnutimeout" 15 bash -c "until curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"net_version\",\"id\":42}' http://localhost:8545 > /dev/null; do sleep 1; done"
 bash "${SCRIPT_DIR}"/faucet/ethereum_start.sh
-sleep 5
 bash "${SCRIPT_DIR}"/ethereum/scraper_start.sh
 
 echo


### PR DESCRIPTION
This prevents

> Error: connect ECONNREFUSED 172.17.0.1:8545

and

```
Status: Downloaded newer image for trufflesuite/ganache-cli:v6.4.1
Connecting to http://172.17.0.1:8545
Faucet running and logging into /tmp/faucet_start_ethereum.P96CTzdy2/faucet_ethereum.log
{ Error: socket hang up
    at createHangUpError (_http_client.js:323:15)
    at Socket.socketOnEnd (_http_client.js:426:23)
    at Socket.emit (events.js:194:15)
    at endReadableNT (_stream_readable.js:1125:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
  code: 'ECONNRESET',
```