### PR TITLE
Feature – Update lisk start/stop scripts

### DIFF
--- a/packages/sanes-chrome-extension/test/scripts/lisk/start.sh
+++ b/packages/sanes-chrome-extension/test/scripts/lisk/start.sh
@@ -4,18 +4,28 @@ command -v shellcheck > /dev/null && shellcheck "$0"
 
 # A temporary dir created to make the docker-compose files from
 # https://github.com/LiskHQ/lisk/tree/v1.4.0/docker available.
-# Only used as long as this script runs
-TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/lisk_start.XXXXXXXXX")
+TMP_DIR="${TMPDIR:-/tmp}/@iov"
+mkdir -p "$TMP_DIR"
 
+LISK_DIR="lisk"
 # can be a branch or tag
-LISK_BRANCH="v1.4.0"
+LISK_TAG="v1.6.0"
 # Use a version available on docker hub: https://hub.docker.com/r/lisk/core/tags/
-LISK_DOCKER_VERSION="1.4.0"
+LISK_DOCKER_VERSION="1.6.0"
 
 (
   cd "$TMP_DIR"
   echo "Navigated to temp directory $(pwd)"
-  git clone --depth 1 --branch "$LISK_BRANCH" https://github.com/LiskHQ/lisk.git
+  if [ -d "$LISK_DIR" ]; then
+    if ! git -C "$LISK_DIR" describe --tags --exact-match --match="$LISK_TAG"; then
+      echo "WARNING: Found incompatible Lisk repo. Deleting..."
+      rm -rf "$LISK_DIR"
+      git clone --depth 1 --branch "$LISK_TAG" https://github.com/LiskHQ/lisk.git
+    fi
+  else
+    git clone --depth 1 --branch "$LISK_TAG" https://github.com/LiskHQ/lisk.git
+  fi
+
 
   (
     cd "lisk/docker"

--- a/packages/sanes-chrome-extension/test/scripts/lisk/stop.sh
+++ b/packages/sanes-chrome-extension/test/scripts/lisk/stop.sh
@@ -4,16 +4,25 @@ command -v shellcheck > /dev/null && shellcheck "$0"
 
 # A temporary dir created to make the docker-compose files from
 # https://github.com/LiskHQ/lisk/tree/1.2.0/docker available.
-# Only used as long as this script runs
-TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/lisk_stop.XXXXXXXXX")
+TMP_DIR="${TMPDIR:-/tmp}/@iov"
+mkdir "$TMP_DIR" || true
 
+LISK_DIR="lisk"
 # can be a branch or tag
-LISK_BRANCH="v1.4.0"
+LISK_TAG="v1.6.0"
 
 (
   cd "$TMP_DIR"
   echo "Navigated to temp directory $(pwd)"
-  git clone --depth 1 --branch "$LISK_BRANCH" https://github.com/LiskHQ/lisk.git
+  if [ -d "$LISK_DIR" ]; then
+    if ! git -C "$LISK_DIR" describe --tags --exact-match --match="$LISK_TAG"; then
+      echo "WARNING: Found incompatible Lisk repo. Deleting..."
+      rm -rf "$LISK_DIR"
+      git clone --depth 1 --branch "$LISK_TAG" https://github.com/LiskHQ/lisk.git
+    fi
+  else
+    git clone --depth 1 --branch "$LISK_TAG" https://github.com/LiskHQ/lisk.git
+  fi
 
   (
     cd "lisk/docker"


### PR DESCRIPTION
- Update Lisk to v1.6.0
- Do not create a fresh repo clone for every start/stop

Scripts copied 1:1 from IOV-Core