### PR TITLE
Feature #16 - Share identity reject view

### DIFF
--- a/packages/bierzo-wallet/src/routes/payment/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/index.stories.tsx
@@ -1,9 +1,9 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
-import DecoratedStorybook from '../../utils/storybook';
+import DecoratedStorybook, { WALLET_ROOT } from '../../utils/storybook';
 import Payment from './index';
 
-storiesOf('Bierzo wallet', module).add(
+storiesOf(WALLET_ROOT, module).add(
   'Payment page',
   (): JSX.Element => (
     <DecoratedStorybook>

--- a/packages/bierzo-wallet/src/routes/welcome/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/welcome/index.stories.tsx
@@ -1,9 +1,9 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
-import DecoratedStorybook from '../../utils/storybook';
+import DecoratedStorybook, { WALLET_ROOT } from '../../utils/storybook';
 import Welcome from './index';
 
-storiesOf('Bierzo wallet', module).add(
+storiesOf(WALLET_ROOT, module).add(
   'Welcome page',
   (): JSX.Element => (
     <DecoratedStorybook>

--- a/packages/bierzo-wallet/src/utils/storybook/index.tsx
+++ b/packages/bierzo-wallet/src/utils/storybook/index.tsx
@@ -7,6 +7,8 @@ import { configureStore } from '../../store';
 import { history } from '../../store/reducers';
 import { globalStyles } from '../../theme/globalStyles';
 
+export const WALLET_ROOT = 'Bierzo wallet';
+
 const store = configureStore();
 
 interface Props {

--- a/packages/medulas-react-components/package.json
+++ b/packages/medulas-react-components/package.json
@@ -23,9 +23,7 @@
     "@types/node": "11.9.4",
     "add": "^2.0.6",
     "final-form": "^4.12.0",
-    "react-final-form-hooks": "^1.0.1"
-  },
-  "devDependencies": {
+    "react-final-form-hooks": "^1.0.1",
     "@material-ui/icons": "^3.0.2"
   }
 }

--- a/packages/medulas-react-components/package.json
+++ b/packages/medulas-react-components/package.json
@@ -24,5 +24,8 @@
     "add": "^2.0.6",
     "final-form": "^4.12.0",
     "react-final-form-hooks": "^1.0.1"
+  },
+  "devDependencies": {
+    "@material-ui/icons": "^3.0.2"
   }
 }

--- a/packages/medulas-react-components/src/components/forms/CheckboxField/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/CheckboxField/index.stories.tsx
@@ -1,0 +1,36 @@
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import React from 'react';
+import CheckboxField from './index';
+import { Storybook } from '../../../utils/storybook';
+import Form, { useForm } from '../Form';
+
+const CheckboxFieldForm = (): JSX.Element => {
+  const { form, handleSubmit } = useForm({
+    onSubmit: () => {
+      console.log('value checked, onSubmit');
+      action('Form submit');
+    },
+  });
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <CheckboxField
+        initial={false}
+        form={form}
+        fieldName="SELECT_FIELD_ATTR"
+        label="Checkbox field"
+        onChangeCallback={(checked: boolean) => {
+          console.log('value checked, onChangeCallback');
+          action(`received ---> ${checked ? 'true' : 'false'}`);
+        }}
+      />
+    </Form>
+  );
+};
+
+storiesOf('Components /forms', module).add('CheckboxField', () => (
+  <Storybook>
+    <CheckboxFieldForm />
+  </Storybook>
+));

--- a/packages/medulas-react-components/src/components/forms/CheckboxField/index.tsx
+++ b/packages/medulas-react-components/src/components/forms/CheckboxField/index.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
 import { Omit } from '@material-ui/core';
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import CheckBoxIcon from '@material-ui/icons/CheckBox';
 
 interface Props extends Omit<CheckboxProps, 'form'> {
   readonly fieldName: string;
@@ -22,7 +24,6 @@ const CheckboxField = ({ fieldName, form, initial, onChangeCallback, label }: Pr
 
   React.useEffect(() => {
     try {
-      console.log(value);
       const firstRender = value === '';
       if (firstRender) {
         onChange(initial);
@@ -31,14 +32,22 @@ const CheckboxField = ({ fieldName, form, initial, onChangeCallback, label }: Pr
   }, [input]);
 
   const onCheckBoxChange = (_: React.ChangeEvent<HTMLInputElement>, checked: boolean): void => {
-    console.log('value checked, onCheckBoxChange');
     onChange(checked);
     if (onChangeCallback) {
       onChangeCallback(checked);
     }
   };
 
-  const control = <Checkbox checked={value} onChange={onCheckBoxChange} inputProps={inputProps} />;
+  const control = (
+    <Checkbox
+      checked={value === '' ? false : value}
+      color="primary"
+      onChange={onCheckBoxChange}
+      inputProps={inputProps}
+      icon={<CheckBoxOutlineBlankIcon fontSize="large" />}
+      checkedIcon={<CheckBoxIcon fontSize="large" />}
+    />
+  );
 
   return <FormControlLabel control={control} label={label} />;
 };

--- a/packages/medulas-react-components/src/components/forms/CheckboxField/index.tsx
+++ b/packages/medulas-react-components/src/components/forms/CheckboxField/index.tsx
@@ -40,7 +40,7 @@ const CheckboxField = ({ fieldName, form, initial, onChangeCallback, label }: Pr
 
   const control = (
     <Checkbox
-      checked={value === '' ? false : value}
+      checked={!!value}
       color="primary"
       onChange={onCheckBoxChange}
       inputProps={inputProps}

--- a/packages/medulas-react-components/src/components/forms/CheckboxField/index.tsx
+++ b/packages/medulas-react-components/src/components/forms/CheckboxField/index.tsx
@@ -1,0 +1,46 @@
+import { FormApi, FieldSubscription } from 'final-form';
+import { useField } from 'react-final-form-hooks';
+import * as React from 'react';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
+import { Omit } from '@material-ui/core';
+
+interface Props extends Omit<CheckboxProps, 'form'> {
+  readonly fieldName: string;
+  readonly label?: string;
+  readonly initial: boolean;
+  readonly form: FormApi;
+  readonly onChangeCallback?: (checked: boolean) => void;
+  readonly subscription?: FieldSubscription;
+}
+
+const CheckboxField = ({ fieldName, form, initial, onChangeCallback, label }: Props): JSX.Element => {
+  const { input } = useField(fieldName, form);
+
+  const { name, onChange, value, ...restInput } = input;
+  const inputProps = { name, ...restInput };
+
+  React.useEffect(() => {
+    try {
+      console.log(value);
+      const firstRender = value === '';
+      if (firstRender) {
+        onChange(initial);
+      }
+    } catch (err) {}
+  }, [input]);
+
+  const onCheckBoxChange = (_: React.ChangeEvent<HTMLInputElement>, checked: boolean): void => {
+    console.log('value checked, onCheckBoxChange');
+    onChange(checked);
+    if (onChangeCallback) {
+      onChangeCallback(checked);
+    }
+  };
+
+  const control = <Checkbox checked={value} onChange={onCheckBoxChange} inputProps={inputProps} />;
+
+  return <FormControlLabel control={control} label={label} />;
+};
+
+export default CheckboxField;

--- a/packages/medulas-react-components/src/components/forms/Form/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/Form/index.stories.tsx
@@ -5,6 +5,7 @@ import Button from '../../Button';
 import Block from '../../Block';
 import SelectFieldForm, { Item } from '../SelectFieldForm';
 import TextFieldForm from '../TextFieldForm';
+import CheckboxField from '../CheckboxField';
 import Form, { useForm, FormValues, ValidationError } from './index';
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms)); // eslint-disable-line
@@ -17,6 +18,7 @@ const onSubmit = async (values: FormValues): Promise<void> => {
 
 const TEXT_FIELD = 'textFieldUniqueIdentifier';
 const SELECT_FIELD = 'selectFieldUniqueIdentifier';
+const CHECKBOX_FIELD = 'checkboxFieldUniqueIdentifier';
 
 const validate = (values: FormValues): object => {
   let errors: ValidationError = {};
@@ -53,6 +55,15 @@ const FormStory = (): JSX.Element => {
           form={form}
           fieldName={SELECT_FIELD}
           onChangeCallback={(item: Item) => console.log(`received ---> ${item.name}`)}
+        />
+      </Block>
+      <Block display="block" marginBottom={2}>
+        <CheckboxField
+          initial={true}
+          form={form}
+          fieldName={CHECKBOX_FIELD}
+          label="Checkbox field"
+          onChangeCallback={(checked: boolean) => console.log(`received ---> ${checked ? 'true' : 'false'}`)}
         />
       </Block>
 

--- a/packages/medulas-react-components/src/components/forms/Form/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/Form/index.stories.tsx
@@ -79,6 +79,7 @@ storiesOf('Components/forms', module).add(
   'Form',
   (): JSX.Element => (
     <Storybook>
+      <Block marginTop={2} />
       <FormStory />
     </Storybook>
   )

--- a/packages/medulas-react-components/src/components/forms/TextFieldForm/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/TextFieldForm/index.stories.tsx
@@ -6,6 +6,7 @@ import { Storybook } from '../../../utils/storybook';
 import Grid, { SizingBreakpoint } from '../../Grid';
 import GridItem from '../../GridItem';
 import Form, { useForm } from '../Form';
+import Block from '../../Block';
 
 interface Props {
   readonly name: string;
@@ -67,6 +68,7 @@ storiesOf('Components/forms', module).add(
   'TextFieldForm',
   (): JSX.Element => (
     <Storybook>
+      <Block marginTop={2} />
       <Grid flexWrap="wrap">
         <GridItem marginBottom={4} width={gridItemWidth}>
           <TextField

--- a/packages/sanes-chrome-extension/src/routes/account/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/index.stories.tsx
@@ -3,8 +3,9 @@ import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import { ToastProvider } from 'medulas-react-components/lib/context/ToastProvider';
 import React from 'react';
 import Layout from './index';
+import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 
-storiesOf('Extension', module).add('Account Status page', () => (
+storiesOf(CHROME_EXTENSION_ROOT, module).add('Account Status page', () => (
   <Storybook>
     <ToastProvider>
       <Layout />

--- a/packages/sanes-chrome-extension/src/routes/login/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/login/index.stories.tsx
@@ -1,9 +1,9 @@
 import { storiesOf } from '@storybook/react';
-import { SanesStorybook } from '../../utils/storybook';
+import { SanesStorybook, CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 import React from 'react';
 import Layout from './index';
 
-storiesOf('Extension', module).add(
+storiesOf(CHROME_EXTENSION_ROOT, module).add(
   'Login page',
   (): JSX.Element => (
     <SanesStorybook>

--- a/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.stories.tsx
@@ -2,8 +2,9 @@ import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
 import RecoveryPhrase from './index';
+import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 
-storiesOf('Extension', module).add(
+storiesOf(CHROME_EXTENSION_ROOT, module).add(
   'Recovery Phrase page',
   (): JSX.Element => (
     <Storybook>

--- a/packages/sanes-chrome-extension/src/routes/restore-account/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/index.stories.tsx
@@ -3,8 +3,9 @@ import { action } from '@storybook/addon-actions';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
 import RestoreAccountForm from './components';
+import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 
-storiesOf('Extension', module).add(
+storiesOf(CHROME_EXTENSION_ROOT, module).add(
   'Restore Account page',
   (): JSX.Element => (
     <Storybook>

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import Button from 'medulas-react-components/lib/components/Button';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import Block from 'medulas-react-components/lib/components/Block';
+import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Back from 'medulas-react-components/lib/components/Button/Back';
+
+interface Props {
+  readonly onAcceptRequest: () => void;
+  readonly onBack: () => void;
+}
+
+const Layout = ({ onBack, onAcceptRequest }: Props): JSX.Element => (
+  <PageLayout primaryTitle="Share" title="Identity">
+    <Block textAlign="center">
+      <Typography variant="body1">The following site:</Typography>
+      <Typography variant="body1" color="primary">
+        http://finex.com
+      </Typography>
+      <Typography variant="body1" inline color="primary">
+        would not be able to request
+      </Typography>
+      <Typography variant="body1" inline>
+        {' '}
+        your identity
+      </Typography>
+    </Block>
+    <Block marginTop={10} />
+    <Button variant="contained" fullWidth onClick={onAcceptRequest}>
+      Confirm
+    </Button>
+    <Block marginTop={2} />
+    <Back fullWidth onClick={onBack}>
+      Back
+    </Back>
+  </PageLayout>
+);
+
+export default Layout;

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
@@ -4,36 +4,61 @@ import Typography from 'medulas-react-components/lib/components/Typography';
 import Block from 'medulas-react-components/lib/components/Block';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import Back from 'medulas-react-components/lib/components/Button/Back';
+import Form, { useForm, FormValues } from 'medulas-react-components/lib/components/forms/Form';
+import CheckboxField from 'medulas-react-components/lib/components/forms/CheckboxField';
+
+const PERMANENT_REJECT = 'permanentRejectField';
 
 interface Props {
-  readonly onAcceptRequest: () => void;
+  readonly onRejectRequest: (permanent: boolean) => void;
   readonly onBack: () => void;
 }
 
-const Layout = ({ onBack, onAcceptRequest }: Props): JSX.Element => (
-  <PageLayout primaryTitle="Share" title="Identity">
-    <Block textAlign="center">
-      <Typography variant="body1">The following site:</Typography>
-      <Typography variant="body1" color="primary">
-        http://finex.com
-      </Typography>
-      <Typography variant="body1" inline color="primary">
-        would not be able to request
-      </Typography>
-      <Typography variant="body1" inline>
-        {' '}
-        your identity
-      </Typography>
-    </Block>
-    <Block marginTop={10} />
-    <Button variant="contained" fullWidth onClick={onAcceptRequest}>
-      Confirm
-    </Button>
-    <Block marginTop={2} />
-    <Back fullWidth onClick={onBack}>
-      Back
-    </Back>
-  </PageLayout>
-);
+const Layout = ({ onBack, onRejectRequest }: Props): JSX.Element => {
+  const onSubmit = async (values: object): Promise<void> => {
+    const formValues = values as FormValues;
+    onRejectRequest(formValues[PERMANENT_REJECT] === 'true');
+  };
+
+  const { form, handleSubmit, pristine, submitting } = useForm({
+    onSubmit,
+  });
+
+  return (
+    <PageLayout primaryTitle="Share" title="Identity">
+      <Form onSubmit={handleSubmit}>
+        <Block textAlign="center">
+          <Typography variant="body1">The following site:</Typography>
+          <Typography variant="body1" color="primary">
+            http://finex.com
+          </Typography>
+          <Typography variant="body1" inline color="error">
+            would not be able to request
+          </Typography>
+          <Typography variant="body1" inline>
+            {' '}
+            your identity.
+          </Typography>
+
+          <Block marginTop={1} />
+          <CheckboxField
+            initial={false}
+            form={form}
+            fieldName={PERMANENT_REJECT}
+            label="Don't ask me again"
+          />
+        </Block>
+        <Block marginTop={10} />
+        <Button variant="contained" fullWidth type="submit" disabled={pristine || submitting}>
+          Reject
+        </Button>
+        <Block marginTop={2} />
+        <Back fullWidth onClick={onBack}>
+          Back
+        </Back>
+      </Form>
+    </PageLayout>
+  );
+};
 
 export default Layout;

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
@@ -6,9 +6,10 @@ import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 
 interface Props {
   readonly showAcceptView: () => void;
+  readonly showRejectView: () => void;
 }
 
-const Layout = ({ showAcceptView }: Props): JSX.Element => (
+const Layout = ({ showAcceptView, showRejectView }: Props): JSX.Element => (
   <PageLayout primaryTitle="Share" title="Identity">
     <Block textAlign="center">
       <Typography variant="body1">The following site:</Typography>
@@ -28,7 +29,7 @@ const Layout = ({ showAcceptView }: Props): JSX.Element => (
       Accept
     </Button>
     <Block marginTop={2} />
-    <Button variant="contained" fullWidth color="secondary">
+    <Button variant="contained" fullWidth color="secondary" onClick={showRejectView}>
       Reject
     </Button>
   </PageLayout>

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
@@ -3,14 +3,19 @@ import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
 import ShowRequest from './components/ShowRequest';
 import AcceptRequest from './components/AcceptRequest';
+import RejectRequest from './components/RejectRequest';
 import { action } from '@storybook/addon-actions';
+import { linkTo } from '@storybook/addon-links';
 
 storiesOf('Extension/Share Identity', module)
   .add(
     'Show Request page',
     (): JSX.Element => (
       <Storybook>
-        <ShowRequest showAcceptView={action('showAcceptView')} />
+        <ShowRequest
+          showAcceptView={linkTo('Routes/Share Identity', 'Accept request')}
+          showRejectView={linkTo('Routes/Share Identity', 'Accept request')}
+        />
       </Storybook>
     )
   )
@@ -18,7 +23,21 @@ storiesOf('Extension/Share Identity', module)
     'Accept Request page',
     (): JSX.Element => (
       <Storybook>
-        <AcceptRequest onBack={action('onBack')} onAcceptRequest={action('onAcceptRequest')} />
+        <AcceptRequest
+          onBack={linkTo('Routes/Share Identity', 'Show request')}
+          onAcceptRequest={action('onAcceptRequest')}
+        />
+      </Storybook>
+    )
+  )
+  .add(
+    'Reject request',
+    (): JSX.Element => (
+      <Storybook>
+        <RejectRequest
+          onBack={linkTo('Routes/Share Identity', 'Show request')}
+          onRejectRequest={action('onAcceptRequest')}
+        />
       </Storybook>
     )
   );

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
@@ -8,35 +8,40 @@ import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 
-storiesOf(`${CHROME_EXTENSION_ROOT}/Share Identity`, module)
+const SHARE_IDENTITY_PATH = `${CHROME_EXTENSION_ROOT}/Share Identity`;
+const SHOW_REQUEST_PAGE = 'Show Request page';
+const ACCEPT_REQUEST_PAGE = 'Accept Request page';
+const REJECT_REQUEST_PAGE = 'Reject Request page';
+
+storiesOf(SHARE_IDENTITY_PATH, module)
   .add(
-    'Show Request page',
+    SHOW_REQUEST_PAGE,
     (): JSX.Element => (
       <Storybook>
         <ShowRequest
-          showAcceptView={linkTo('Routes/Share Identity', 'Accept request')}
-          showRejectView={linkTo('Routes/Share Identity', 'Accept request')}
+          showAcceptView={linkTo(SHARE_IDENTITY_PATH, ACCEPT_REQUEST_PAGE)}
+          showRejectView={linkTo(SHARE_IDENTITY_PATH, REJECT_REQUEST_PAGE)}
         />
       </Storybook>
     )
   )
   .add(
-    'Accept Request page',
+    ACCEPT_REQUEST_PAGE,
     (): JSX.Element => (
       <Storybook>
         <AcceptRequest
-          onBack={linkTo('Routes/Share Identity', 'Show request')}
+          onBack={linkTo(SHARE_IDENTITY_PATH, SHOW_REQUEST_PAGE)}
           onAcceptRequest={action('onAcceptRequest')}
         />
       </Storybook>
     )
   )
   .add(
-    'Reject Request page',
+    REJECT_REQUEST_PAGE,
     (): JSX.Element => (
       <Storybook>
         <RejectRequest
-          onBack={linkTo('Routes/Share Identity', 'Show request')}
+          onBack={linkTo(SHARE_IDENTITY_PATH, SHOW_REQUEST_PAGE)}
           onRejectRequest={action('onAcceptRequest')}
         />
       </Storybook>

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
@@ -6,8 +6,9 @@ import AcceptRequest from './components/AcceptRequest';
 import RejectRequest from './components/RejectRequest';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
+import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 
-storiesOf('Extension/Share Identity', module)
+storiesOf(`${CHROME_EXTENSION_ROOT}/Share Identity`, module)
   .add(
     'Show Request page',
     (): JSX.Element => (

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
@@ -31,7 +31,7 @@ storiesOf('Extension/Share Identity', module)
     )
   )
   .add(
-    'Reject request',
+    'Reject Request page',
     (): JSX.Element => (
       <Storybook>
         <RejectRequest

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
@@ -1,21 +1,28 @@
 import * as React from 'react';
 import AcceptRequest from './components/AcceptRequest';
+import RejectRequest from './components/RejectRequest';
 import ShowRequest from './components/ShowRequest';
 
 const ShareIdentity = (): JSX.Element => {
-  const [action, setAction] = React.useState<'show' | 'accept'>('show');
+  const [action, setAction] = React.useState<'show' | 'accept' | 'reject'>('show');
 
   const showRequestView = (): void => setAction('show');
   const showAcceptView = (): void => setAction('accept');
+  const showRejectView = (): void => setAction('reject');
 
   const onAcceptRequest = (): void => {
     console.log('Accept request');
   };
 
+  const onRejectRequest = (permanent: boolean): void => {
+    console.log(`Reject request. Permanent ${permanent ? 'yes' : 'no'}`);
+  };
+
   return (
     <React.Fragment>
-      {action === 'show' && <ShowRequest showAcceptView={showAcceptView} />}
+      {action === 'show' && <ShowRequest showAcceptView={showAcceptView} showRejectView={showRejectView} />}
       {action === 'accept' && <AcceptRequest onBack={showRequestView} onAcceptRequest={onAcceptRequest} />}
+      {action === 'reject' && <RejectRequest onBack={showRequestView} onRejectRequest={onRejectRequest} />}
     </React.Fragment>
   );
 };

--- a/packages/sanes-chrome-extension/src/routes/signup/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/signup/index.stories.tsx
@@ -5,8 +5,9 @@ import React from 'react';
 import NewAccountForm from './components/NewAccountForm';
 import ShowPhraseForm from './components/ShowPhraseForm';
 import SecurityHintForm from './components/SecurityHintForm';
+import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 
-storiesOf('Extension/Signup', module)
+storiesOf(`${CHROME_EXTENSION_ROOT}/Signup`, module)
   .add(
     'New Account page',
     (): JSX.Element => (

--- a/packages/sanes-chrome-extension/src/routes/welcome/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/welcome/index.stories.tsx
@@ -2,8 +2,9 @@ import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
 import Layout from './index';
+import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 
-storiesOf('Extension', module).add(
+storiesOf(CHROME_EXTENSION_ROOT, module).add(
   'Welcome page',
   (): JSX.Element => (
     <Storybook>

--- a/packages/sanes-chrome-extension/src/utils/storybook/index.tsx
+++ b/packages/sanes-chrome-extension/src/utils/storybook/index.tsx
@@ -7,6 +7,8 @@ import { createStore, combineReducers } from 'redux';
 import * as React from 'react';
 import { PersonaProvider } from '../../context/PersonaProvider';
 
+export const CHROME_EXTENSION_ROOT = 'Extension';
+
 const storybookHistory = createMemoryHistory();
 
 //eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -142,9 +142,9 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
           <h6
             className="MuiTypography-root-45 MuiTypography-subtitle2-57 MuiTypography-colorTextSecondary-71 makeStyles-weight-43 makeStyles-weight-126"
           >
-            balance: 
+            balance:
             24
-             
+
             IOV
           </h6>
         </div>
@@ -771,7 +771,7 @@ exports[`Storyshots Components Layout 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-394 makeStyles-weight-426 makeStyles-inline-392"
     >
-       
+
       storybook
     </h4>
   </div>
@@ -1358,7 +1358,7 @@ Array [
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-558 makeStyles-weight-604 makeStyles-inline-556"
   >
-    First part of the text. 
+    First part of the text.
   </h6>,
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-558 makeStyles-weight-605 makeStyles-inline-556"
@@ -1819,7 +1819,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-941 makeStyles-weight-973 makeStyles-inline-939"
     >
-       
+
       Status
     </h4>
   </div>
@@ -2017,7 +2017,7 @@ exports[`Storyshots Extension Login page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1054 makeStyles-weight-1086 makeStyles-inline-1052"
     >
-       
+
       In
     </h4>
   </div>
@@ -2175,7 +2175,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1165 makeStyles-weight-1197 makeStyles-inline-1163"
     >
-       
+
       phrase
     </h4>
   </div>
@@ -2247,7 +2247,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1165 makeStyles-weight-1228 makeStyles-inline-1163"
       >
-        
+
       </p>
     </div>
     <div
@@ -2318,7 +2318,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1265 makeStyles-weight-1297 makeStyles-inline-1263"
     >
-       
+
       Account
     </h4>
   </div>
@@ -2482,7 +2482,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1383 makeStyles-weight-1415 makeStyles-inline-1381"
     >
-       
+
       to your IOV manager
     </h4>
   </div>
@@ -2613,7 +2613,7 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1546 makeStyles-weight-1578 makeStyles-inline-1544"
     >
-       
+
       Identity
     </h4>
   </div>
@@ -2641,13 +2641,13 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1546 makeStyles-weight-1584 makeStyles-inline-1544"
       >
-         
+
         your identity on
       </p>
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1546 makeStyles-weight-1585 makeStyles-inline-1544"
       >
-         
+
         ETH
       </p>
     </div>
@@ -2742,7 +2742,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1463 makeStyles-weight-1495 makeStyles-inline-1461"
     >
-       
+
       Identity
     </h4>
   </div>
@@ -2770,7 +2770,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1463 makeStyles-weight-1501 makeStyles-inline-1461"
       >
-         
+
         ETH
       </p>
     </div>
@@ -2865,7 +2865,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1630 makeStyles-weight-1662 makeStyles-inline-1628"
     >
-       
+
       Account
     </h4>
   </div>
@@ -3156,7 +3156,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1768 makeStyles-weight-1800 makeStyles-inline-1766"
     >
-       
+
       Account
     </h4>
   </div>
@@ -3243,7 +3243,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1768 makeStyles-weight-1847 makeStyles-inline-1766"
       >
-        
+
       </p>
     </div>
     <div
@@ -3344,7 +3344,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1885 makeStyles-weight-1917 makeStyles-inline-1883"
     >
-       
+
       Account
     </h4>
   </div>

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -142,9 +142,9 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
           <h6
             className="MuiTypography-root-45 MuiTypography-subtitle2-57 MuiTypography-colorTextSecondary-71 makeStyles-weight-43 makeStyles-weight-126"
           >
-            balance:
+            balance: 
             24
-
+             
             IOV
           </h6>
         </div>
@@ -835,7 +835,7 @@ exports[`Storyshots Components Layout 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-394 makeStyles-weight-426 makeStyles-inline-392"
     >
-
+       
       storybook
     </h4>
   </div>
@@ -1422,7 +1422,7 @@ Array [
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-558 makeStyles-weight-604 makeStyles-inline-556"
   >
-    First part of the text.
+    First part of the text. 
   </h6>,
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-558 makeStyles-weight-605 makeStyles-inline-556"
@@ -1944,7 +1944,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1093 makeStyles-weight-1125 makeStyles-inline-1091"
     >
-
+       
       Status
     </h4>
   </div>
@@ -2142,7 +2142,7 @@ exports[`Storyshots Extension Login page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1206 makeStyles-weight-1238 makeStyles-inline-1204"
     >
-
+       
       In
     </h4>
   </div>
@@ -2300,7 +2300,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1317 makeStyles-weight-1349 makeStyles-inline-1315"
     >
-
+       
       phrase
     </h4>
   </div>
@@ -2372,7 +2372,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1317 makeStyles-weight-1380 makeStyles-inline-1315"
       >
-
+        
       </p>
     </div>
     <div
@@ -2443,7 +2443,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1417 makeStyles-weight-1449 makeStyles-inline-1415"
     >
-
+       
       Account
     </h4>
   </div>
@@ -2607,7 +2607,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1535 makeStyles-weight-1567 makeStyles-inline-1533"
     >
-
+       
       to your IOV manager
     </h4>
   </div>
@@ -2738,7 +2738,7 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1698 makeStyles-weight-1730 makeStyles-inline-1696"
     >
-
+       
       Identity
     </h4>
   </div>
@@ -2766,12 +2766,13 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1698 makeStyles-weight-1736 makeStyles-inline-1696"
       >
-
+         
         your identity on
       </p>
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1698 makeStyles-weight-1737 makeStyles-inline-1696"
       >
+         
         ETH
       </p>
     </div>
@@ -2866,57 +2867,15 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1782 makeStyles-weight-1814 makeStyles-inline-1780"
     >
-
+       
       Identity
     </h4>
   </div>
   <div
     className="MuiBox-root MuiBox-root-1815"
   >
-    <div
-      className="MuiBox-root MuiBox-root-1497"
-    >
-      <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1463 makeStyles-weight-1498"
-      >
-        The following site:
-      </p>
-      <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1463 makeStyles-weight-1499"
-      >
-        http://finex.com
-      </p>
-      <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1463 makeStyles-weight-1500 makeStyles-inline-1461"
-      >
-        wants to see your identity on
-      </p>
-      <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1463 makeStyles-weight-1501 makeStyles-inline-1461"
-      >
-
-        ETH
-      </p>
-    </div>
-    <div
-      className="MuiBox-root MuiBox-root-1502"
-    />
-    <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex="0"
-      type="button"
+    <form
+      onSubmit={[Function]}
     >
       <div
         className="MuiBox-root MuiBox-root-1816"
@@ -2939,7 +2898,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
         <p
           className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1782 makeStyles-weight-1820 makeStyles-inline-1780"
         >
-
+           
           your identity.
         </p>
         <div
@@ -3091,7 +3050,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1615 makeStyles-weight-1647 makeStyles-inline-1613"
     >
-
+       
       Identity
     </h4>
   </div>
@@ -3119,8 +3078,8 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1615 makeStyles-weight-1653 makeStyles-inline-1613"
       >
-
-        BTC
+         
+        ETH
       </p>
     </div>
     <div
@@ -3215,7 +3174,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1900 makeStyles-weight-1932 makeStyles-inline-1898"
     >
-
+       
       Account
     </h4>
   </div>
@@ -3506,7 +3465,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2038 makeStyles-weight-2070 makeStyles-inline-2036"
     >
-
+       
       Account
     </h4>
   </div>
@@ -3593,7 +3552,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2038 makeStyles-weight-2117 makeStyles-inline-2036"
       >
-
+        
       </p>
     </div>
     <div
@@ -3694,7 +3653,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2155 makeStyles-weight-2187 makeStyles-inline-2153"
     >
-
+       
       Account
     </h4>
   </div>

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -432,22 +432,86 @@ exports[`Storyshots Bierzo wallet Welcome page 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components /forms CheckboxField 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <label
+    className="MuiFormControlLabel-root"
+  >
+    <span
+      aria-disabled={false}
+      className="MuiButtonBase-root MuiIconButton-root MuiPrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={null}
+    >
+      <span
+        className="MuiIconButton-label"
+      >
+        <svg
+          aria-hidden="true"
+          className="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+          focusable="false"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+          />
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+        </svg>
+        <input
+          checked={false}
+          className="MuiPrivateSwitchBase-input"
+          data-indeterminate={false}
+          name="SELECT_FIELD_ATTR"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="checkbox"
+        />
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </span>
+    <span
+      className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label"
+    >
+      Checkbox field
+    </span>
+  </label>
+</form>
+`;
+
 exports[`Storyshots Components /forms SelectField 1`] = `
 <form
   onSubmit={[Function]}
 >
   <div
-    className="makeStyles-dropdown-903"
+    className="makeStyles-dropdown-822"
     onClick={[Function]}
   >
     <div
-      className="MuiInputBase-root makeStyles-root-904 makeStyles-root-906"
+      className="MuiInputBase-root makeStyles-root-823 makeStyles-root-825"
       onClick={[Function]}
       role="button"
     >
       <input
         autoComplete="off"
-        className="MuiInputBase-input makeStyles-input-905"
+        className="MuiInputBase-input makeStyles-input-824"
         name="SELECT_FIELD_ATTR"
         onBlur={[Function]}
         onChange={[Function]}
@@ -459,7 +523,7 @@ exports[`Storyshots Components /forms SelectField 1`] = `
     </div>
     <img
       alt="Phone Menu"
-      className="makeStyles-root-924 makeStyles-noShrink-925"
+      className="makeStyles-root-843 makeStyles-noShrink-844"
       height="5"
       src="selectChevron.svg"
       width="8"
@@ -1426,20 +1490,20 @@ exports[`Storyshots Components/forms Form 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-802"
+    className="MuiBox-root MuiBox-root-905"
   >
     <div
-      className="makeStyles-dropdown-803"
+      className="makeStyles-dropdown-906"
       onClick={[Function]}
     >
       <div
-        className="MuiInputBase-root makeStyles-root-804 makeStyles-root-806"
+        className="MuiInputBase-root makeStyles-root-907 makeStyles-root-909"
         onClick={[Function]}
         role="button"
       >
         <input
           autoComplete="off"
-          className="MuiInputBase-input makeStyles-input-805"
+          className="MuiInputBase-input makeStyles-input-908"
           name="selectFieldUniqueIdentifier"
           onBlur={[Function]}
           onChange={[Function]}
@@ -1451,7 +1515,7 @@ exports[`Storyshots Components/forms Form 1`] = `
       </div>
       <img
         alt="Phone Menu"
-        className="makeStyles-root-807 makeStyles-noShrink-808"
+        className="makeStyles-root-910 makeStyles-noShrink-911"
         height="5"
         src="selectChevron.svg"
         width="8"
@@ -1459,14 +1523,14 @@ exports[`Storyshots Components/forms Form 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-676"
+    className="MuiBox-root MuiBox-root-915"
   >
     <label
       className="MuiFormControlLabel-root"
     >
       <span
         aria-disabled={false}
-        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-689 MuiCheckbox-root MuiCheckbox-colorPrimary"
+        className="MuiButtonBase-root MuiIconButton-root MuiPrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary"
         onBlur={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1499,7 +1563,7 @@ exports[`Storyshots Components/forms Form 1`] = `
           </svg>
           <input
             checked={false}
-            className="PrivateSwitchBase-input-692"
+            className="MuiPrivateSwitchBase-input"
             data-indeterminate={false}
             name="checkboxFieldUniqueIdentifier"
             onBlur={[Function]}
@@ -1508,6 +1572,9 @@ exports[`Storyshots Components/forms Form 1`] = `
             type="checkbox"
           />
         </span>
+        <span
+          className="MuiTouchRipple-root"
+        />
       </span>
       <span
         className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label"
@@ -1546,10 +1613,10 @@ exports[`Storyshots Components/forms Form 1`] = `
 
 exports[`Storyshots Components/forms TextFieldForm 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-833"
+  className="MuiBox-root MuiBox-root-1011"
 >
   <div
-    className="MuiBox-root MuiBox-root-834"
+    className="MuiBox-root MuiBox-root-1012"
   >
     <form
       onSubmit={[Function]}
@@ -1615,7 +1682,7 @@ exports[`Storyshots Components/forms TextFieldForm 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-899"
+    className="MuiBox-root MuiBox-root-1077"
   >
     <form
       onSubmit={[Function]}
@@ -1676,7 +1743,7 @@ exports[`Storyshots Components/forms TextFieldForm 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-900"
+    className="MuiBox-root MuiBox-root-1078"
   >
     <form
       onSubmit={[Function]}
@@ -1737,7 +1804,7 @@ exports[`Storyshots Components/forms TextFieldForm 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-901"
+    className="MuiBox-root MuiBox-root-1079"
   >
     <form
       onSubmit={[Function]}
@@ -1798,7 +1865,7 @@ exports[`Storyshots Components/forms TextFieldForm 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-902"
+    className="MuiBox-root MuiBox-root-1080"
   >
     <form
       onSubmit={[Function]}
@@ -1863,51 +1930,51 @@ exports[`Storyshots Components/forms TextFieldForm 1`] = `
 
 exports[`Storyshots Extension Account Status page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-937"
+  className="MuiBox-root MuiBox-root-1089"
   id="/account"
 >
   <div
-    className="MuiBox-root MuiBox-root-938"
+    className="MuiBox-root MuiBox-root-1090"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-941 makeStyles-weight-942 makeStyles-inline-939"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1093 makeStyles-weight-1094 makeStyles-inline-1091"
     >
       Account
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-941 makeStyles-weight-973 makeStyles-inline-939"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1093 makeStyles-weight-1125 makeStyles-inline-1091"
     >
 
       Status
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-974"
+    className="MuiBox-root MuiBox-root-1126"
   >
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-975"
+        className="MuiBox-root MuiBox-root-1127"
       >
         <h6
-          className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-941 makeStyles-weight-976"
+          className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-1093 makeStyles-weight-1128"
         >
           Available accounts
         </h6>
       </div>
       <div
-        className="makeStyles-dropdown-977"
+        className="makeStyles-dropdown-1129"
         onClick={[Function]}
       >
         <div
-          className="MuiInputBase-root makeStyles-root-978 makeStyles-root-980"
+          className="MuiInputBase-root makeStyles-root-1130 makeStyles-root-1132"
           onClick={[Function]}
           role="button"
         >
           <input
             autoComplete="off"
-            className="MuiInputBase-input makeStyles-input-979"
+            className="MuiInputBase-input makeStyles-input-1131"
             name="SELECT_FIELD_ATTR"
             onBlur={[Function]}
             onChange={[Function]}
@@ -1919,7 +1986,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
         </div>
         <img
           alt="Phone Menu"
-          className="makeStyles-root-998 makeStyles-noShrink-999"
+          className="makeStyles-root-1150 makeStyles-noShrink-1151"
           height="5"
           src="selectChevron.svg"
           width="8"
@@ -1927,16 +1994,16 @@ exports[`Storyshots Extension Account Status page 1`] = `
       </div>
     </form>
     <div
-      className="MuiBox-root MuiBox-root-1003"
+      className="MuiBox-root MuiBox-root-1155"
     />
     <div
-      className="MuiBox-root MuiBox-root-1004"
+      className="MuiBox-root MuiBox-root-1156"
     >
       <nav
         className="MuiList-root MuiList-padding"
       >
         <div
-          className="MuiBox-root MuiBox-root-1009"
+          className="MuiBox-root MuiBox-root-1161"
         >
           <li
             className="MuiListItem-root MuiListItem-default MuiListItem-gutters"
@@ -1946,7 +2013,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
               className="MuiListItemText-root"
             >
               <p
-                className="MuiTypography-root MuiTypography-body1 makeStyles-weight-941 makeStyles-weight-1028"
+                className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1093 makeStyles-weight-1180"
               >
                 Transations
               </p>
@@ -1954,27 +2021,27 @@ exports[`Storyshots Extension Account Status page 1`] = `
           </li>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-1029"
+          className="MuiBox-root MuiBox-root-1181"
         />
         <div
-          className="MuiBox-root MuiBox-root-1033"
+          className="MuiBox-root MuiBox-root-1185"
         />
         <li
-          className="MuiListItem-root MuiListItem-default MuiListItem-gutters makeStyles-center-1031"
+          className="MuiListItem-root MuiListItem-default MuiListItem-gutters makeStyles-center-1183"
           disabled={false}
         >
           <div
-            className="MuiListItemIcon-root makeStyles-empty-1030"
+            className="MuiListItemIcon-root makeStyles-empty-1182"
           >
             <img
               alt="No Transations"
-              className="makeStyles-root-998"
+              className="makeStyles-root-1150"
               height="42"
               src="uptodate.svg"
             />
           </div>
           <div
-            className="MuiListItemText-root makeStyles-text-1032"
+            className="MuiListItemText-root makeStyles-text-1184"
           >
             <span
               className="MuiTypography-root MuiTypography-body1 MuiListItemText-primary"
@@ -1986,13 +2053,13 @@ exports[`Storyshots Extension Account Status page 1`] = `
       </nav>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1035"
+      className="MuiBox-root MuiBox-root-1187"
     >
       <nav
         className="MuiList-root MuiList-padding"
       >
         <div
-          className="MuiBox-root MuiBox-root-1036"
+          className="MuiBox-root MuiBox-root-1188"
         >
           <li
             className="MuiListItem-root MuiListItem-default MuiListItem-gutters"
@@ -2002,7 +2069,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
               className="MuiListItemText-root"
             >
               <p
-                className="MuiTypography-root MuiTypography-body1 makeStyles-weight-941 makeStyles-weight-1037"
+                className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1093 makeStyles-weight-1189"
               >
                 Pending Transactions
               </p>
@@ -2010,27 +2077,27 @@ exports[`Storyshots Extension Account Status page 1`] = `
           </li>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-1038"
+          className="MuiBox-root MuiBox-root-1190"
         />
         <div
-          className="MuiBox-root MuiBox-root-1039"
+          className="MuiBox-root MuiBox-root-1191"
         />
         <li
-          className="MuiListItem-root MuiListItem-default MuiListItem-gutters makeStyles-center-1031"
+          className="MuiListItem-root MuiListItem-default MuiListItem-gutters makeStyles-center-1183"
           disabled={false}
         >
           <div
-            className="MuiListItemIcon-root makeStyles-empty-1030"
+            className="MuiListItemIcon-root makeStyles-empty-1182"
           >
             <img
               alt="No Pending Transactions"
-              className="makeStyles-root-998"
+              className="makeStyles-root-1150"
               height="42"
               src="uptodate.svg"
             />
           </div>
           <div
-            className="MuiListItemText-root makeStyles-text-1032"
+            className="MuiListItemText-root makeStyles-text-1184"
           >
             <span
               className="MuiTypography-root MuiTypography-body1 MuiListItemText-primary"
@@ -2043,14 +2110,14 @@ exports[`Storyshots Extension Account Status page 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1040"
+    className="MuiBox-root MuiBox-root-1192"
   />
   <div
-    className="MuiBox-root MuiBox-root-1041"
+    className="MuiBox-root MuiBox-root-1193"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-998"
+      className="makeStyles-root-1150"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2061,32 +2128,32 @@ exports[`Storyshots Extension Account Status page 1`] = `
 
 exports[`Storyshots Extension Login page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1050"
+  className="MuiBox-root MuiBox-root-1202"
   id="/login"
 >
   <div
-    className="MuiBox-root MuiBox-root-1051"
+    className="MuiBox-root MuiBox-root-1203"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1054 makeStyles-weight-1055 makeStyles-inline-1052"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1206 makeStyles-weight-1207 makeStyles-inline-1204"
     >
       Log
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1054 makeStyles-weight-1086 makeStyles-inline-1052"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1206 makeStyles-weight-1238 makeStyles-inline-1204"
     >
 
       In
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1087"
+    className="MuiBox-root MuiBox-root-1239"
   >
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-1088"
+        className="MuiBox-root MuiBox-root-1240"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -2137,10 +2204,10 @@ exports[`Storyshots Extension Login page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1126"
+        className="MuiBox-root MuiBox-root-1278"
       >
         <div
-          className="MuiBox-root MuiBox-root-1127"
+          className="MuiBox-root MuiBox-root-1279"
         >
           <button
             className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
@@ -2168,31 +2235,31 @@ exports[`Storyshots Extension Login page 1`] = `
       </div>
     </form>
     <div
-      className="MuiBox-root MuiBox-root-1148"
+      className="MuiBox-root MuiBox-root-1300"
     >
       <div
-        className="MuiBox-root MuiBox-root-1149"
+        className="MuiBox-root MuiBox-root-1301"
       >
         <a
           href="/restore-account"
           onClick={[Function]}
         >
           <h6
-            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-1054 makeStyles-weight-1150 makeStyles-inline-1052 makeStyles-link-1053"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-1206 makeStyles-weight-1302 makeStyles-inline-1204 makeStyles-link-1205"
           >
             Restore account
           </h6>
         </a>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1151"
+        className="MuiBox-root MuiBox-root-1303"
       >
         <a
           href="/welcome"
           onClick={[Function]}
         >
           <h6
-            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-1054 makeStyles-weight-1152 makeStyles-inline-1052 makeStyles-link-1053"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-1206 makeStyles-weight-1304 makeStyles-inline-1204 makeStyles-link-1205"
           >
             More options
           </h6>
@@ -2201,14 +2268,14 @@ exports[`Storyshots Extension Login page 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1153"
+    className="MuiBox-root MuiBox-root-1305"
   />
   <div
-    className="MuiBox-root MuiBox-root-1154"
+    className="MuiBox-root MuiBox-root-1306"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1155"
+      className="makeStyles-root-1307"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2219,42 +2286,42 @@ exports[`Storyshots Extension Login page 1`] = `
 
 exports[`Storyshots Extension Recovery Phrase page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1161"
+  className="MuiBox-root MuiBox-root-1313"
   id="/recovery-phrase"
 >
   <div
-    className="MuiBox-root MuiBox-root-1162"
+    className="MuiBox-root MuiBox-root-1314"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1165 makeStyles-weight-1166 makeStyles-inline-1163"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1317 makeStyles-weight-1318 makeStyles-inline-1315"
     >
       Recovery
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1165 makeStyles-weight-1197 makeStyles-inline-1163"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1317 makeStyles-weight-1349 makeStyles-inline-1315"
     >
 
       phrase
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1198"
+    className="MuiBox-root MuiBox-root-1350"
   >
     <div
-      className="MuiBox-root MuiBox-root-1199"
+      className="MuiBox-root MuiBox-root-1351"
     >
       <h6
-        className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-1165 makeStyles-weight-1200"
+        className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-1317 makeStyles-weight-1352"
       >
         Your Recovery Phrase are 12 random words that are set in a particular order that acts as a tool to recover or back up your wallet on any platform.
       </h6>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1201"
+      className="MuiBox-root MuiBox-root-1353"
     >
       <button
         aria-label="Export as CSV"
-        className="MuiButtonBase-root MuiFab-root makeStyles-root-1202 MuiFab-extended makeStyles-extended-1203 MuiFab-secondary makeStyles-secondary-1205 MuiFab-sizeSmall makeStyles-sizeSmall-1204"
+        className="MuiButtonBase-root MuiFab-root makeStyles-root-1354 MuiFab-extended makeStyles-extended-1355 MuiFab-secondary makeStyles-secondary-1357 MuiFab-sizeSmall makeStyles-sizeSmall-1356"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -2274,21 +2341,21 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
           className="MuiFab-label"
         >
           <div
-            className="MuiBox-root MuiBox-root-1219"
+            className="MuiBox-root MuiBox-root-1371"
           >
             <img
               alt="Download"
-              className="makeStyles-root-1220"
+              className="makeStyles-root-1372"
               height={16}
               src="download.svg"
               width={16}
             />
           </div>
           <div
-            className="MuiBox-root MuiBox-root-1225"
+            className="MuiBox-root MuiBox-root-1377"
           >
             <h6
-              className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextPrimary makeStyles-weight-1165 makeStyles-weight-1226"
+              className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextPrimary makeStyles-weight-1317 makeStyles-weight-1378"
             >
               Export as .PDF
             </h6>
@@ -2300,19 +2367,19 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
       </button>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1227"
+      className="MuiBox-root MuiBox-root-1379"
     >
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1165 makeStyles-weight-1228 makeStyles-inline-1163"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1317 makeStyles-weight-1380 makeStyles-inline-1315"
       >
 
       </p>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1229"
+      className="MuiBox-root MuiBox-root-1381"
     >
       <div
-        className="MuiBox-root MuiBox-root-1230"
+        className="MuiBox-root MuiBox-root-1382"
       >
         <button
           className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -2344,14 +2411,14 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1248"
+    className="MuiBox-root MuiBox-root-1400"
   />
   <div
-    className="MuiBox-root MuiBox-root-1249"
+    className="MuiBox-root MuiBox-root-1401"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1220"
+      className="makeStyles-root-1372"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2362,29 +2429,29 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
 
 exports[`Storyshots Extension Restore Account page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1261"
+  className="MuiBox-root MuiBox-root-1413"
   id="/restore-account"
 >
   <div
-    className="MuiBox-root MuiBox-root-1262"
+    className="MuiBox-root MuiBox-root-1414"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1265 makeStyles-weight-1266 makeStyles-inline-1263"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1417 makeStyles-weight-1418 makeStyles-inline-1415"
     >
       Restore
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1265 makeStyles-weight-1297 makeStyles-inline-1263"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1417 makeStyles-weight-1449 makeStyles-inline-1415"
     >
 
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1298"
+    className="MuiBox-root MuiBox-root-1450"
   >
     <h6
-      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-1265 makeStyles-weight-1299 makeStyles-inline-1263"
+      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-1417 makeStyles-weight-1451 makeStyles-inline-1415"
     >
       Restore your account with your recovery words. Enter your recovery words here.
     </h6>
@@ -2392,7 +2459,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-1300"
+        className="MuiBox-root MuiBox-root-1452"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -2443,10 +2510,10 @@ exports[`Storyshots Extension Restore Account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1338"
+        className="MuiBox-root MuiBox-root-1490"
       >
         <div
-          className="MuiBox-root MuiBox-root-1339"
+          className="MuiBox-root MuiBox-root-1491"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -2476,7 +2543,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
           </button>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-1360"
+          className="MuiBox-root MuiBox-root-1512"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -2508,14 +2575,14 @@ exports[`Storyshots Extension Restore Account page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1361"
+    className="MuiBox-root MuiBox-root-1513"
   />
   <div
-    className="MuiBox-root MuiBox-root-1362"
+    className="MuiBox-root MuiBox-root-1514"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1363"
+      className="makeStyles-root-1515"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2526,34 +2593,34 @@ exports[`Storyshots Extension Restore Account page 1`] = `
 
 exports[`Storyshots Extension Welcome page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1379"
+  className="MuiBox-root MuiBox-root-1531"
   id="/welcome"
 >
   <div
-    className="MuiBox-root MuiBox-root-1380"
+    className="MuiBox-root MuiBox-root-1532"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1383 makeStyles-weight-1384 makeStyles-inline-1381"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1535 makeStyles-weight-1536 makeStyles-inline-1533"
     >
       Welcome
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1383 makeStyles-weight-1415 makeStyles-inline-1381"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1535 makeStyles-weight-1567 makeStyles-inline-1533"
     >
 
       to your IOV manager
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1416"
+    className="MuiBox-root MuiBox-root-1568"
   >
     <p
-      className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1383 makeStyles-weight-1417 makeStyles-inline-1381"
+      className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1535 makeStyles-weight-1569 makeStyles-inline-1533"
     >
       This plugin lets you manage all your accounts in one place.
     </p>
     <div
-      className="MuiBox-root MuiBox-root-1418"
+      className="MuiBox-root MuiBox-root-1570"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -2582,7 +2649,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
       />
     </button>
     <div
-      className="MuiBox-root MuiBox-root-1439"
+      className="MuiBox-root MuiBox-root-1591"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -2611,7 +2678,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
       />
     </button>
     <div
-      className="MuiBox-root MuiBox-root-1440"
+      className="MuiBox-root MuiBox-root-1592"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -2640,14 +2707,14 @@ exports[`Storyshots Extension Welcome page 1`] = `
     </button>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1441"
+    className="MuiBox-root MuiBox-root-1593"
   />
   <div
-    className="MuiBox-root MuiBox-root-1442"
+    className="MuiBox-root MuiBox-root-1594"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1443"
+      className="makeStyles-root-1595"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2658,59 +2725,59 @@ exports[`Storyshots Extension Welcome page 1`] = `
 
 exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1542"
+  className="MuiBox-root MuiBox-root-1694"
 >
   <div
-    className="MuiBox-root MuiBox-root-1543"
+    className="MuiBox-root MuiBox-root-1695"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1546 makeStyles-weight-1547 makeStyles-inline-1544"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1698 makeStyles-weight-1699 makeStyles-inline-1696"
     >
       Share
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1546 makeStyles-weight-1578 makeStyles-inline-1544"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1698 makeStyles-weight-1730 makeStyles-inline-1696"
     >
 
       Identity
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1579"
+    className="MuiBox-root MuiBox-root-1731"
   >
     <div
-      className="MuiBox-root MuiBox-root-1580"
+      className="MuiBox-root MuiBox-root-1732"
     >
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1546 makeStyles-weight-1581"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1698 makeStyles-weight-1733"
       >
         The following site:
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1546 makeStyles-weight-1582"
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1698 makeStyles-weight-1734"
       >
         http://finex.com
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1546 makeStyles-weight-1583 makeStyles-inline-1544"
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1698 makeStyles-weight-1735 makeStyles-inline-1696"
       >
         will be able to see
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1546 makeStyles-weight-1584 makeStyles-inline-1544"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1698 makeStyles-weight-1736 makeStyles-inline-1696"
       >
 
         your identity on
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1546 makeStyles-weight-1585 makeStyles-inline-1544"
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1698 makeStyles-weight-1737 makeStyles-inline-1696"
       >
 
         ETH
       </p>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1586"
+      className="MuiBox-root MuiBox-root-1738"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -2739,7 +2806,7 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
       />
     </button>
     <div
-      className="MuiBox-root MuiBox-root-1607"
+      className="MuiBox-root MuiBox-root-1759"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -2769,14 +2836,14 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
     </button>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1608"
+    className="MuiBox-root MuiBox-root-1760"
   />
   <div
-    className="MuiBox-root MuiBox-root-1609"
+    className="MuiBox-root MuiBox-root-1761"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1610"
+      className="makeStyles-root-1762"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2785,26 +2852,27 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
 </div>
 `;
 
-exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
+exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1459"
+  className="MuiBox-root MuiBox-root-1778"
 >
   <div
-    className="MuiBox-root MuiBox-root-1460"
+    className="MuiBox-root MuiBox-root-1779"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1463 makeStyles-weight-1464 makeStyles-inline-1461"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1782 makeStyles-weight-1783 makeStyles-inline-1780"
     >
       Share
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1463 makeStyles-weight-1495 makeStyles-inline-1461"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1782 makeStyles-weight-1814 makeStyles-inline-1780"
     >
+
       Identity
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1496"
+    className="MuiBox-root MuiBox-root-1815"
   >
     <div
       className="MuiBox-root MuiBox-root-1497"
@@ -2851,6 +2919,231 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       tabIndex="0"
       type="button"
     >
+      <div
+        className="MuiBox-root MuiBox-root-1816"
+      >
+        <p
+          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1782 makeStyles-weight-1817"
+        >
+          The following site:
+        </p>
+        <p
+          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1782 makeStyles-weight-1818"
+        >
+          http://finex.com
+        </p>
+        <p
+          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorError makeStyles-weight-1782 makeStyles-weight-1819 makeStyles-inline-1780"
+        >
+          would not be able to request
+        </p>
+        <p
+          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1782 makeStyles-weight-1820 makeStyles-inline-1780"
+        >
+
+          your identity.
+        </p>
+        <div
+          className="MuiBox-root MuiBox-root-1821"
+        />
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root MuiPrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+              </svg>
+              <input
+                checked={false}
+                className="MuiPrivateSwitchBase-input"
+                data-indeterminate={false}
+                name="permanentRejectField"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                type="checkbox"
+              />
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label"
+          >
+            Don't ask me again
+          </span>
+        </label>
+      </div>
+      <div
+        className="MuiBox-root MuiBox-root-1859"
+      />
+      <button
+        className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
+        disabled={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex="-1"
+        type="submit"
+      >
+        <span
+          className="MuiButton-label"
+        >
+          Reject
+        </span>
+      </button>
+      <div
+        className="MuiBox-root MuiBox-root-1877"
+      />
+      <button
+        className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex="0"
+        type="button"
+      >
+        <span
+          className="MuiButton-label"
+        >
+          Back
+        </span>
+        <span
+          className="MuiTouchRipple-root"
+        />
+      </button>
+    </form>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-1878"
+  />
+  <div
+    className="MuiBox-root MuiBox-root-1879"
+  >
+    <img
+      alt="IOV logo"
+      className="makeStyles-root-1880"
+      height={39}
+      src="iov-logo.png"
+      width={84}
+    />
+  </div>
+</div>
+`;
+
+exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
+<div
+  className="MuiBox-root MuiBox-root-1611"
+>
+  <div
+    className="MuiBox-root MuiBox-root-1612"
+  >
+    <h4
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1615 makeStyles-weight-1616 makeStyles-inline-1613"
+    >
+      Share
+    </h4>
+    <h4
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1615 makeStyles-weight-1647 makeStyles-inline-1613"
+    >
+
+      Identity
+    </h4>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-1648"
+  >
+    <div
+      className="MuiBox-root MuiBox-root-1649"
+    >
+      <p
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1615 makeStyles-weight-1650"
+      >
+        The following site:
+      </p>
+      <p
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1615 makeStyles-weight-1651"
+      >
+        http://finex.com
+      </p>
+      <p
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1615 makeStyles-weight-1652 makeStyles-inline-1613"
+      >
+        wants to see your identity on
+      </p>
+      <p
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1615 makeStyles-weight-1653 makeStyles-inline-1613"
+      >
+
+        BTC
+      </p>
+    </div>
+    <div
+      className="MuiBox-root MuiBox-root-1654"
+    />
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
       <span
         className="MuiButton-label"
       >
@@ -2861,7 +3154,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       />
     </button>
     <div
-      className="MuiBox-root MuiBox-root-1523"
+      className="MuiBox-root MuiBox-root-1675"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-fullWidth"
@@ -2891,14 +3184,14 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
     </button>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1524"
+    className="MuiBox-root MuiBox-root-1676"
   />
   <div
-    className="MuiBox-root MuiBox-root-1525"
+    className="MuiBox-root MuiBox-root-1677"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1526"
+      className="makeStyles-root-1678"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2909,149 +3202,32 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
 
 exports[`Storyshots Extension/Signup New Account page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1626"
+  className="MuiBox-root MuiBox-root-1896"
   id="/signup1"
 >
   <div
-    className="MuiBox-root MuiBox-root-1627"
+    className="MuiBox-root MuiBox-root-1897"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1630 makeStyles-weight-1631 makeStyles-inline-1628"
-    >
-      Share
-    </h4>
-    <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1630 makeStyles-weight-1662 makeStyles-inline-1628"
-    >
-
-      Account
-    </h4>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-1663"
-  >
-    <div
-      className="MuiBox-root-1134 MuiBox-root-1173"
-    >
-      <p
-        className="MuiTypography-root-1141 MuiTypography-body1-1143 makeStyles-weight-1139 makeStyles-weight-1174"
-      >
-        The following site:
-      </p>
-      <p
-        className="MuiTypography-root-1141 MuiTypography-body1-1143 MuiTypography-colorPrimary-1164 makeStyles-weight-1139 makeStyles-weight-1175"
-      >
-        http://finex.com
-      </p>
-      <p
-        className="MuiTypography-root-1141 MuiTypography-body1-1143 makeStyles-weight-1139 makeStyles-weight-1176 makeStyles-inline-1137"
-      >
-        wants to see your identity on
-      </p>
-
-      <p
-        className="MuiTypography-root-1141 MuiTypography-body1-1143 MuiTypography-colorPrimary-1164 makeStyles-weight-1139 makeStyles-weight-1177 makeStyles-inline-1137"
-      >
-        BTC
-      </p>
-    </div>
-    <div
-      className="MuiBox-root-1134 MuiBox-root-1178"
-    />
-    <button
-      className="MuiButtonBase-root-1196 MuiButton-root-1179 MuiButton-contained-1187 MuiButton-containedPrimary-1188 MuiButton-fullWidth-1195"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex="0"
-      type="button"
-    >
-      <span
-        className="MuiButton-label-1180"
-      >
-        Accept
-      </span>
-    </button>
-    <div
-      className="MuiBox-root-1134 MuiBox-root-1199"
-    />
-    <button
-      className="MuiButtonBase-root-1196 MuiButton-root-1179 MuiButton-contained-1187 MuiButton-containedSecondary-1189 MuiButton-fullWidth-1195"
-      disabled={false}
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex="0"
-      type="button"
-    >
-      <span
-        className="MuiButton-label-1180"
-      >
-        Reject
-      </span>
-    </button>
-  </div>
-  <div
-    className="MuiBox-root-1134 MuiBox-root-1200"
-  />
-  <div
-    className="MuiBox-root-1134 MuiBox-root-1201"
-  >
-    <img
-      alt="IOV logo"
-      className="makeStyles-root-1354"
-      height={39}
-      src="iov-logo.png"
-      width={84}
-    />
-  </div>
-</div>
-`;
-
-exports[`Storyshots Routes/Signup New account page 1`] = `
-<div
-  className="MuiBox-root-1301 MuiBox-root-1302"
-  id="/signup1"
->
-  <div
-    className="MuiBox-root MuiBox-root-1573"
-  >
-    <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1576 makeStyles-weight-1577 makeStyles-inline-1574"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1900 makeStyles-weight-1901 makeStyles-inline-1898"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1576 makeStyles-weight-1608 makeStyles-inline-1574"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1900 makeStyles-weight-1932 makeStyles-inline-1898"
     >
 
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1609"
+    className="MuiBox-root MuiBox-root-1933"
   >
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-1664"
+        className="MuiBox-root MuiBox-root-1934"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3113,7 +3289,7 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1721"
+        className="MuiBox-root MuiBox-root-1991"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3175,7 +3351,7 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1722"
+        className="MuiBox-root MuiBox-root-1992"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3237,10 +3413,10 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1723"
+        className="MuiBox-root MuiBox-root-1993"
       >
         <div
-          className="MuiBox-root MuiBox-root-1724"
+          className="MuiBox-root MuiBox-root-1994"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -3270,7 +3446,7 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
           </button>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-1745"
+          className="MuiBox-root MuiBox-root-2015"
         >
           <button
             className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
@@ -3299,14 +3475,14 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1746"
+    className="MuiBox-root MuiBox-root-2016"
   />
   <div
-    className="MuiBox-root MuiBox-root-1747"
+    className="MuiBox-root MuiBox-root-2017"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1748"
+      className="makeStyles-root-2018"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3317,49 +3493,49 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
 
 exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1764"
+  className="MuiBox-root MuiBox-root-2034"
   id="/signup2"
 >
   <div
-    className="MuiBox-root MuiBox-root-1765"
+    className="MuiBox-root MuiBox-root-2035"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1768 makeStyles-weight-1769 makeStyles-inline-1766"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2038 makeStyles-weight-2039 makeStyles-inline-2036"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1768 makeStyles-weight-1800 makeStyles-inline-1766"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2038 makeStyles-weight-2070 makeStyles-inline-2036"
     >
 
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1801"
+    className="MuiBox-root MuiBox-root-2071"
   >
     <div
-      className="MuiBox-root MuiBox-root-1802"
+      className="MuiBox-root MuiBox-root-2072"
     >
       <div
-        className="MuiBox-root MuiBox-root-1803"
+        className="MuiBox-root MuiBox-root-2073"
       >
         <div
-          className="MuiBox-root MuiBox-root-1804"
+          className="MuiBox-root MuiBox-root-2074"
         >
           <h6
-            className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-1768 makeStyles-weight-1805 makeStyles-inline-1766"
+            className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-2038 makeStyles-weight-2075 makeStyles-inline-2036"
           >
             Activate Recovery Phrase?
           </h6>
         </div>
         <div
-          className="makeStyles-container-1807"
+          className="makeStyles-container-2077"
           onClick={[Function]}
         >
           <img
             alt="Info"
-            className="makeStyles-root-1810"
+            className="makeStyles-root-2080"
             height={16}
             src="info_normal.svg"
             width={16}
@@ -3413,19 +3589,19 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
       </label>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1846"
+      className="MuiBox-root MuiBox-root-2116"
     >
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1768 makeStyles-weight-1847 makeStyles-inline-1766"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2038 makeStyles-weight-2117 makeStyles-inline-2036"
       >
 
       </p>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1848"
+      className="MuiBox-root MuiBox-root-2118"
     >
       <div
-        className="MuiBox-root MuiBox-root-1849"
+        className="MuiBox-root MuiBox-root-2119"
       >
         <button
           className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -3455,7 +3631,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
         </button>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1867"
+        className="MuiBox-root MuiBox-root-2137"
       >
         <button
           className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -3487,14 +3663,14 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1868"
+    className="MuiBox-root MuiBox-root-2138"
   />
   <div
-    className="MuiBox-root MuiBox-root-1869"
+    className="MuiBox-root MuiBox-root-2139"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1810"
+      className="makeStyles-root-2080"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3505,29 +3681,29 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
 
 exports[`Storyshots Extension/Signup Security Hint page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1881"
+  className="MuiBox-root MuiBox-root-2151"
   id="/signup3"
 >
   <div
-    className="MuiBox-root MuiBox-root-1882"
+    className="MuiBox-root MuiBox-root-2152"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1885 makeStyles-weight-1886 makeStyles-inline-1883"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2155 makeStyles-weight-2156 makeStyles-inline-2153"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1885 makeStyles-weight-1917 makeStyles-inline-1883"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2155 makeStyles-weight-2187 makeStyles-inline-2153"
     >
 
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1918"
+    className="MuiBox-root MuiBox-root-2188"
   >
     <h6
-      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-1885 makeStyles-weight-1919 makeStyles-inline-1883"
+      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-2155 makeStyles-weight-2189 makeStyles-inline-2153"
     >
       To help you remember your details in the future please provide a security hint:
     </h6>
@@ -3535,7 +3711,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-1920"
+        className="MuiBox-root MuiBox-root-2190"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3586,10 +3762,10 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1958"
+        className="MuiBox-root MuiBox-root-2228"
       >
         <div
-          className="MuiBox-root MuiBox-root-1959"
+          className="MuiBox-root MuiBox-root-2229"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -3619,7 +3795,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
           </button>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-1980"
+          className="MuiBox-root MuiBox-root-2250"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -3651,14 +3827,14 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1981"
+    className="MuiBox-root MuiBox-root-2251"
   />
   <div
-    className="MuiBox-root MuiBox-root-1982"
+    className="MuiBox-root MuiBox-root-2252"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1983"
+      className="makeStyles-root-2253"
       height={39}
       src="iov-logo.png"
       width={84}

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2860,7 +2860,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1630 makeStyles-weight-1631 makeStyles-inline-1628"
     >
-      New
+      Share
     </h4>
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1630 makeStyles-weight-1662 makeStyles-inline-1628"
@@ -2871,6 +2871,122 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
   </div>
   <div
     className="MuiBox-root MuiBox-root-1663"
+  >
+    <div
+      className="MuiBox-root-1134 MuiBox-root-1173"
+    >
+      <p
+        className="MuiTypography-root-1141 MuiTypography-body1-1143 makeStyles-weight-1139 makeStyles-weight-1174"
+      >
+        The following site:
+      </p>
+      <p
+        className="MuiTypography-root-1141 MuiTypography-body1-1143 MuiTypography-colorPrimary-1164 makeStyles-weight-1139 makeStyles-weight-1175"
+      >
+        http://finex.com
+      </p>
+      <p
+        className="MuiTypography-root-1141 MuiTypography-body1-1143 makeStyles-weight-1139 makeStyles-weight-1176 makeStyles-inline-1137"
+      >
+        wants to see you identity on
+      </p>
+
+      <p
+        className="MuiTypography-root-1141 MuiTypography-body1-1143 MuiTypography-colorPrimary-1164 makeStyles-weight-1139 makeStyles-weight-1177 makeStyles-inline-1137"
+      >
+        BTC
+      </p>
+    </div>
+    <div
+      className="MuiBox-root-1134 MuiBox-root-1178"
+    />
+    <button
+      className="MuiButtonBase-root-1196 MuiButton-root-1179 MuiButton-contained-1187 MuiButton-containedPrimary-1188 MuiButton-fullWidth-1195"
+      disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiButton-label-1180"
+      >
+        Accept
+      </span>
+    </button>
+    <div
+      className="MuiBox-root-1134 MuiBox-root-1199"
+    />
+    <button
+      className="MuiButtonBase-root-1196 MuiButton-root-1179 MuiButton-contained-1187 MuiButton-containedSecondary-1189 MuiButton-fullWidth-1195"
+      disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiButton-label-1180"
+      >
+        Reject
+      </span>
+    </button>
+  </div>
+  <div
+    className="MuiBox-root-1134 MuiBox-root-1200"
+  />
+  <div
+    className="MuiBox-root-1134 MuiBox-root-1201"
+  >
+    <img
+      alt="IOV logo"
+      className="makeStyles-root-1202"
+      height={39}
+      src="iov-logo.png"
+      width={84}
+    />
+  </div>
+</div>
+`;
+
+exports[`Storyshots Routes/Signup New account page 1`] = `
+<div
+  className="MuiBox-root-1217 MuiBox-root-1218"
+  id="/signup1"
+>
+  <div
+    className="MuiBox-root-1217 MuiBox-root-1219"
+  >
+    <h4
+      className="MuiTypography-root-1224 MuiTypography-h4-1232 MuiTypography-colorPrimary-1247 makeStyles-weight-1222 makeStyles-weight-1223 makeStyles-inline-1220"
+    >
+      New
+    </h4>
+    <h4
+      className="MuiTypography-root-1224 MuiTypography-h4-1232 makeStyles-weight-1222 makeStyles-weight-1254 makeStyles-inline-1220"
+    >
+
+      Account
+    </h4>
+  </div>
+  <div
+    className="MuiBox-root-1217 MuiBox-root-1255"
   >
     <form
       onSubmit={[Function]}

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2742,7 +2742,6 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1463 makeStyles-weight-1495 makeStyles-inline-1461"
     >
-
       Identity
     </h4>
   </div>
@@ -2972,22 +2971,22 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
   id="/signup1"
 >
   <div
-    className="MuiBox-root-1301 MuiBox-root-1303"
+    className="MuiBox-root MuiBox-root-1303"
   >
     <h4
-      className="MuiTypography-root-1308 MuiTypography-h4-1316 MuiTypography-colorPrimary-1331 makeStyles-weight-1306 makeStyles-weight-1307 makeStyles-inline-1304"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1306 makeStyles-weight-1307 makeStyles-inline-1304"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root-1308 MuiTypography-h4-1316 makeStyles-weight-1306 makeStyles-weight-1338 makeStyles-inline-1304"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1306 makeStyles-weight-1338 makeStyles-inline-1304"
     >
 
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root-1301 MuiBox-root-1339"
+    className="MuiBox-root MuiBox-root-1339"
   >
     <form
       onSubmit={[Function]}

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -1458,6 +1458,64 @@ exports[`Storyshots Components/forms Form 1`] = `
       />
     </div>
   </div>
+  <div
+    className="MuiBox-root MuiBox-root-676"
+  >
+    <label
+      className="MuiFormControlLabel-root"
+    >
+      <span
+        aria-disabled={false}
+        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-689 MuiCheckbox-root MuiCheckbox-colorPrimary"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={null}
+      >
+        <span
+          className="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+            />
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+          </svg>
+          <input
+            checked={false}
+            className="PrivateSwitchBase-input-692"
+            data-indeterminate={false}
+            name="checkboxFieldUniqueIdentifier"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="checkbox"
+          />
+        </span>
+      </span>
+      <span
+        className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label"
+      >
+        Checkbox field
+      </span>
+    </label>
+  </div>
   <button
     className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled"
     disabled={true}
@@ -2809,6 +2867,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-fullWidth"
       disabled={false}
       onBlur={[Function]}
+      onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
@@ -2956,7 +3015,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1202"
+      className="makeStyles-root-1354"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2971,22 +3030,22 @@ exports[`Storyshots Routes/Signup New account page 1`] = `
   id="/signup1"
 >
   <div
-    className="MuiBox-root MuiBox-root-1303"
+    className="MuiBox-root MuiBox-root-1573"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1306 makeStyles-weight-1307 makeStyles-inline-1304"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1576 makeStyles-weight-1577 makeStyles-inline-1574"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1306 makeStyles-weight-1338 makeStyles-inline-1304"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1576 makeStyles-weight-1608 makeStyles-inline-1574"
     >
 
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1339"
+    className="MuiBox-root MuiBox-root-1609"
   >
     <form
       onSubmit={[Function]}

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -1433,548 +1433,558 @@ Array [
 `;
 
 exports[`Storyshots Components/forms Form 1`] = `
-<form
-  onSubmit={[Function]}
->
+Array [
   <div
-    className="MuiFormControl-root MuiFormControl-marginNormal MuiTextField-root"
+    className="MuiBox-root MuiBox-root-849"
+  />,
+  <form
+    onSubmit={[Function]}
   >
-    <label
-      className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
-      data-shrink={true}
-    >
-      Unique Identifier
-    </label>
     <div
-      className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
-      onClick={[Function]}
+      className="MuiFormControl-root MuiFormControl-marginNormal MuiTextField-root"
     >
-      <fieldset
-        aria-hidden={true}
-        className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-        style={
-          Object {
-            "paddingLeft": 8,
-          }
-        }
+      <label
+        className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+        data-shrink={true}
       >
-        <legend
-          className="MuiPrivateNotchedOutline-legend"
+        Unique Identifier
+      </label>
+      <div
+        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+        onClick={[Function]}
+      >
+        <fieldset
+          aria-hidden={true}
+          className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
           style={
             Object {
-              "width": 0.01,
+              "paddingLeft": 8,
             }
           }
         >
-          <span
-            dangerouslySetInnerHTML={
+          <legend
+            className="MuiPrivateNotchedOutline-legend"
+            style={
               Object {
-                "__html": "&#8203;",
+                "width": 0.01,
               }
             }
-          />
-        </legend>
-      </fieldset>
-      <input
-        aria-invalid={false}
-        className="MuiInputBase-input MuiOutlinedInput-input"
-        disabled={false}
-        name="textFieldUniqueIdentifier"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder="Unique Identifier"
-        required={false}
-        type="text"
-      />
-    </div>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-905"
-  >
-    <div
-      className="makeStyles-dropdown-906"
-      onClick={[Function]}
-    >
-      <div
-        className="MuiInputBase-root makeStyles-root-907 makeStyles-root-909"
-        onClick={[Function]}
-        role="button"
-      >
+          >
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "&#8203;",
+                }
+              }
+            />
+          </legend>
+        </fieldset>
         <input
-          autoComplete="off"
-          className="MuiInputBase-input makeStyles-input-908"
-          name="selectFieldUniqueIdentifier"
+          aria-invalid={false}
+          className="MuiInputBase-input MuiOutlinedInput-input"
+          disabled={false}
+          name="textFieldUniqueIdentifier"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          readOnly={true}
+          placeholder="Unique Identifier"
+          required={false}
           type="text"
-          value=""
         />
       </div>
-      <img
-        alt="Phone Menu"
-        className="makeStyles-root-910 makeStyles-noShrink-911"
-        height="5"
-        src="selectChevron.svg"
-        width="8"
-      />
     </div>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-915"
-  >
-    <label
-      className="MuiFormControlLabel-root"
+    <div
+      className="MuiBox-root MuiBox-root-906"
     >
-      <span
-        aria-disabled={false}
-        className="MuiButtonBase-root MuiIconButton-root MuiPrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={null}
+      <div
+        className="makeStyles-dropdown-907"
+        onClick={[Function]}
       >
-        <span
-          className="MuiIconButton-label"
+        <div
+          className="MuiInputBase-root makeStyles-root-908 makeStyles-root-910"
+          onClick={[Function]}
+          role="button"
         >
-          <svg
-            aria-hidden="true"
-            className="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-            focusable="false"
-            role="presentation"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-            />
-            <path
-              d="M0 0h24v24H0z"
-              fill="none"
-            />
-          </svg>
           <input
-            checked={false}
-            className="MuiPrivateSwitchBase-input"
-            data-indeterminate={false}
-            name="checkboxFieldUniqueIdentifier"
+            autoComplete="off"
+            className="MuiInputBase-input makeStyles-input-909"
+            name="selectFieldUniqueIdentifier"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
-            type="checkbox"
+            readOnly={true}
+            type="text"
+            value=""
+          />
+        </div>
+        <img
+          alt="Phone Menu"
+          className="makeStyles-root-911 makeStyles-noShrink-912"
+          height="5"
+          src="selectChevron.svg"
+          width="8"
+        />
+      </div>
+    </div>
+    <div
+      className="MuiBox-root MuiBox-root-916"
+    >
+      <label
+        className="MuiFormControlLabel-root"
+      >
+        <span
+          aria-disabled={false}
+          className="MuiButtonBase-root MuiIconButton-root MuiPrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={null}
+        >
+          <span
+            className="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+            </svg>
+            <input
+              checked={false}
+              className="MuiPrivateSwitchBase-input"
+              data-indeterminate={false}
+              name="checkboxFieldUniqueIdentifier"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="checkbox"
+            />
+          </span>
+          <span
+            className="MuiTouchRipple-root"
           />
         </span>
         <span
-          className="MuiTouchRipple-root"
-        />
-      </span>
-      <span
-        className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label"
-      >
-        Checkbox field
-      </span>
-    </label>
-  </div>
-  <button
-    className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled"
-    disabled={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    tabIndex="-1"
-    type="submit"
-  >
-    <span
-      className="MuiButton-label"
+          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label"
+        >
+          Checkbox field
+        </span>
+      </label>
+    </div>
+    <button
+      className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled"
+      disabled={true}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="-1"
+      type="submit"
     >
-      Submit
-    </span>
-  </button>
-  <pre>
-    {}
-  </pre>
-</form>
+      <span
+        className="MuiButton-label"
+      >
+        Submit
+      </span>
+    </button>
+    <pre>
+      {}
+    </pre>
+  </form>,
+]
 `;
 
 exports[`Storyshots Components/forms TextFieldForm 1`] = `
-<div
-  className="MuiBox-root MuiBox-root-1011"
->
+Array [
   <div
     className="MuiBox-root MuiBox-root-1012"
-  >
-    <form
-      onSubmit={[Function]}
-    >
-      <div
-        className="MuiFormControl-root MuiFormControl-marginNormal MuiTextField-root"
-      >
-        <label
-          className="MuiFormLabel-root Mui-error Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
-          data-shrink={true}
-        >
-          Error
-        </label>
-        <div
-          className="MuiInputBase-root MuiOutlinedInput-root Mui-error Mui-error MuiInputBase-formControl"
-          onClick={[Function]}
-        >
-          <fieldset
-            aria-hidden={true}
-            className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-            style={
-              Object {
-                "paddingLeft": 8,
-              }
-            }
-          >
-            <legend
-              className="MuiPrivateNotchedOutline-legend"
-              style={
-                Object {
-                  "width": 0.01,
-                }
-              }
-            >
-              <span
-                dangerouslySetInnerHTML={
-                  Object {
-                    "__html": "&#8203;",
-                  }
-                }
-              />
-            </legend>
-          </fieldset>
-          <input
-            aria-invalid={true}
-            className="MuiInputBase-input MuiOutlinedInput-input"
-            defaultValue="Standard Error"
-            disabled={false}
-            name="field-with-error"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            required={false}
-            type="text"
-          />
-        </div>
-        <p
-          className="MuiFormHelperText-root MuiFormHelperText-contained Mui-error"
-        >
-          This is an error message
-        </p>
-      </div>
-    </form>
-  </div>
+  />,
   <div
-    className="MuiBox-root MuiBox-root-1077"
+    className="MuiBox-root MuiBox-root-1013"
   >
-    <form
-      onSubmit={[Function]}
+    <div
+      className="MuiBox-root MuiBox-root-1014"
     >
-      <div
-        className="MuiFormControl-root MuiFormControl-marginNormal MuiTextField-root"
+      <form
+        onSubmit={[Function]}
       >
-        <label
-          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
-          data-shrink={true}
-        >
-          Filled
-        </label>
         <div
-          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
-          onClick={[Function]}
+          className="MuiFormControl-root MuiFormControl-marginNormal MuiTextField-root"
         >
-          <fieldset
-            aria-hidden={true}
-            className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-            style={
-              Object {
-                "paddingLeft": 8,
-              }
-            }
+          <label
+            className="MuiFormLabel-root Mui-error Mui-error MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+            data-shrink={true}
           >
-            <legend
-              className="MuiPrivateNotchedOutline-legend"
+            Error
+          </label>
+          <div
+            className="MuiInputBase-root MuiOutlinedInput-root Mui-error Mui-error MuiInputBase-formControl"
+            onClick={[Function]}
+          >
+            <fieldset
+              aria-hidden={true}
+              className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
               style={
                 Object {
-                  "width": 0.01,
+                  "paddingLeft": 8,
                 }
               }
             >
-              <span
-                dangerouslySetInnerHTML={
+              <legend
+                className="MuiPrivateNotchedOutline-legend"
+                style={
                   Object {
-                    "__html": "&#8203;",
+                    "width": 0.01,
                   }
                 }
-              />
-            </legend>
-          </fieldset>
-          <input
-            aria-invalid={false}
-            className="MuiInputBase-input MuiOutlinedInput-input"
-            defaultValue="test*iov"
-            disabled={false}
-            name="field-filled"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            required={false}
-            type="text"
-          />
-        </div>
-      </div>
-    </form>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-1078"
-  >
-    <form
-      onSubmit={[Function]}
-    >
-      <div
-        className="MuiFormControl-root MuiFormControl-marginNormal MuiTextField-root"
-      >
-        <label
-          className="MuiFormLabel-root Mui-disabled Mui-disabled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
-          data-shrink={true}
-        >
-          Disabled
-        </label>
-        <div
-          className="MuiInputBase-root MuiOutlinedInput-root Mui-disabled Mui-disabled MuiInputBase-formControl"
-          onClick={[Function]}
-        >
-          <fieldset
-            aria-hidden={true}
-            className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-            style={
-              Object {
-                "paddingLeft": 8,
-              }
-            }
+              >
+                <span
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "&#8203;",
+                    }
+                  }
+                />
+              </legend>
+            </fieldset>
+            <input
+              aria-invalid={true}
+              className="MuiInputBase-input MuiOutlinedInput-input"
+              defaultValue="Standard Error"
+              disabled={false}
+              name="field-with-error"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              required={false}
+              type="text"
+            />
+          </div>
+          <p
+            className="MuiFormHelperText-root MuiFormHelperText-contained Mui-error"
           >
-            <legend
-              className="MuiPrivateNotchedOutline-legend"
+            This is an error message
+          </p>
+        </div>
+      </form>
+    </div>
+    <div
+      className="MuiBox-root MuiBox-root-1079"
+    >
+      <form
+        onSubmit={[Function]}
+      >
+        <div
+          className="MuiFormControl-root MuiFormControl-marginNormal MuiTextField-root"
+        >
+          <label
+            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+            data-shrink={true}
+          >
+            Filled
+          </label>
+          <div
+            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+            onClick={[Function]}
+          >
+            <fieldset
+              aria-hidden={true}
+              className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
               style={
                 Object {
-                  "width": 0.01,
+                  "paddingLeft": 8,
                 }
               }
             >
-              <span
-                dangerouslySetInnerHTML={
+              <legend
+                className="MuiPrivateNotchedOutline-legend"
+                style={
                   Object {
-                    "__html": "&#8203;",
+                    "width": 0.01,
                   }
                 }
-              />
-            </legend>
-          </fieldset>
-          <input
-            aria-invalid={false}
-            className="MuiInputBase-input MuiOutlinedInput-input Mui-disabled Mui-disabled"
-            defaultValue="Disabled input"
-            disabled={true}
-            name="standard-disabled"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            required={false}
-            type="text"
-          />
+              >
+                <span
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "&#8203;",
+                    }
+                  }
+                />
+              </legend>
+            </fieldset>
+            <input
+              aria-invalid={false}
+              className="MuiInputBase-input MuiOutlinedInput-input"
+              defaultValue="test*iov"
+              disabled={false}
+              name="field-filled"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              required={false}
+              type="text"
+            />
+          </div>
         </div>
-      </div>
-    </form>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-1079"
-  >
-    <form
-      onSubmit={[Function]}
+      </form>
+    </div>
+    <div
+      className="MuiBox-root MuiBox-root-1080"
     >
-      <div
-        className="MuiFormControl-root MuiFormControl-marginNormal MuiTextField-root"
+      <form
+        onSubmit={[Function]}
       >
-        <label
-          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
-          data-shrink={true}
-        >
-          Empty
-        </label>
         <div
-          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
-          onClick={[Function]}
+          className="MuiFormControl-root MuiFormControl-marginNormal MuiTextField-root"
         >
-          <fieldset
-            aria-hidden={true}
-            className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-            style={
-              Object {
-                "paddingLeft": 8,
-              }
-            }
+          <label
+            className="MuiFormLabel-root Mui-disabled Mui-disabled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+            data-shrink={true}
           >
-            <legend
-              className="MuiPrivateNotchedOutline-legend"
+            Disabled
+          </label>
+          <div
+            className="MuiInputBase-root MuiOutlinedInput-root Mui-disabled Mui-disabled MuiInputBase-formControl"
+            onClick={[Function]}
+          >
+            <fieldset
+              aria-hidden={true}
+              className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
               style={
                 Object {
-                  "width": 0.01,
+                  "paddingLeft": 8,
                 }
               }
             >
-              <span
-                dangerouslySetInnerHTML={
+              <legend
+                className="MuiPrivateNotchedOutline-legend"
+                style={
                   Object {
-                    "__html": "&#8203;",
+                    "width": 0.01,
                   }
                 }
-              />
-            </legend>
-          </fieldset>
-          <input
-            aria-invalid={false}
-            className="MuiInputBase-input MuiOutlinedInput-input"
-            disabled={false}
-            name="standard-with-placeholder"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder="IOV or wallet address"
-            required={false}
-            type="text"
-          />
+              >
+                <span
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "&#8203;",
+                    }
+                  }
+                />
+              </legend>
+            </fieldset>
+            <input
+              aria-invalid={false}
+              className="MuiInputBase-input MuiOutlinedInput-input Mui-disabled Mui-disabled"
+              defaultValue="Disabled input"
+              disabled={true}
+              name="standard-disabled"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              required={false}
+              type="text"
+            />
+          </div>
         </div>
-      </div>
-    </form>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-1080"
-  >
-    <form
-      onSubmit={[Function]}
+      </form>
+    </div>
+    <div
+      className="MuiBox-root MuiBox-root-1081"
     >
-      <div
-        className="MuiFormControl-root MuiFormControl-marginNormal MuiTextField-root"
+      <form
+        onSubmit={[Function]}
       >
-        <label
-          className="MuiFormLabel-root MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
-          data-shrink={true}
-        >
-          Empty
-        </label>
         <div
-          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline"
-          onClick={[Function]}
+          className="MuiFormControl-root MuiFormControl-marginNormal MuiTextField-root"
         >
-          <fieldset
-            aria-hidden={true}
-            className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-            style={
-              Object {
-                "paddingLeft": 8,
-              }
-            }
+          <label
+            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+            data-shrink={true}
           >
-            <legend
-              className="MuiPrivateNotchedOutline-legend"
+            Empty
+          </label>
+          <div
+            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl"
+            onClick={[Function]}
+          >
+            <fieldset
+              aria-hidden={true}
+              className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
               style={
                 Object {
-                  "width": 0,
+                  "paddingLeft": 8,
                 }
               }
             >
-              <span
-                dangerouslySetInnerHTML={
+              <legend
+                className="MuiPrivateNotchedOutline-legend"
+                style={
                   Object {
-                    "__html": "&#8203;",
+                    "width": 0.01,
                   }
                 }
-              />
-            </legend>
-          </fieldset>
-          <textarea
-            aria-invalid={false}
-            className="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
-            disabled={false}
-            name="standard-with-placeholder"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            required={false}
-            rows={5}
-            value="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
-          />
+              >
+                <span
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "&#8203;",
+                    }
+                  }
+                />
+              </legend>
+            </fieldset>
+            <input
+              aria-invalid={false}
+              className="MuiInputBase-input MuiOutlinedInput-input"
+              disabled={false}
+              name="standard-with-placeholder"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="IOV or wallet address"
+              required={false}
+              type="text"
+            />
+          </div>
         </div>
-      </div>
-    </form>
-  </div>
-</div>
+      </form>
+    </div>
+    <div
+      className="MuiBox-root MuiBox-root-1082"
+    >
+      <form
+        onSubmit={[Function]}
+      >
+        <div
+          className="MuiFormControl-root MuiFormControl-marginNormal MuiTextField-root"
+        >
+          <label
+            className="MuiFormLabel-root MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+            data-shrink={true}
+          >
+            Empty
+          </label>
+          <div
+            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-formControl MuiInputBase-multiline MuiOutlinedInput-multiline"
+            onClick={[Function]}
+          >
+            <fieldset
+              aria-hidden={true}
+              className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+              style={
+                Object {
+                  "paddingLeft": 8,
+                }
+              }
+            >
+              <legend
+                className="MuiPrivateNotchedOutline-legend"
+                style={
+                  Object {
+                    "width": 0,
+                  }
+                }
+              >
+                <span
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "&#8203;",
+                    }
+                  }
+                />
+              </legend>
+            </fieldset>
+            <textarea
+              aria-invalid={false}
+              className="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
+              disabled={false}
+              name="standard-with-placeholder"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              required={false}
+              rows={5}
+              value="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+            />
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>,
+]
 `;
 
 exports[`Storyshots Extension Account Status page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1089"
+  className="MuiBox-root MuiBox-root-1091"
   id="/account"
 >
   <div
-    className="MuiBox-root MuiBox-root-1090"
+    className="MuiBox-root MuiBox-root-1092"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1093 makeStyles-weight-1094 makeStyles-inline-1091"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1095 makeStyles-weight-1096 makeStyles-inline-1093"
     >
       Account
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1093 makeStyles-weight-1125 makeStyles-inline-1091"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1095 makeStyles-weight-1127 makeStyles-inline-1093"
     >
        
       Status
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1126"
+    className="MuiBox-root MuiBox-root-1128"
   >
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-1127"
+        className="MuiBox-root MuiBox-root-1129"
       >
         <h6
-          className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-1093 makeStyles-weight-1128"
+          className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-1095 makeStyles-weight-1130"
         >
           Available accounts
         </h6>
       </div>
       <div
-        className="makeStyles-dropdown-1129"
+        className="makeStyles-dropdown-1131"
         onClick={[Function]}
       >
         <div
-          className="MuiInputBase-root makeStyles-root-1130 makeStyles-root-1132"
+          className="MuiInputBase-root makeStyles-root-1132 makeStyles-root-1134"
           onClick={[Function]}
           role="button"
         >
           <input
             autoComplete="off"
-            className="MuiInputBase-input makeStyles-input-1131"
+            className="MuiInputBase-input makeStyles-input-1133"
             name="SELECT_FIELD_ATTR"
             onBlur={[Function]}
             onChange={[Function]}
@@ -1986,7 +1996,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
         </div>
         <img
           alt="Phone Menu"
-          className="makeStyles-root-1150 makeStyles-noShrink-1151"
+          className="makeStyles-root-1152 makeStyles-noShrink-1153"
           height="5"
           src="selectChevron.svg"
           width="8"
@@ -1994,16 +2004,16 @@ exports[`Storyshots Extension Account Status page 1`] = `
       </div>
     </form>
     <div
-      className="MuiBox-root MuiBox-root-1155"
+      className="MuiBox-root MuiBox-root-1157"
     />
     <div
-      className="MuiBox-root MuiBox-root-1156"
+      className="MuiBox-root MuiBox-root-1158"
     >
       <nav
         className="MuiList-root MuiList-padding"
       >
         <div
-          className="MuiBox-root MuiBox-root-1161"
+          className="MuiBox-root MuiBox-root-1163"
         >
           <li
             className="MuiListItem-root MuiListItem-default MuiListItem-gutters"
@@ -2013,7 +2023,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
               className="MuiListItemText-root"
             >
               <p
-                className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1093 makeStyles-weight-1180"
+                className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1095 makeStyles-weight-1182"
               >
                 Transations
               </p>
@@ -2021,27 +2031,27 @@ exports[`Storyshots Extension Account Status page 1`] = `
           </li>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-1181"
+          className="MuiBox-root MuiBox-root-1183"
         />
         <div
-          className="MuiBox-root MuiBox-root-1185"
+          className="MuiBox-root MuiBox-root-1187"
         />
         <li
-          className="MuiListItem-root MuiListItem-default MuiListItem-gutters makeStyles-center-1183"
+          className="MuiListItem-root MuiListItem-default MuiListItem-gutters makeStyles-center-1185"
           disabled={false}
         >
           <div
-            className="MuiListItemIcon-root makeStyles-empty-1182"
+            className="MuiListItemIcon-root makeStyles-empty-1184"
           >
             <img
               alt="No Transations"
-              className="makeStyles-root-1150"
+              className="makeStyles-root-1152"
               height="42"
               src="uptodate.svg"
             />
           </div>
           <div
-            className="MuiListItemText-root makeStyles-text-1184"
+            className="MuiListItemText-root makeStyles-text-1186"
           >
             <span
               className="MuiTypography-root MuiTypography-body1 MuiListItemText-primary"
@@ -2053,13 +2063,13 @@ exports[`Storyshots Extension Account Status page 1`] = `
       </nav>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1187"
+      className="MuiBox-root MuiBox-root-1189"
     >
       <nav
         className="MuiList-root MuiList-padding"
       >
         <div
-          className="MuiBox-root MuiBox-root-1188"
+          className="MuiBox-root MuiBox-root-1190"
         >
           <li
             className="MuiListItem-root MuiListItem-default MuiListItem-gutters"
@@ -2069,7 +2079,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
               className="MuiListItemText-root"
             >
               <p
-                className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1093 makeStyles-weight-1189"
+                className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1095 makeStyles-weight-1191"
               >
                 Pending Transactions
               </p>
@@ -2077,27 +2087,27 @@ exports[`Storyshots Extension Account Status page 1`] = `
           </li>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-1190"
+          className="MuiBox-root MuiBox-root-1192"
         />
         <div
-          className="MuiBox-root MuiBox-root-1191"
+          className="MuiBox-root MuiBox-root-1193"
         />
         <li
-          className="MuiListItem-root MuiListItem-default MuiListItem-gutters makeStyles-center-1183"
+          className="MuiListItem-root MuiListItem-default MuiListItem-gutters makeStyles-center-1185"
           disabled={false}
         >
           <div
-            className="MuiListItemIcon-root makeStyles-empty-1182"
+            className="MuiListItemIcon-root makeStyles-empty-1184"
           >
             <img
               alt="No Pending Transactions"
-              className="makeStyles-root-1150"
+              className="makeStyles-root-1152"
               height="42"
               src="uptodate.svg"
             />
           </div>
           <div
-            className="MuiListItemText-root makeStyles-text-1184"
+            className="MuiListItemText-root makeStyles-text-1186"
           >
             <span
               className="MuiTypography-root MuiTypography-body1 MuiListItemText-primary"
@@ -2110,14 +2120,14 @@ exports[`Storyshots Extension Account Status page 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1192"
+    className="MuiBox-root MuiBox-root-1194"
   />
   <div
-    className="MuiBox-root MuiBox-root-1193"
+    className="MuiBox-root MuiBox-root-1195"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1150"
+      className="makeStyles-root-1152"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2128,32 +2138,32 @@ exports[`Storyshots Extension Account Status page 1`] = `
 
 exports[`Storyshots Extension Login page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1202"
+  className="MuiBox-root MuiBox-root-1204"
   id="/login"
 >
   <div
-    className="MuiBox-root MuiBox-root-1203"
+    className="MuiBox-root MuiBox-root-1205"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1206 makeStyles-weight-1207 makeStyles-inline-1204"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1208 makeStyles-weight-1209 makeStyles-inline-1206"
     >
       Log
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1206 makeStyles-weight-1238 makeStyles-inline-1204"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1208 makeStyles-weight-1240 makeStyles-inline-1206"
     >
        
       In
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1239"
+    className="MuiBox-root MuiBox-root-1241"
   >
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-1240"
+        className="MuiBox-root MuiBox-root-1242"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -2204,10 +2214,10 @@ exports[`Storyshots Extension Login page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1278"
+        className="MuiBox-root MuiBox-root-1280"
       >
         <div
-          className="MuiBox-root MuiBox-root-1279"
+          className="MuiBox-root MuiBox-root-1281"
         >
           <button
             className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
@@ -2235,31 +2245,31 @@ exports[`Storyshots Extension Login page 1`] = `
       </div>
     </form>
     <div
-      className="MuiBox-root MuiBox-root-1300"
+      className="MuiBox-root MuiBox-root-1302"
     >
       <div
-        className="MuiBox-root MuiBox-root-1301"
+        className="MuiBox-root MuiBox-root-1303"
       >
         <a
           href="/restore-account"
           onClick={[Function]}
         >
           <h6
-            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-1206 makeStyles-weight-1302 makeStyles-inline-1204 makeStyles-link-1205"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-1208 makeStyles-weight-1304 makeStyles-inline-1206 makeStyles-link-1207"
           >
             Restore account
           </h6>
         </a>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1303"
+        className="MuiBox-root MuiBox-root-1305"
       >
         <a
           href="/welcome"
           onClick={[Function]}
         >
           <h6
-            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-1206 makeStyles-weight-1304 makeStyles-inline-1204 makeStyles-link-1205"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-1208 makeStyles-weight-1306 makeStyles-inline-1206 makeStyles-link-1207"
           >
             More options
           </h6>
@@ -2268,14 +2278,14 @@ exports[`Storyshots Extension Login page 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1305"
+    className="MuiBox-root MuiBox-root-1307"
   />
   <div
-    className="MuiBox-root MuiBox-root-1306"
+    className="MuiBox-root MuiBox-root-1308"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1307"
+      className="makeStyles-root-1309"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2286,42 +2296,42 @@ exports[`Storyshots Extension Login page 1`] = `
 
 exports[`Storyshots Extension Recovery Phrase page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1313"
+  className="MuiBox-root MuiBox-root-1315"
   id="/recovery-phrase"
 >
   <div
-    className="MuiBox-root MuiBox-root-1314"
+    className="MuiBox-root MuiBox-root-1316"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1317 makeStyles-weight-1318 makeStyles-inline-1315"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1319 makeStyles-weight-1320 makeStyles-inline-1317"
     >
       Recovery
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1317 makeStyles-weight-1349 makeStyles-inline-1315"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1319 makeStyles-weight-1351 makeStyles-inline-1317"
     >
        
       phrase
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1350"
+    className="MuiBox-root MuiBox-root-1352"
   >
     <div
-      className="MuiBox-root MuiBox-root-1351"
+      className="MuiBox-root MuiBox-root-1353"
     >
       <h6
-        className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-1317 makeStyles-weight-1352"
+        className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-1319 makeStyles-weight-1354"
       >
         Your Recovery Phrase are 12 random words that are set in a particular order that acts as a tool to recover or back up your wallet on any platform.
       </h6>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1353"
+      className="MuiBox-root MuiBox-root-1355"
     >
       <button
         aria-label="Export as CSV"
-        className="MuiButtonBase-root MuiFab-root makeStyles-root-1354 MuiFab-extended makeStyles-extended-1355 MuiFab-secondary makeStyles-secondary-1357 MuiFab-sizeSmall makeStyles-sizeSmall-1356"
+        className="MuiButtonBase-root MuiFab-root makeStyles-root-1356 MuiFab-extended makeStyles-extended-1357 MuiFab-secondary makeStyles-secondary-1359 MuiFab-sizeSmall makeStyles-sizeSmall-1358"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -2341,21 +2351,21 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
           className="MuiFab-label"
         >
           <div
-            className="MuiBox-root MuiBox-root-1371"
+            className="MuiBox-root MuiBox-root-1373"
           >
             <img
               alt="Download"
-              className="makeStyles-root-1372"
+              className="makeStyles-root-1374"
               height={16}
               src="download.svg"
               width={16}
             />
           </div>
           <div
-            className="MuiBox-root MuiBox-root-1377"
+            className="MuiBox-root MuiBox-root-1379"
           >
             <h6
-              className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextPrimary makeStyles-weight-1317 makeStyles-weight-1378"
+              className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextPrimary makeStyles-weight-1319 makeStyles-weight-1380"
             >
               Export as .PDF
             </h6>
@@ -2367,19 +2377,19 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
       </button>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1379"
+      className="MuiBox-root MuiBox-root-1381"
     >
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1317 makeStyles-weight-1380 makeStyles-inline-1315"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1319 makeStyles-weight-1382 makeStyles-inline-1317"
       >
         
       </p>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1381"
+      className="MuiBox-root MuiBox-root-1383"
     >
       <div
-        className="MuiBox-root MuiBox-root-1382"
+        className="MuiBox-root MuiBox-root-1384"
       >
         <button
           className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -2411,14 +2421,14 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1400"
+    className="MuiBox-root MuiBox-root-1402"
   />
   <div
-    className="MuiBox-root MuiBox-root-1401"
+    className="MuiBox-root MuiBox-root-1403"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1372"
+      className="makeStyles-root-1374"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2429,29 +2439,29 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
 
 exports[`Storyshots Extension Restore Account page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1413"
+  className="MuiBox-root MuiBox-root-1415"
   id="/restore-account"
 >
   <div
-    className="MuiBox-root MuiBox-root-1414"
+    className="MuiBox-root MuiBox-root-1416"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1417 makeStyles-weight-1418 makeStyles-inline-1415"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1419 makeStyles-weight-1420 makeStyles-inline-1417"
     >
       Restore
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1417 makeStyles-weight-1449 makeStyles-inline-1415"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1419 makeStyles-weight-1451 makeStyles-inline-1417"
     >
        
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1450"
+    className="MuiBox-root MuiBox-root-1452"
   >
     <h6
-      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-1417 makeStyles-weight-1451 makeStyles-inline-1415"
+      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-1419 makeStyles-weight-1453 makeStyles-inline-1417"
     >
       Restore your account with your recovery words. Enter your recovery words here.
     </h6>
@@ -2459,7 +2469,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-1452"
+        className="MuiBox-root MuiBox-root-1454"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -2510,10 +2520,10 @@ exports[`Storyshots Extension Restore Account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1490"
+        className="MuiBox-root MuiBox-root-1492"
       >
         <div
-          className="MuiBox-root MuiBox-root-1491"
+          className="MuiBox-root MuiBox-root-1493"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -2543,7 +2553,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
           </button>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-1512"
+          className="MuiBox-root MuiBox-root-1514"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -2575,14 +2585,14 @@ exports[`Storyshots Extension Restore Account page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1513"
+    className="MuiBox-root MuiBox-root-1515"
   />
   <div
-    className="MuiBox-root MuiBox-root-1514"
+    className="MuiBox-root MuiBox-root-1516"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1515"
+      className="makeStyles-root-1517"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2593,34 +2603,34 @@ exports[`Storyshots Extension Restore Account page 1`] = `
 
 exports[`Storyshots Extension Welcome page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1531"
+  className="MuiBox-root MuiBox-root-1533"
   id="/welcome"
 >
   <div
-    className="MuiBox-root MuiBox-root-1532"
+    className="MuiBox-root MuiBox-root-1534"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1535 makeStyles-weight-1536 makeStyles-inline-1533"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1537 makeStyles-weight-1538 makeStyles-inline-1535"
     >
       Welcome
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1535 makeStyles-weight-1567 makeStyles-inline-1533"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1537 makeStyles-weight-1569 makeStyles-inline-1535"
     >
        
       to your IOV manager
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1568"
+    className="MuiBox-root MuiBox-root-1570"
   >
     <p
-      className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1535 makeStyles-weight-1569 makeStyles-inline-1533"
+      className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1537 makeStyles-weight-1571 makeStyles-inline-1535"
     >
       This plugin lets you manage all your accounts in one place.
     </p>
     <div
-      className="MuiBox-root MuiBox-root-1570"
+      className="MuiBox-root MuiBox-root-1572"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -2649,7 +2659,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
       />
     </button>
     <div
-      className="MuiBox-root MuiBox-root-1591"
+      className="MuiBox-root MuiBox-root-1593"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -2678,7 +2688,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
       />
     </button>
     <div
-      className="MuiBox-root MuiBox-root-1592"
+      className="MuiBox-root MuiBox-root-1594"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -2707,14 +2717,14 @@ exports[`Storyshots Extension Welcome page 1`] = `
     </button>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1593"
+    className="MuiBox-root MuiBox-root-1595"
   />
   <div
-    className="MuiBox-root MuiBox-root-1594"
+    className="MuiBox-root MuiBox-root-1596"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1595"
+      className="makeStyles-root-1597"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2725,59 +2735,59 @@ exports[`Storyshots Extension Welcome page 1`] = `
 
 exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1694"
+  className="MuiBox-root MuiBox-root-1696"
 >
   <div
-    className="MuiBox-root MuiBox-root-1695"
+    className="MuiBox-root MuiBox-root-1697"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1698 makeStyles-weight-1699 makeStyles-inline-1696"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1700 makeStyles-weight-1701 makeStyles-inline-1698"
     >
       Share
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1698 makeStyles-weight-1730 makeStyles-inline-1696"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1700 makeStyles-weight-1732 makeStyles-inline-1698"
     >
        
       Identity
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1731"
+    className="MuiBox-root MuiBox-root-1733"
   >
     <div
-      className="MuiBox-root MuiBox-root-1732"
+      className="MuiBox-root MuiBox-root-1734"
     >
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1698 makeStyles-weight-1733"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1700 makeStyles-weight-1735"
       >
         The following site:
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1698 makeStyles-weight-1734"
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1700 makeStyles-weight-1736"
       >
         http://finex.com
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1698 makeStyles-weight-1735 makeStyles-inline-1696"
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1700 makeStyles-weight-1737 makeStyles-inline-1698"
       >
         will be able to see
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1698 makeStyles-weight-1736 makeStyles-inline-1696"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1700 makeStyles-weight-1738 makeStyles-inline-1698"
       >
          
         your identity on
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1698 makeStyles-weight-1737 makeStyles-inline-1696"
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1700 makeStyles-weight-1739 makeStyles-inline-1698"
       >
          
         ETH
       </p>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1738"
+      className="MuiBox-root MuiBox-root-1740"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -2806,7 +2816,7 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
       />
     </button>
     <div
-      className="MuiBox-root MuiBox-root-1759"
+      className="MuiBox-root MuiBox-root-1761"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -2836,14 +2846,14 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
     </button>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1760"
+    className="MuiBox-root MuiBox-root-1762"
   />
   <div
-    className="MuiBox-root MuiBox-root-1761"
+    className="MuiBox-root MuiBox-root-1763"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1762"
+      className="makeStyles-root-1764"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -2854,55 +2864,55 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
 
 exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1778"
+  className="MuiBox-root MuiBox-root-1780"
 >
   <div
-    className="MuiBox-root MuiBox-root-1779"
+    className="MuiBox-root MuiBox-root-1781"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1782 makeStyles-weight-1783 makeStyles-inline-1780"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1784 makeStyles-weight-1785 makeStyles-inline-1782"
     >
       Share
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1782 makeStyles-weight-1814 makeStyles-inline-1780"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1784 makeStyles-weight-1816 makeStyles-inline-1782"
     >
        
       Identity
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1815"
+    className="MuiBox-root MuiBox-root-1817"
   >
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-1816"
+        className="MuiBox-root MuiBox-root-1818"
       >
         <p
-          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1782 makeStyles-weight-1817"
+          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1784 makeStyles-weight-1819"
         >
           The following site:
         </p>
         <p
-          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1782 makeStyles-weight-1818"
+          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1784 makeStyles-weight-1820"
         >
           http://finex.com
         </p>
         <p
-          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorError makeStyles-weight-1782 makeStyles-weight-1819 makeStyles-inline-1780"
+          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorError makeStyles-weight-1784 makeStyles-weight-1821 makeStyles-inline-1782"
         >
           would not be able to request
         </p>
         <p
-          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1782 makeStyles-weight-1820 makeStyles-inline-1780"
+          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1784 makeStyles-weight-1822 makeStyles-inline-1782"
         >
            
           your identity.
         </p>
         <div
-          className="MuiBox-root MuiBox-root-1821"
+          className="MuiBox-root MuiBox-root-1823"
         />
         <label
           className="MuiFormControlLabel-root"
@@ -2963,7 +2973,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
         </label>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1859"
+        className="MuiBox-root MuiBox-root-1861"
       />
       <button
         className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
@@ -2988,7 +2998,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
         </span>
       </button>
       <div
-        className="MuiBox-root MuiBox-root-1877"
+        className="MuiBox-root MuiBox-root-1879"
       />
       <button
         className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -3019,14 +3029,14 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1878"
+    className="MuiBox-root MuiBox-root-1880"
   />
   <div
-    className="MuiBox-root MuiBox-root-1879"
+    className="MuiBox-root MuiBox-root-1881"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1880"
+      className="makeStyles-root-1882"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3037,53 +3047,53 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
 
 exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1611"
+  className="MuiBox-root MuiBox-root-1613"
 >
   <div
-    className="MuiBox-root MuiBox-root-1612"
+    className="MuiBox-root MuiBox-root-1614"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1615 makeStyles-weight-1616 makeStyles-inline-1613"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1617 makeStyles-weight-1618 makeStyles-inline-1615"
     >
       Share
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1615 makeStyles-weight-1647 makeStyles-inline-1613"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1617 makeStyles-weight-1649 makeStyles-inline-1615"
     >
        
       Identity
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1648"
+    className="MuiBox-root MuiBox-root-1650"
   >
     <div
-      className="MuiBox-root MuiBox-root-1649"
+      className="MuiBox-root MuiBox-root-1651"
     >
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1615 makeStyles-weight-1650"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1617 makeStyles-weight-1652"
       >
         The following site:
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1615 makeStyles-weight-1651"
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1617 makeStyles-weight-1653"
       >
         http://finex.com
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1615 makeStyles-weight-1652 makeStyles-inline-1613"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1617 makeStyles-weight-1654 makeStyles-inline-1615"
       >
         wants to see your identity on
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1615 makeStyles-weight-1653 makeStyles-inline-1613"
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1617 makeStyles-weight-1655 makeStyles-inline-1615"
       >
          
         ETH
       </p>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-1654"
+      className="MuiBox-root MuiBox-root-1656"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -3112,7 +3122,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       />
     </button>
     <div
-      className="MuiBox-root MuiBox-root-1675"
+      className="MuiBox-root MuiBox-root-1677"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-fullWidth"
@@ -3142,14 +3152,14 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
     </button>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1676"
+    className="MuiBox-root MuiBox-root-1678"
   />
   <div
-    className="MuiBox-root MuiBox-root-1677"
+    className="MuiBox-root MuiBox-root-1679"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1678"
+      className="makeStyles-root-1680"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3160,32 +3170,32 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
 
 exports[`Storyshots Extension/Signup New Account page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1896"
+  className="MuiBox-root MuiBox-root-1898"
   id="/signup1"
 >
   <div
-    className="MuiBox-root MuiBox-root-1897"
+    className="MuiBox-root MuiBox-root-1899"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1900 makeStyles-weight-1901 makeStyles-inline-1898"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1902 makeStyles-weight-1903 makeStyles-inline-1900"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1900 makeStyles-weight-1932 makeStyles-inline-1898"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1902 makeStyles-weight-1934 makeStyles-inline-1900"
     >
        
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1933"
+    className="MuiBox-root MuiBox-root-1935"
   >
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-1934"
+        className="MuiBox-root MuiBox-root-1936"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3247,7 +3257,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1991"
+        className="MuiBox-root MuiBox-root-1993"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3309,7 +3319,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1992"
+        className="MuiBox-root MuiBox-root-1994"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3371,10 +3381,10 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1993"
+        className="MuiBox-root MuiBox-root-1995"
       >
         <div
-          className="MuiBox-root MuiBox-root-1994"
+          className="MuiBox-root MuiBox-root-1996"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -3404,7 +3414,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
           </button>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-2015"
+          className="MuiBox-root MuiBox-root-2017"
         >
           <button
             className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
@@ -3433,14 +3443,14 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2016"
+    className="MuiBox-root MuiBox-root-2018"
   />
   <div
-    className="MuiBox-root MuiBox-root-2017"
+    className="MuiBox-root MuiBox-root-2019"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2018"
+      className="makeStyles-root-2020"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3451,49 +3461,49 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
 
 exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2034"
+  className="MuiBox-root MuiBox-root-2036"
   id="/signup2"
 >
   <div
-    className="MuiBox-root MuiBox-root-2035"
+    className="MuiBox-root MuiBox-root-2037"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2038 makeStyles-weight-2039 makeStyles-inline-2036"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2040 makeStyles-weight-2041 makeStyles-inline-2038"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2038 makeStyles-weight-2070 makeStyles-inline-2036"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2040 makeStyles-weight-2072 makeStyles-inline-2038"
     >
        
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2071"
+    className="MuiBox-root MuiBox-root-2073"
   >
     <div
-      className="MuiBox-root MuiBox-root-2072"
+      className="MuiBox-root MuiBox-root-2074"
     >
       <div
-        className="MuiBox-root MuiBox-root-2073"
+        className="MuiBox-root MuiBox-root-2075"
       >
         <div
-          className="MuiBox-root MuiBox-root-2074"
+          className="MuiBox-root MuiBox-root-2076"
         >
           <h6
-            className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-2038 makeStyles-weight-2075 makeStyles-inline-2036"
+            className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-2040 makeStyles-weight-2077 makeStyles-inline-2038"
           >
             Activate Recovery Phrase?
           </h6>
         </div>
         <div
-          className="makeStyles-container-2077"
+          className="makeStyles-container-2079"
           onClick={[Function]}
         >
           <img
             alt="Info"
-            className="makeStyles-root-2080"
+            className="makeStyles-root-2082"
             height={16}
             src="info_normal.svg"
             width={16}
@@ -3547,19 +3557,19 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
       </label>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-2116"
+      className="MuiBox-root MuiBox-root-2118"
     >
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2038 makeStyles-weight-2117 makeStyles-inline-2036"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2040 makeStyles-weight-2119 makeStyles-inline-2038"
       >
         
       </p>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-2118"
+      className="MuiBox-root MuiBox-root-2120"
     >
       <div
-        className="MuiBox-root MuiBox-root-2119"
+        className="MuiBox-root MuiBox-root-2121"
       >
         <button
           className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -3589,7 +3599,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
         </button>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2137"
+        className="MuiBox-root MuiBox-root-2139"
       >
         <button
           className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -3621,14 +3631,14 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2138"
+    className="MuiBox-root MuiBox-root-2140"
   />
   <div
-    className="MuiBox-root MuiBox-root-2139"
+    className="MuiBox-root MuiBox-root-2141"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2080"
+      className="makeStyles-root-2082"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3639,29 +3649,29 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
 
 exports[`Storyshots Extension/Signup Security Hint page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2151"
+  className="MuiBox-root MuiBox-root-2153"
   id="/signup3"
 >
   <div
-    className="MuiBox-root MuiBox-root-2152"
+    className="MuiBox-root MuiBox-root-2154"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2155 makeStyles-weight-2156 makeStyles-inline-2153"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2157 makeStyles-weight-2158 makeStyles-inline-2155"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2155 makeStyles-weight-2187 makeStyles-inline-2153"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2157 makeStyles-weight-2189 makeStyles-inline-2155"
     >
        
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2188"
+    className="MuiBox-root MuiBox-root-2190"
   >
     <h6
-      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-2155 makeStyles-weight-2189 makeStyles-inline-2153"
+      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-2157 makeStyles-weight-2191 makeStyles-inline-2155"
     >
       To help you remember your details in the future please provide a security hint:
     </h6>
@@ -3669,7 +3679,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-2190"
+        className="MuiBox-root MuiBox-root-2192"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3720,10 +3730,10 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2228"
+        className="MuiBox-root MuiBox-root-2230"
       >
         <div
-          className="MuiBox-root MuiBox-root-2229"
+          className="MuiBox-root MuiBox-root-2231"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
@@ -3753,7 +3763,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
           </button>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-2250"
+          className="MuiBox-root MuiBox-root-2252"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -3785,14 +3795,14 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2251"
+    className="MuiBox-root MuiBox-root-2253"
   />
   <div
-    className="MuiBox-root MuiBox-root-2252"
+    className="MuiBox-root MuiBox-root-2254"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2253"
+      className="makeStyles-root-2255"
       height={39}
       src="iov-logo.png"
       width={84}

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2888,7 +2888,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
       <p
         className="MuiTypography-root-1141 MuiTypography-body1-1143 makeStyles-weight-1139 makeStyles-weight-1176 makeStyles-inline-1137"
       >
-        wants to see you identity on
+        wants to see your identity on
       </p>
 
       <p
@@ -2904,6 +2904,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
       className="MuiButtonBase-root-1196 MuiButton-root-1179 MuiButton-contained-1187 MuiButton-containedPrimary-1188 MuiButton-fullWidth-1195"
       disabled={false}
       onBlur={[Function]}
+      onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
@@ -2967,26 +2968,26 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
 
 exports[`Storyshots Routes/Signup New account page 1`] = `
 <div
-  className="MuiBox-root-1217 MuiBox-root-1218"
+  className="MuiBox-root-1301 MuiBox-root-1302"
   id="/signup1"
 >
   <div
-    className="MuiBox-root-1217 MuiBox-root-1219"
+    className="MuiBox-root-1301 MuiBox-root-1303"
   >
     <h4
-      className="MuiTypography-root-1224 MuiTypography-h4-1232 MuiTypography-colorPrimary-1247 makeStyles-weight-1222 makeStyles-weight-1223 makeStyles-inline-1220"
+      className="MuiTypography-root-1308 MuiTypography-h4-1316 MuiTypography-colorPrimary-1331 makeStyles-weight-1306 makeStyles-weight-1307 makeStyles-inline-1304"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root-1224 MuiTypography-h4-1232 makeStyles-weight-1222 makeStyles-weight-1254 makeStyles-inline-1220"
+      className="MuiTypography-root-1308 MuiTypography-h4-1316 makeStyles-weight-1306 makeStyles-weight-1338 makeStyles-inline-1304"
     >
 
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root-1217 MuiBox-root-1255"
+    className="MuiBox-root-1301 MuiBox-root-1339"
   >
     <form
       onSubmit={[Function]}

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2772,7 +2772,6 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1698 makeStyles-weight-1737 makeStyles-inline-1696"
       >
-
         ETH
       </p>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2227,6 +2227,14 @@
     react-transition-group "^2.5.3"
     warning "^4.0.1"
 
+"@material-ui/icons@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/@material-ui/icons/-/icons-3.0.2.tgz#d67a6dd1ec8312d3a88ec97944a63daeef24fe10"
+  integrity sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    recompose "0.28.0 - 0.30.0"
+
 "@material-ui/styles@^4.0.0-alpha.6":
   version "4.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.0.0-beta.1.tgz#a552fe402763f0579cbd39e79a9e42fbf6762139"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14463,7 +14463,7 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-recompose@^0.30.0:
+"recompose@0.28.0 - 0.30.0", recompose@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.30.0.tgz#82773641b3927e8c7d24a0d87d65aeeba18aabd0"
   integrity sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==


### PR DESCRIPTION
**Description**
This PR will add Share Identity Reject view and simple logic to the extension. It will implement "Create storybook and view of the Reject screen" part of the #16.

**Before**
N/A

**After**
![share-identity-reject](https://user-images.githubusercontent.com/3502260/57231712-bdae6500-7023-11e9-82de-9f7efca33401.png)
