### PR TITLE
Change payment form validation approach

### DIFF
--- a/packages/bierzo-wallet/src/routes/payment/components/CurrencyToSend/index.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/components/CurrencyToSend/index.tsx
@@ -103,7 +103,6 @@ const CurrencyToSend = (props: Props): JSX.Element => {
                 margin="none"
               />
             </Block>
-            {/*NOTE hardcoded initial value*/}
             <Block height="32px">
               <SelectFieldForm
                 fieldName={CURRENCY_FIELD}

--- a/packages/bierzo-wallet/src/routes/payment/components/ReceiverAddress/index.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/components/ReceiverAddress/index.tsx
@@ -1,45 +1,25 @@
 import Paper from '@material-ui/core/Paper';
+import { FormApi } from 'final-form';
 import Block from 'medulas-react-components/lib/components/Block';
-import Form, {
-  FormValues,
-  useForm,
-  ValidationError,
-} from 'medulas-react-components/lib/components/forms/Form';
 import TextFieldForm from 'medulas-react-components/lib/components/forms/TextFieldForm';
 import Tooltip from 'medulas-react-components/lib/components/Tooltip';
 import Typography from 'medulas-react-components/lib/components/Typography';
+import {
+  composeValidators,
+  notLongerThan,
+  required,
+  validAddress,
+} from 'medulas-react-components/lib/utils/forms/validators';
 import React from 'react';
 
 const ADDRESS_FIELD = 'addressField';
+const ADDRESS_MAX_LENGTH = 254;
 
-const onSubmit = (): void => {};
+interface Props {
+  form: FormApi;
+}
 
-const validate = (values: object): object => {
-  const formValues = values as FormValues;
-  const errors: ValidationError = {};
-
-  if (!formValues[ADDRESS_FIELD]) {
-    errors[ADDRESS_FIELD] = 'Required';
-  }
-
-  if (formValues[ADDRESS_FIELD] && formValues[ADDRESS_FIELD].length > 254) {
-    errors[ADDRESS_FIELD] = 'Can not be longer than 254 characters';
-  }
-
-  //TODO implement valid pattern
-  if (formValues[ADDRESS_FIELD] && !formValues[ADDRESS_FIELD].endsWith('*iov')) {
-    errors[ADDRESS_FIELD] = 'Invalid address';
-  }
-
-  return errors;
-};
-
-const ReceiverAddress = (): JSX.Element => {
-  const { form, handleSubmit } = useForm({
-    onSubmit,
-    validate,
-  });
-
+const ReceiverAddress = (props: Props): JSX.Element => {
   return (
     <Paper>
       <Block display="flex" flexDirection="column" width="100%" padding={5}>
@@ -47,23 +27,20 @@ const ReceiverAddress = (): JSX.Element => {
           To
         </Typography>
         <Block width="100%" marginTop={2} marginBottom={1}>
-          <Form onSubmit={handleSubmit}>
-            <TextFieldForm
-              name={ADDRESS_FIELD}
-              form={form}
-              required
-              placeholder="IOV or wallet address"
-              fullWidth
-              margin="none"
-            />
-          </Form>
+          <TextFieldForm
+            name={ADDRESS_FIELD}
+            form={props.form}
+            validate={composeValidators(required, validAddress, notLongerThan(ADDRESS_MAX_LENGTH))}
+            placeholder="IOV or wallet address"
+            fullWidth
+            margin="none"
+          />
         </Block>
         <Block display="flex" alignSelf="flex-end" marginTop={3}>
           <Typography color="textPrimary" variant="subtitle1">
             How it works
           </Typography>
           <Block alignSelf="center" marginLeft={1}>
-            {/*TODO add info popup*/}
             <Tooltip>
               <Typography variant="body2">
                 Send payments to anyone with an IOV handle, and it will go directly to their account. If they

--- a/packages/bierzo-wallet/src/routes/payment/components/TextNote/index.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/components/TextNote/index.tsx
@@ -1,36 +1,19 @@
 import { faStickyNote } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Paper from '@material-ui/core/Paper';
+import { FormApi } from 'final-form';
 import Block from 'medulas-react-components/lib/components/Block';
-import Form, {
-  FormValues,
-  useForm,
-  ValidationError,
-} from 'medulas-react-components/lib/components/forms/Form';
 import TextFieldForm from 'medulas-react-components/lib/components/forms/TextFieldForm';
+import { notLongerThan } from 'medulas-react-components/lib/utils/forms/validators';
 import React from 'react';
 
 const TEXTNOTE_FIELD = 'textNoteField';
 
-const onSubmit = (): void => {};
+interface Props {
+  form: FormApi;
+}
 
-const validate = (values: object): object => {
-  const formValues = values as FormValues;
-  const errors: ValidationError = {};
-
-  if (formValues[TEXTNOTE_FIELD] && formValues[TEXTNOTE_FIELD].length > 150) {
-    errors[TEXTNOTE_FIELD] = 'Can not be longer than 150 characters';
-  }
-
-  return errors;
-};
-
-const TextNote = (): JSX.Element => {
-  const { form, handleSubmit } = useForm({
-    onSubmit,
-    validate,
-  });
-
+const TextNote = (props: Props): JSX.Element => {
   return (
     <Paper>
       <Block padding={5}>
@@ -39,17 +22,16 @@ const TextNote = (): JSX.Element => {
             <FontAwesomeIcon icon={faStickyNote} color="#a2a6a8" size="lg" />
           </Block>
           <Block width="100%" marginLeft={2}>
-            <Form onSubmit={handleSubmit}>
-              <TextFieldForm
-                name={TEXTNOTE_FIELD}
-                form={form}
-                placeholder="Add a note"
-                multiline
-                rows="2"
-                fullWidth
-                margin="none"
-              />
-            </Form>
+            <TextFieldForm
+              name={TEXTNOTE_FIELD}
+              form={props.form}
+              validate={notLongerThan(150)}
+              placeholder="Add a note"
+              multiline
+              rows="2"
+              fullWidth
+              margin="none"
+            />
           </Block>
         </Block>
       </Block>

--- a/packages/bierzo-wallet/src/routes/payment/index.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/index.tsx
@@ -44,38 +44,37 @@ const onSubmit = (): void => {};
 const Payment = (): JSX.Element => {
   const classes = useStyles();
 
-  const { handleSubmit, invalid, pristine, submitting } = useForm({
+  const { form, handleSubmit, invalid, pristine, submitting } = useForm({
     onSubmit,
   });
 
-  //TODO make the button be disabled according to the state of the components
   return (
-    <Block
-      width="100vw"
-      height="auto"
-      minHeight="100vh"
-      display="grid"
-      alignContent="center"
-      justifyContent="center"
-      className={classes.payment}
-    >
-      <Block width="100%" className={classes.currencyToSend}>
-        <CurrencyToSend />
-      </Block>
-      <Block width="100%" className={classes.receiverAddress}>
-        <ReceiverAddress />
-      </Block>
-      <Block width="100%" className={classes.textNote}>
-        <TextNote />
-      </Block>
-      <Block width="75%" className={classes.continue}>
-        <Form onSubmit={handleSubmit}>
+    <Form onSubmit={handleSubmit}>
+      <Block
+        width="100vw"
+        height="auto"
+        minHeight="100vh"
+        display="grid"
+        alignContent="center"
+        justifyContent="center"
+        className={classes.payment}
+      >
+        <Block width="100%" className={classes.currencyToSend}>
+          <CurrencyToSend form={form} />
+        </Block>
+        <Block width="100%" className={classes.receiverAddress}>
+          <ReceiverAddress form={form} />
+        </Block>
+        <Block width="100%" className={classes.textNote}>
+          <TextNote form={form} />
+        </Block>
+        <Block width="75%" className={classes.continue}>
           <Button fullWidth type="submit" disabled={invalid || pristine || submitting}>
             Continue
           </Button>
-        </Form>
+        </Block>
       </Block>
-    </Block>
+    </Form>
   );
 };
 

--- a/packages/medulas-react-components/package.json
+++ b/packages/medulas-react-components/package.json
@@ -23,7 +23,7 @@
     "@types/node": "11.9.4",
     "add": "^2.0.6",
     "final-form": "^4.12.0",
-    "react-final-form-hooks": "^1.0.1",
+    "react-final-form-hooks": "^2.0.0",
     "@material-ui/icons": "^3.0.2"
   }
 }

--- a/packages/medulas-react-components/src/components/forms/TextFieldForm/index.tsx
+++ b/packages/medulas-react-components/src/components/forms/TextFieldForm/index.tsx
@@ -1,19 +1,19 @@
-import * as React from 'react';
 import MuiTextField, { TextFieldProps } from '@material-ui/core/TextField';
-
-import { FormApi, FieldSubscription } from 'final-form';
+import { FieldSubscription, FieldValidator, FormApi } from 'final-form';
+import * as React from 'react';
 import { useField } from 'react-final-form-hooks';
 
 interface InnerProps {
   name: string;
   form: FormApi;
+  validate?: FieldValidator;
   subscription?: FieldSubscription;
 }
 
 type Props = InnerProps & TextFieldProps;
 
-const TextFieldForm = ({ name, form, ...restProps }: Props): JSX.Element => {
-  const { input, meta } = useField(name, form);
+const TextFieldForm = ({ name, form, validate, ...restProps }: Props): JSX.Element => {
+  const { input, meta } = useField(name, form, validate);
   const error = meta.error && (meta.touched || !meta.pristine);
 
   return (

--- a/packages/medulas-react-components/src/utils/forms/validators/index.tsx
+++ b/packages/medulas-react-components/src/utils/forms/validators/index.tsx
@@ -4,8 +4,8 @@ type ValidationError = string | undefined;
 
 export const composeValidators = (...validators: FieldValidator[]): FieldValidator => {
   return (value): ValidationError => {
-    for (let i = 0; i < validators.length; i++) {
-      const validationError = validators[i](value, {});
+    for (let validator of validators) {
+      const validationError = validator(value, {});
 
       if (validationError) {
         return validationError;

--- a/packages/medulas-react-components/src/utils/forms/validators/index.tsx
+++ b/packages/medulas-react-components/src/utils/forms/validators/index.tsx
@@ -1,0 +1,59 @@
+import { FieldValidator } from 'final-form';
+
+type ValidationError = string | undefined;
+
+export const composeValidators = (...validators: FieldValidator[]): FieldValidator => {
+  return (value): ValidationError => {
+    for (let i = 0; i < validators.length; i++) {
+      const validationError = validators[i](value, {});
+
+      if (validationError) {
+        return validationError;
+      }
+    }
+
+    return undefined;
+  };
+};
+
+export const required: FieldValidator = (value): ValidationError => {
+  return value ? undefined : 'Required';
+};
+
+export const number: FieldValidator = (value): ValidationError => {
+  return !isNaN(value) ? undefined : 'Must be a number';
+};
+
+export const validAddress: FieldValidator = (value): ValidationError => {
+  return value.endsWith('*iov') ? undefined : 'Invalid address';
+};
+
+export const lowerOrEqualThan = (max: number): FieldValidator => {
+  return (value): ValidationError => {
+    if (value && value > max) {
+      return `Should be lower or equal than ${max}`;
+    }
+
+    return undefined;
+  };
+};
+
+export const greaterOrEqualThan = (min: number): FieldValidator => {
+  return (value): ValidationError => {
+    if (value && value < min) {
+      return `Should be lower or equal than ${min}`;
+    }
+
+    return undefined;
+  };
+};
+
+export const notLongerThan = (maxLength: number): FieldValidator => {
+  return (value): ValidationError => {
+    if (value && value.length > maxLength) {
+      return `Can not be longer than ${maxLength} characters`;
+    }
+
+    return undefined;
+  };
+};

--- a/packages/medulas-react-components/src/utils/forms/validators/index.tsx
+++ b/packages/medulas-react-components/src/utils/forms/validators/index.tsx
@@ -41,7 +41,7 @@ export const lowerOrEqualThan = (max: number): FieldValidator => {
 export const greaterOrEqualThan = (min: number): FieldValidator => {
   return (value): ValidationError => {
     if (value && value < min) {
-      return `Should be lower or equal than ${min}`;
+      return `Should be greater or equal than ${min}`;
     }
 
     return undefined;

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -1,23 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Bierzo wallet Payment page 1`] = `
-<div
-  className="MuiBox-root MuiBox-root-7 makeStyles-payment-1"
+<form
+  onSubmit={[Function]}
 >
   <div
-    className="MuiBox-root MuiBox-root-8 makeStyles-currencyToSend-2"
+    className="MuiBox-root MuiBox-root-7 makeStyles-payment-1"
   >
     <div
-      className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+      className="MuiBox-root MuiBox-root-8 makeStyles-currencyToSend-2"
     >
       <div
-        className="MuiBox-root MuiBox-root-37"
+        className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       >
         <div
-          className="MuiAvatar-root makeStyles-avatar-9 MuiAvatar-colorDefault"
+          className="MuiBox-root MuiBox-root-37"
         >
           <div
-            className="MuiAvatar-root-38 makeStyles-avatar-9 MuiAvatar-colorDefault-39"
+            className="MuiAvatar-root makeStyles-avatar-9 MuiAvatar-colorDefault"
           >
             <svg
               aria-hidden="true"
@@ -28,19 +28,23 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
               focusable="false"
               role="img"
               style={Object {}}
-            />
-          </svg>
-        </div>
-        <h6
-          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextPrimary makeStyles-weight-43 makeStyles-weight-44"
-        >
-          You send
-        </h6>
-        <div
-          className="MuiBox-root MuiBox-root-75"
-        >
-          <form
-            onSubmit={[Function]}
+              viewBox="0 0 448 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M313.6 304c-28.7 0-42.5 16-89.6 16-47.1 0-60.8-16-89.6-16C60.2 304 0 364.2 0 438.4V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48v-25.6c0-74.2-60.2-134.4-134.4-134.4zM400 464H48v-25.6c0-47.6 38.8-86.4 86.4-86.4 14.6 0 38.3 16 89.6 16 51.7 0 74.9-16 89.6-16 47.6 0 86.4 38.8 86.4 86.4V464zM224 288c79.5 0 144-64.5 144-144S303.5 0 224 0 80 64.5 80 144s64.5 144 144 144zm0-240c52.9 0 96 43.1 96 96s-43.1 96-96 96-96-43.1-96-96 43.1-96 96-96z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </div>
+          <h6
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextPrimary makeStyles-weight-43 makeStyles-weight-44"
+          >
+            You send
+          </h6>
+          <div
+            className="MuiBox-root MuiBox-root-75"
           >
             <div
               className="MuiBox-root MuiBox-root-76"
@@ -130,51 +134,38 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
                 </div>
               </div>
             </div>
-          </form>
-        </div>
-        <div
-          className="MuiBox-root MuiBox-root-125"
-        >
-          <h6
-            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextSecondary makeStyles-weight-43 makeStyles-weight-126"
+          </div>
+          <div
+            className="MuiBox-root MuiBox-root-125"
           >
             <h6
-              className="MuiTypography-root-45 MuiTypography-subtitle2-57 MuiTypography-colorTextSecondary-71 makeStyles-weight-43 makeStyles-weight-126"
+              className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextSecondary makeStyles-weight-43 makeStyles-weight-126"
             >
-              balance:
+              balance: 
               24
-
+               
               IOV
             </h6>
           </div>
         </div>
       </div>
     </div>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-127 makeStyles-receiverAddress-3"
-  >
     <div
-      className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+      className="MuiBox-root MuiBox-root-127 makeStyles-receiverAddress-3"
     >
       <div
-        className="MuiBox-root MuiBox-root-128"
+        className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       >
-        <h6
-          className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextPrimary makeStyles-weight-43 makeStyles-weight-129"
-        >
-          To
-        </h6>
         <div
-          className="MuiBox-root MuiBox-root-130"
+          className="MuiBox-root MuiBox-root-128"
         >
           <h6
-            className="MuiTypography-root-45 MuiTypography-subtitle2-57 MuiTypography-colorTextPrimary-70 makeStyles-weight-43 makeStyles-weight-129"
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextPrimary makeStyles-weight-43 makeStyles-weight-129"
           >
             To
           </h6>
           <div
-            className="MuiBox-root-6 MuiBox-root-130"
+            className="MuiBox-root MuiBox-root-130"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root"
@@ -223,26 +214,17 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
                 />
               </div>
             </div>
-          </form>
-        </div>
-        <div
-          className="MuiBox-root MuiBox-root-131"
-        >
-          <h6
-            className="MuiTypography-root MuiTypography-subtitle1 MuiTypography-colorTextPrimary makeStyles-weight-43 makeStyles-weight-132"
-          >
-            How it works
-          </h6>
+          </div>
           <div
-            className="MuiBox-root MuiBox-root-133"
+            className="MuiBox-root MuiBox-root-131"
           >
             <h6
-              className="MuiTypography-root-45 MuiTypography-subtitle1-56 MuiTypography-colorTextPrimary-70 makeStyles-weight-43 makeStyles-weight-132"
+              className="MuiTypography-root MuiTypography-subtitle1 MuiTypography-colorTextPrimary makeStyles-weight-43 makeStyles-weight-132"
             >
               How it works
             </h6>
             <div
-              className="MuiBox-root-6 MuiBox-root-133"
+              className="MuiBox-root MuiBox-root-133"
             >
               <div
                 className="makeStyles-container-135"
@@ -261,24 +243,20 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
         </div>
       </div>
     </div>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-138 makeStyles-textNote-4"
-  >
     <div
-      className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+      className="MuiBox-root MuiBox-root-138 makeStyles-textNote-4"
     >
       <div
-        className="MuiBox-root MuiBox-root-139"
+        className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       >
         <div
-          className="MuiBox-root MuiBox-root-140"
+          className="MuiBox-root MuiBox-root-139"
         >
           <div
-            className="MuiBox-root MuiBox-root-141"
+            className="MuiBox-root MuiBox-root-140"
           >
             <div
-              className="MuiBox-root-6 MuiBox-root-141"
+              className="MuiBox-root MuiBox-root-141"
             >
               <svg
                 aria-hidden="true"
@@ -289,14 +267,18 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
                 focusable="false"
                 role="img"
                 style={Object {}}
-              />
-            </svg>
-          </div>
-          <div
-            className="MuiBox-root MuiBox-root-142"
-          >
-            <form
-              onSubmit={[Function]}
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M448 348.106V80c0-26.51-21.49-48-48-48H48C21.49 32 0 53.49 0 80v351.988c0 26.51 21.49 48 48 48h268.118a48 48 0 0 0 33.941-14.059l83.882-83.882A48 48 0 0 0 448 348.106zm-128 80v-76.118h76.118L320 428.106zM400 80v223.988H296c-13.255 0-24 10.745-24 24v104H48V80h352z"
+                  fill="currentColor"
+                  style={Object {}}
+                />
+              </svg>
+            </div>
+            <div
+              className="MuiBox-root MuiBox-root-142"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root"
@@ -350,12 +332,8 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
         </div>
       </div>
     </div>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-143 makeStyles-continue-5"
-  >
-    <form
-      onSubmit={[Function]}
+    <div
+      className="MuiBox-root MuiBox-root-143 makeStyles-continue-5"
     >
       <button
         className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
@@ -868,7 +846,7 @@ exports[`Storyshots Components Layout 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-395 makeStyles-weight-427 makeStyles-inline-393"
     >
-
+       
       storybook
     </h4>
   </div>
@@ -1455,7 +1433,7 @@ Array [
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-559 makeStyles-weight-605 makeStyles-inline-557"
   >
-    First part of the text.
+    First part of the text. 
   </h6>,
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-559 makeStyles-weight-606 makeStyles-inline-557"
@@ -1987,7 +1965,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1096 makeStyles-weight-1128 makeStyles-inline-1094"
     >
-
+       
       Status
     </h4>
   </div>
@@ -2185,7 +2163,7 @@ exports[`Storyshots Extension Login page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1209 makeStyles-weight-1241 makeStyles-inline-1207"
     >
-
+       
       In
     </h4>
   </div>
@@ -2343,7 +2321,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1320 makeStyles-weight-1352 makeStyles-inline-1318"
     >
-
+       
       phrase
     </h4>
   </div>
@@ -2415,7 +2393,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1320 makeStyles-weight-1383 makeStyles-inline-1318"
       >
-
+        
       </p>
     </div>
     <div
@@ -2486,7 +2464,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1420 makeStyles-weight-1452 makeStyles-inline-1418"
     >
-
+       
       Account
     </h4>
   </div>
@@ -2650,7 +2628,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1538 makeStyles-weight-1570 makeStyles-inline-1536"
     >
-
+       
       to your IOV manager
     </h4>
   </div>
@@ -2781,7 +2759,7 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1701 makeStyles-weight-1733 makeStyles-inline-1699"
     >
-
+       
       Identity
     </h4>
   </div>
@@ -2809,13 +2787,13 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1701 makeStyles-weight-1739 makeStyles-inline-1699"
       >
-
+         
         your identity on
       </p>
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1701 makeStyles-weight-1740 makeStyles-inline-1699"
       >
-
+         
         ETH
       </p>
     </div>
@@ -2910,7 +2888,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1785 makeStyles-weight-1817 makeStyles-inline-1783"
     >
-
+       
       Identity
     </h4>
   </div>
@@ -2941,7 +2919,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
         <p
           className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1785 makeStyles-weight-1823 makeStyles-inline-1783"
         >
-
+           
           your identity.
         </p>
         <div
@@ -3093,7 +3071,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1618 makeStyles-weight-1650 makeStyles-inline-1616"
     >
-
+       
       Identity
     </h4>
   </div>
@@ -3121,7 +3099,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1618 makeStyles-weight-1656 makeStyles-inline-1616"
       >
-
+         
         ETH
       </p>
     </div>
@@ -3217,7 +3195,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1903 makeStyles-weight-1935 makeStyles-inline-1901"
     >
-
+       
       Account
     </h4>
   </div>
@@ -3508,7 +3486,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2041 makeStyles-weight-2073 makeStyles-inline-2039"
     >
-
+       
       Account
     </h4>
   </div>
@@ -3595,7 +3573,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2041 makeStyles-weight-2120 makeStyles-inline-2039"
       >
-
+        
       </p>
     </div>
     <div
@@ -3696,7 +3674,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2158 makeStyles-weight-2190 makeStyles-inline-2156"
     >
-
+       
       Account
     </h4>
   </div>

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -16,21 +16,17 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
         <div
           className="MuiAvatar-root makeStyles-avatar-9 MuiAvatar-colorDefault"
         >
-          <svg
-            aria-hidden="true"
-            className="svg-inline--fa fa-user fa-w-14 "
-            color="#ffffff"
-            data-icon="user"
-            data-prefix="far"
-            focusable="false"
-            role="img"
-            style={Object {}}
-            viewBox="0 0 448 512"
-            xmlns="http://www.w3.org/2000/svg"
+          <div
+            className="MuiAvatar-root-38 makeStyles-avatar-9 MuiAvatar-colorDefault-39"
           >
-            <path
-              d="M313.6 304c-28.7 0-42.5 16-89.6 16-47.1 0-60.8-16-89.6-16C60.2 304 0 364.2 0 438.4V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48v-25.6c0-74.2-60.2-134.4-134.4-134.4zM400 464H48v-25.6c0-47.6 38.8-86.4 86.4-86.4 14.6 0 38.3 16 89.6 16 51.7 0 74.9-16 89.6-16 47.6 0 86.4 38.8 86.4 86.4V464zM224 288c79.5 0 144-64.5 144-144S303.5 0 224 0 80 64.5 80 144s64.5 144 144 144zm0-240c52.9 0 96 43.1 96 96s-43.1 96-96 96-96-43.1-96-96 43.1-96 96-96z"
-              fill="currentColor"
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-user fa-w-14 "
+              color="#ffffff"
+              data-icon="user"
+              data-prefix="far"
+              focusable="false"
+              role="img"
               style={Object {}}
             />
           </svg>
@@ -94,7 +90,7 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
                       onChange={[Function]}
                       onFocus={[Function]}
                       placeholder="0,00"
-                      required={true}
+                      required={false}
                       type="text"
                     />
                   </div>
@@ -142,11 +138,15 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
           <h6
             className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextSecondary makeStyles-weight-43 makeStyles-weight-126"
           >
-            balance: 
-            24
-             
-            IOV
-          </h6>
+            <h6
+              className="MuiTypography-root-45 MuiTypography-subtitle2-57 MuiTypography-colorTextSecondary-71 makeStyles-weight-43 makeStyles-weight-126"
+            >
+              balance:
+              24
+
+              IOV
+            </h6>
+          </div>
         </div>
       </div>
     </div>
@@ -168,8 +168,13 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
         <div
           className="MuiBox-root MuiBox-root-130"
         >
-          <form
-            onSubmit={[Function]}
+          <h6
+            className="MuiTypography-root-45 MuiTypography-subtitle2-57 MuiTypography-colorTextPrimary-70 makeStyles-weight-43 makeStyles-weight-129"
+          >
+            To
+          </h6>
+          <div
+            className="MuiBox-root-6 MuiBox-root-130"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root"
@@ -213,7 +218,7 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
                   onChange={[Function]}
                   onFocus={[Function]}
                   placeholder="IOV or wallet address"
-                  required={true}
+                  required={false}
                   type="text"
                 />
               </div>
@@ -231,17 +236,26 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
           <div
             className="MuiBox-root MuiBox-root-133"
           >
-            <div
-              className="makeStyles-container-135"
-              onClick={[Function]}
+            <h6
+              className="MuiTypography-root-45 MuiTypography-subtitle1-56 MuiTypography-colorTextPrimary-70 makeStyles-weight-43 makeStyles-weight-132"
             >
-              <img
-                alt="Info"
-                className="makeStyles-root-120"
-                height={16}
-                src="info_normal.svg"
-                width={16}
-              />
+              How it works
+            </h6>
+            <div
+              className="MuiBox-root-6 MuiBox-root-133"
+            >
+              <div
+                className="makeStyles-container-135"
+                onClick={[Function]}
+              >
+                <img
+                  alt="Info"
+                  className="makeStyles-root-120"
+                  height={16}
+                  src="info_normal.svg"
+                  width={16}
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -263,21 +277,17 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
           <div
             className="MuiBox-root MuiBox-root-141"
           >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-sticky-note fa-w-14 fa-lg "
-              color="#a2a6a8"
-              data-icon="sticky-note"
-              data-prefix="far"
-              focusable="false"
-              role="img"
-              style={Object {}}
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="MuiBox-root-6 MuiBox-root-141"
             >
-              <path
-                d="M448 348.106V80c0-26.51-21.49-48-48-48H48C21.49 32 0 53.49 0 80v351.988c0 26.51 21.49 48 48 48h268.118a48 48 0 0 0 33.941-14.059l83.882-83.882A48 48 0 0 0 448 348.106zm-128 80v-76.118h76.118L320 428.106zM400 80v223.988H296c-13.255 0-24 10.745-24 24v104H48V80h352z"
-                fill="currentColor"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-sticky-note fa-w-14 fa-lg "
+                color="#a2a6a8"
+                data-icon="sticky-note"
+                data-prefix="far"
+                focusable="false"
+                role="img"
                 style={Object {}}
               />
             </svg>
@@ -335,7 +345,7 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
                   />
                 </div>
               </div>
-            </form>
+            </div>
           </div>
         </div>
       </div>
@@ -369,9 +379,9 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
           Continue
         </span>
       </button>
-    </form>
+    </div>
   </div>
-</div>
+</form>
 `;
 
 exports[`Storyshots Bierzo wallet Welcome page 1`] = `
@@ -858,7 +868,7 @@ exports[`Storyshots Components Layout 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-395 makeStyles-weight-427 makeStyles-inline-393"
     >
-       
+
       storybook
     </h4>
   </div>
@@ -1445,7 +1455,7 @@ Array [
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-559 makeStyles-weight-605 makeStyles-inline-557"
   >
-    First part of the text. 
+    First part of the text.
   </h6>,
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-559 makeStyles-weight-606 makeStyles-inline-557"
@@ -1977,7 +1987,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1096 makeStyles-weight-1128 makeStyles-inline-1094"
     >
-       
+
       Status
     </h4>
   </div>
@@ -2175,7 +2185,7 @@ exports[`Storyshots Extension Login page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1209 makeStyles-weight-1241 makeStyles-inline-1207"
     >
-       
+
       In
     </h4>
   </div>
@@ -2333,7 +2343,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1320 makeStyles-weight-1352 makeStyles-inline-1318"
     >
-       
+
       phrase
     </h4>
   </div>
@@ -2405,7 +2415,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1320 makeStyles-weight-1383 makeStyles-inline-1318"
       >
-        
+
       </p>
     </div>
     <div
@@ -2476,7 +2486,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1420 makeStyles-weight-1452 makeStyles-inline-1418"
     >
-       
+
       Account
     </h4>
   </div>
@@ -2640,7 +2650,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1538 makeStyles-weight-1570 makeStyles-inline-1536"
     >
-       
+
       to your IOV manager
     </h4>
   </div>
@@ -2771,7 +2781,7 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1701 makeStyles-weight-1733 makeStyles-inline-1699"
     >
-       
+
       Identity
     </h4>
   </div>
@@ -2799,13 +2809,13 @@ exports[`Storyshots Extension/Share Identity Accept Request page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1701 makeStyles-weight-1739 makeStyles-inline-1699"
       >
-         
+
         your identity on
       </p>
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1701 makeStyles-weight-1740 makeStyles-inline-1699"
       >
-         
+
         ETH
       </p>
     </div>
@@ -2900,7 +2910,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1785 makeStyles-weight-1817 makeStyles-inline-1783"
     >
-       
+
       Identity
     </h4>
   </div>
@@ -2931,7 +2941,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
         <p
           className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1785 makeStyles-weight-1823 makeStyles-inline-1783"
         >
-           
+
           your identity.
         </p>
         <div
@@ -3083,7 +3093,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1618 makeStyles-weight-1650 makeStyles-inline-1616"
     >
-       
+
       Identity
     </h4>
   </div>
@@ -3111,7 +3121,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1618 makeStyles-weight-1656 makeStyles-inline-1616"
       >
-         
+
         ETH
       </p>
     </div>
@@ -3207,7 +3217,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1903 makeStyles-weight-1935 makeStyles-inline-1901"
     >
-       
+
       Account
     </h4>
   </div>
@@ -3498,7 +3508,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2041 makeStyles-weight-2073 makeStyles-inline-2039"
     >
-       
+
       Account
     </h4>
   </div>
@@ -3585,7 +3595,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2041 makeStyles-weight-2120 makeStyles-inline-2039"
       >
-        
+
       </p>
     </div>
     <div
@@ -3686,7 +3696,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2158 makeStyles-weight-2190 makeStyles-inline-2156"
     >
-       
+
       Account
     </h4>
   </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2411,6 +2411,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sindresorhus/is@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
+  integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
+
 "@storybook/addon-actions@^5.1.0-alpha.27":
   version "5.1.0-alpha.39"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-5.1.0-alpha.39.tgz#221e6fc9b4914eb8623aa214de6c933ab3954202"
@@ -2882,6 +2887,13 @@
     "@svgr/plugin-svgo" "^4.2.0"
     loader-utils "^1.2.3"
 
+"@szmarczak/http-timer@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
+  integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
+  dependencies:
+    defer-to-connect "^1.0.1"
+
 "@types/abstract-leveldown@*", "@types/abstract-leveldown@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz#3c7750d0186b954c7f2d2f6acc8c3c7ba0c3412e"
@@ -2963,6 +2975,15 @@
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.28.tgz#c054e8af4d9dd75db4e63abc76f885168714d4b3"
   integrity sha1-wFTor02d11205jq8dviFFocU1LM=
+
+"@types/glob@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
+  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
 
 "@types/history@*", "@types/history@^4.7.2":
   version "4.7.2"
@@ -3054,6 +3075,11 @@
   integrity sha512-3VlN94b29j7/9XPGfy1kTPmyA5YfFiC0miQRpOCbCJOALy2ejM2IzgDB7fIBTYyf2isr1r8h3qbZmT/1RsCP9Q==
   dependencies:
     "@types/abstract-leveldown" "*"
+
+"@types/minimatch@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
   version "12.0.0"
@@ -4090,6 +4116,11 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
+async-exit-hook@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz#8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3"
+  integrity sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==
+
 async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
@@ -5044,6 +5075,19 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+cacheable-request@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.0.0.tgz#4a1727414e02ac4af82560c4da1b61daa3fa2b63"
+  integrity sha512-2N7AmszH/WPPpl5Z3XMw1HAP+8d+xugnKQAeKvxFZ/04dbT/CAznqwbl+7eSr3HkwdepNwtb2yx3CAMQWvG01Q==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^4.0.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^3.0.0"
+    lowercase-keys "^1.0.1"
+    normalize-url "^3.1.0"
+    responselike "^1.0.2"
+
 call-me-maybe@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
@@ -5187,7 +5231,7 @@ ccount@^1.0.3:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
   integrity sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -5235,6 +5279,11 @@ character-reference-invalid@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz#21e421ad3d84055952dab4a43a04e73cd425d3ed"
   integrity sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+  integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -5481,6 +5530,13 @@ clone-deep@^2.0.1:
     is-plain-object "^2.0.4"
     kind-of "^6.0.0"
     shallow-clone "^1.0.0"
+
+clone-response@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
+  integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
+  dependencies:
+    mimic-response "^1.0.0"
 
 clone@^1.0.2:
   version "1.0.4"
@@ -6416,6 +6472,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
+  dependencies:
+    mimic-response "^1.0.0"
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -6476,6 +6539,11 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+defer-to-connect@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.0.2.tgz#4bae758a314b034ae33902b5aac25a8dd6a8633e"
+  integrity sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==
+
 deferred-leveldown@~5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/deferred-leveldown/-/deferred-leveldown-5.0.1.tgz#1642eb18b535dfb2b6ac4d39fb10a9cbcfd13b09"
@@ -6524,6 +6592,19 @@ del@^3.0.0:
     p-map "^1.1.1"
     pify "^3.0.0"
     rimraf "^2.2.8"
+
+del@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4"
+  integrity sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    globby "^6.1.0"
+    is-path-cwd "^2.0.0"
+    is-path-in-cwd "^2.0.0"
+    p-map "^2.0.0"
+    pify "^4.0.1"
+    rimraf "^2.6.3"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -7608,6 +7689,15 @@ extend@3.0.2, extend@^3.0.0, extend@~3.0.1, extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+external-editor@^2.0.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  integrity sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
 external-editor@^3.0.0, external-editor@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
@@ -8376,6 +8466,11 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
+github-url-from-git@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/github-url-from-git/-/github-url-from-git-1.5.0.tgz#f985fedcc0a9aa579dc88d7aff068d55cc6251a0"
+  integrity sha1-+YX+3MCpqledyI16/waNVcxiUaA=
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -8510,6 +8605,23 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
+got@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
+  integrity sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==
+  dependencies:
+    "@sindresorhus/is" "^0.14.0"
+    "@szmarczak/http-timer" "^1.1.2"
+    cacheable-request "^6.0.0"
+    decompress-response "^3.3.0"
+    duplexer3 "^0.1.4"
+    get-stream "^4.1.0"
+    lowercase-keys "^1.0.1"
+    mimic-response "^1.0.1"
+    p-cancelable "^1.0.0"
+    to-readable-stream "^1.0.0"
+    url-parse-lax "^3.0.0"
+
 graceful-fs@4.1.11:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
@@ -8597,6 +8709,11 @@ has-color@~0.1.0:
   resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
   integrity sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=
 
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+  integrity sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -8642,6 +8759,11 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+has-yarn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-2.1.0.tgz#137e11354a7b5bf11aa5cb649cf0c6f3ff2b2e77"
+  integrity sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==
 
 has@^1.0.0, has@^1.0.1, has@^1.0.3:
   version "1.0.3"
@@ -8740,7 +8862,7 @@ hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.1, hoist-non-react-
   dependencies:
     react-is "^16.7.0"
 
-hosted-git-info@^2.1.4, hosted-git-info@^2.6.0:
+hosted-git-info@^2.1.4, hosted-git-info@^2.6.0, hosted-git-info@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
@@ -8830,6 +8952,11 @@ http-cache-semantics@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
   integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
+
+http-cache-semantics@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz#495704773277eeef6e43f9ab2c2c7d259dda25c5"
+  integrity sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==
 
 http-deceiver@^1.2.7:
   version "1.2.7"
@@ -8940,7 +9067,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.13, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.13, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -9180,7 +9307,27 @@ inquirer@^0.12.0:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
-inquirer@^6.1.0, inquirer@^6.2.0, inquirer@^6.2.2:
+inquirer@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  integrity sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^6.1.0, inquirer@^6.2.0, inquirer@^6.2.1, inquirer@^6.2.2:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
   integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==
@@ -9521,6 +9668,11 @@ is-path-cwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
   integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
 
+is-path-cwd@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.1.0.tgz#2e0c7e463ff5b7a0eb60852d851a6809347a124c"
+  integrity sha512-Sc5j3/YnM8tDeyCsVeKlm/0p95075DyLmDEIkSgQ7mXkrOX+uTCtmQFm0CYzVyJwcCCmO3k8qfJt17SxQwB5Zw==
+
 is-path-in-cwd@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
@@ -9528,12 +9680,26 @@ is-path-in-cwd@^1.0.0:
   dependencies:
     is-path-inside "^1.0.0"
 
+is-path-in-cwd@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz#bfe2dca26c69f397265a4009963602935a053acb"
+  integrity sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==
+  dependencies:
+    is-path-inside "^2.1.0"
+
 is-path-inside@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
   integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
   dependencies:
     path-is-inside "^1.0.1"
+
+is-path-inside@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-2.1.0.tgz#7c9810587d659a40d27bcdb4d5616eab059494b2"
+  integrity sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==
+  dependencies:
+    path-is-inside "^1.0.2"
 
 is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -9600,6 +9766,20 @@ is-root@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.0.0.tgz#838d1e82318144e5a6f77819d90207645acc7019"
   integrity sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg==
+
+is-scoped@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-scoped/-/is-scoped-1.0.0.tgz#449ca98299e713038256289ecb2b540dc437cb30"
+  integrity sha1-RJypgpnnEwOCViieyytUDcQ3yzA=
+  dependencies:
+    scoped-regex "^1.0.0"
+
+is-scoped@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-scoped/-/is-scoped-2.1.0.tgz#fef0713772658bdf5bee418608267ddae6d3566d"
+  integrity sha512-Cv4OpPTHAK9kHYzkzCrof3VJh7H/PrG2MBUMvvJebaaUMbqhm0YAtXnvh0I3Hnj2tMZWwrRROWLSgfJrKqWmlQ==
+  dependencies:
+    scoped-regex "^2.0.0"
 
 is-ssh@^1.3.0:
   version "1.3.1"
@@ -9708,6 +9888,11 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
+issue-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/issue-regex/-/issue-regex-2.0.0.tgz#bb1802490394f8083c7a6787247cbf975638ef5d"
+  integrity sha512-flaQ/45dMqCYSMzBQI/h3bcto6T70uN7kjNnI8n3gQU6no5p+QcnMWBNXkraED0YvbUymxKaqdvgPa09RZQM5A==
 
 istanbul-lib-coverage@^2.0.2, istanbul-lib-coverage@^2.0.5:
   version "2.0.5"
@@ -10304,6 +10489,11 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
+json-buffer@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
+  integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
+
 json-merge-patch@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-merge-patch/-/json-merge-patch-0.2.3.tgz#fa2c6b5af87da77bae2966a589d52e23ed81fe40"
@@ -10532,6 +10722,13 @@ jws@^3.1.4:
   dependencies:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
+
+keyv@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
+  integrity sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
+  dependencies:
+    json-buffer "3.0.0"
 
 killable@^1.0.0:
   version "1.0.1"
@@ -10794,6 +10991,15 @@ lint-staged@^8.1.4:
     stringify-object "^3.2.2"
     yup "^0.27.0"
 
+listr-input@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/listr-input/-/listr-input-0.1.3.tgz#0c313967b6d179ebe964a81e9363ce2a5a39d25c"
+  integrity sha512-dvjSD1MrWGXxxPixpMQlSBmkyqhJrPxGo30un25k/vlvFOWZj70AauU+YkEh7CA8vmpkE6Wde37DJDmqYqF39g==
+  dependencies:
+    inquirer "^3.3.0"
+    rxjs "^5.5.2"
+    through "^2.3.8"
+
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
@@ -10823,7 +11029,7 @@ listr-verbose-renderer@^0.5.0:
     date-fns "^1.27.2"
     figures "^2.0.0"
 
-listr@^0.14.2:
+listr@^0.14.2, listr@^0.14.3:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
   integrity sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
@@ -11047,6 +11253,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
+lodash.zip@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
+  integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
+
 lodash@4.17.11, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.2:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
@@ -11065,6 +11276,13 @@ log-symbols@^2.2.0:
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
+
+log-symbols@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
+  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
+  dependencies:
+    chalk "^2.4.2"
 
 log-update@^2.3.0:
   version "2.3.0"
@@ -11105,7 +11323,7 @@ lower-case@^1.1.1:
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
   integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
 
-lowercase-keys@^1.0.0:
+lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
@@ -11262,7 +11480,7 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-mem@^4.0.0:
+mem@^4.0.0, mem@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
   integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
@@ -11328,6 +11546,21 @@ meow@^4.0.0:
     read-pkg-up "^3.0.0"
     redent "^2.0.0"
     trim-newlines "^2.0.0"
+
+meow@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
+  integrity sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==
+  dependencies:
+    camelcase-keys "^4.0.0"
+    decamelize-keys "^1.0.0"
+    loud-rejection "^1.0.0"
+    minimist-options "^3.0.1"
+    normalize-package-data "^2.3.4"
+    read-pkg-up "^3.0.0"
+    redent "^2.0.0"
+    trim-newlines "^2.0.0"
+    yargs-parser "^10.0.0"
 
 merge-deep@^3.0.2:
   version "3.0.2"
@@ -11414,10 +11647,15 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
-mimic-fn@^2.0.0:
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+mimic-response@^1.0.0, mimic-response@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
+  integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
 min-document@^2.19.0:
   version "2.19.0"
@@ -11894,7 +12132,7 @@ normalize-scroll-left@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz#6b79691ba79eb5fb107fa5edfbdc06b55caee2aa"
   integrity sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg==
 
-normalize-url@^3.0.0, normalize-url@^3.3.0:
+normalize-url@^3.0.0, normalize-url@^3.1.0, normalize-url@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
@@ -11903,6 +12141,44 @@ normalize.css@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
   integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
+
+np@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/np/-/np-5.0.1.tgz#54ac5347691d3dfc3ee0f0780d5a425ee2a692c1"
+  integrity sha512-2TiY5X0hbQEevPV0WjJ4Os0hjt+Ja3P7cDtiAqBU3jSgyT33Uv6P0g8lIkwLzeTaA8KJe9ykpszjB8DOo27m5Q==
+  dependencies:
+    "@samverschueren/stream-to-observable" "^0.3.0"
+    any-observable "^0.3.0"
+    async-exit-hook "^2.0.1"
+    chalk "^2.3.0"
+    cosmiconfig "^5.1.0"
+    del "^4.1.0"
+    execa "^1.0.0"
+    github-url-from-git "^1.5.0"
+    has-yarn "^2.1.0"
+    hosted-git-info "^2.7.1"
+    inquirer "^6.2.1"
+    is-installed-globally "^0.1.0"
+    is-scoped "^2.1.0"
+    issue-regex "^2.0.0"
+    listr "^0.14.3"
+    listr-input "^0.1.3"
+    log-symbols "^3.0.0"
+    meow "^5.0.0"
+    npm-name "^5.0.1"
+    onetime "^5.1.0"
+    open "^6.1.0"
+    ow "^0.12.0"
+    p-memoize "^3.1.0"
+    p-timeout "^3.1.0"
+    pkg-dir "^4.1.0"
+    read-pkg-up "^5.0.0"
+    rxjs "^6.3.3"
+    semver "^6.0.0"
+    split "^1.0.0"
+    symbol-observable "^1.2.0"
+    terminal-link "^1.2.0"
+    update-notifier "^2.1.0"
 
 npm-bundled@^1.0.1:
   version "1.0.6"
@@ -11922,6 +12198,18 @@ npm-lifecycle@^2.1.0:
     uid-number "0.0.6"
     umask "^1.1.0"
     which "^1.3.1"
+
+npm-name@^5.0.1:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/npm-name/-/npm-name-5.3.0.tgz#fdfcef069fd51d81e7cf3762128f2a4a40e9e969"
+  integrity sha512-w/Vq1px8uSEFGb0QOYei+Fr0VfIHnh0D1LzaFQOUFfVEzurF+UoQSASPg+6ZSlp0tvSlMjiMThJws/weBAV+IQ==
+  dependencies:
+    got "^9.6.0"
+    is-scoped "^1.0.0"
+    lodash.zip "^4.2.0"
+    registry-auth-token "^3.4.0"
+    registry-url "^4.0.0"
+    validate-npm-package-name "^3.0.0"
 
 "npm-package-arg@^4.0.0 || ^5.0.0 || ^6.0.0", npm-package-arg@^6.0.0, npm-package-arg@^6.1.0:
   version "6.1.0"
@@ -12171,6 +12459,13 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+onetime@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
+  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+  dependencies:
+    mimic-fn "^2.1.0"
+
 open@^6.1.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/open/-/open-6.2.0.tgz#7cf92cb961b5d8498b071e64098bf5e27f57230c"
@@ -12286,6 +12581,16 @@ osenv@0, osenv@^0.1.4, osenv@^0.1.5:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+ow@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/ow/-/ow-0.12.0.tgz#ce3b53a81af78171a21478bd684bd9862b152b35"
+  integrity sha512-GWAoq5RiK3HpMbwvM/aszyYYm7UvZzNfx5QPDbCXd52lROiDVBn6x6M06DhsL/Y8BTl42djQAPWhu6adaWwZyQ==
+
+p-cancelable@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
+  integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
+
 p-defer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
@@ -12353,6 +12658,14 @@ p-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
 
+p-memoize@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-memoize/-/p-memoize-3.1.0.tgz#ac7587983c9e530139f969ca7b41ef40e93659aa"
+  integrity sha512-e5tIvrsr7ydUUnxb534iQWtXxWgk/86IsH+H+nV4FHouIggBt4coXboKBt26o4lTu7JbEnGSeXdEsYR8BhAHFA==
+  dependencies:
+    mem "^4.3.0"
+    mimic-fn "^2.1.0"
+
 p-pipe@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-pipe/-/p-pipe-1.2.0.tgz#4b1a11399a11520a67790ee5a0c1d5881d6befe9"
@@ -12362,6 +12675,13 @@ p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
   integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
+
+p-timeout@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.1.0.tgz#198c1f503bb973e9b9727177a276c80afd6851f3"
+  integrity sha512-C27DYI+tCroT8J8cTEyySGydl2B7FlxrGNF5/wmMbl1V+jeehUCzEE/BVgzRebdm2K3ZitKOKx8YbdFumDyYmw==
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -12724,6 +13044,13 @@ pkg-dir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
   integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+  dependencies:
+    find-up "^3.0.0"
+
+pkg-dir@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.1.0.tgz#aaeb91c0d3b9c4f74a44ad849f4de34781ae01de"
+  integrity sha512-55k9QN4saZ8q518lE6EFgYiu95u3BWkSajCifhdQjvLvmr8IpnRbhI+UGpWJQfa0KzDguHeeWT1ccO1PmkOi3A==
   dependencies:
     find-up "^3.0.0"
 
@@ -13457,6 +13784,11 @@ prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prepend-http@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
+  integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
 prettier-linter-helpers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
@@ -14019,10 +14351,12 @@ react-fast-compare@^2.0.2:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-final-form-hooks@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-final-form-hooks/-/react-final-form-hooks-1.0.1.tgz#aba54aa4a7adfff8dd1db767d537f30d78328ee3"
-  integrity sha512-ifrMO9IaIsd4NfXz8eNSNCBcsc2XcbKPBoyhW1b6R+gn9sgXiYTOElGONxexyYnbxJBnZ2+WQ2tP+wyXbvUlGQ==
+react-final-form-hooks@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-final-form-hooks/-/react-final-form-hooks-2.0.0.tgz#a551cc9047130a44bf0372b3778150cc8b14586a"
+  integrity sha512-TP0nEcvJm4kOIFpTbwmStsXTfAM5TlrE7b+vQvEJpr4khOAe4vZahWnD3vfdFBkZ2BSpb3sK/iWTvq44Xa1KNw==
+  dependencies:
+    np "^5.0.1"
 
 react-focus-lock@^1.18.3:
   version "1.19.1"
@@ -14619,7 +14953,7 @@ regexpu-core@^4.5.4:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.1.0"
 
-registry-auth-token@^3.0.1:
+registry-auth-token@^3.0.1, registry-auth-token@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.4.0.tgz#d7446815433f5d5ed6431cd5dca21048f66b397e"
   integrity sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==
@@ -14633,6 +14967,13 @@ registry-url@^3.0.3:
   integrity sha1-PU74cPc93h138M+aOBQyRE4XSUI=
   dependencies:
     rc "^1.0.1"
+
+registry-url@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-4.0.0.tgz#7dc344ef0f1496fc95a6ad04ccb9a491df11c025"
+  integrity sha512-WAfGLywivb8s2+Cfblq1UV+kOyzURHzWSJmciDvrmstr4bv/0lnVSB9jfoOfkxx5xNJ1OGlSFmZh9WYBLFJOPg==
+  dependencies:
+    rc "^1.2.7"
 
 regjsgen@^0.5.0:
   version "0.5.0"
@@ -14873,6 +15214,13 @@ resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1,
   dependencies:
     path-parse "^1.0.6"
 
+responselike@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
+  integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
+  dependencies:
+    lowercase-keys "^1.0.0"
+
 restore-cursor@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
@@ -14975,10 +15323,29 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  integrity sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+  integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
+
 rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
   integrity sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=
+
+rxjs@^5.5.2:
+  version "5.5.12"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
+  integrity sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==
+  dependencies:
+    symbol-observable "1.0.1"
 
 rxjs@^6.1.0, rxjs@^6.3.3, rxjs@^6.4.0:
   version "6.5.1"
@@ -15082,6 +15449,16 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
+
+scoped-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-1.0.0.tgz#a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8"
+  integrity sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=
+
+scoped-regex@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-2.1.0.tgz#7b9be845d81fd9d21d1ec97c61a0b7cf86d2015f"
+  integrity sha512-g3WxHrqSWCZHGHlSrF51VXFdjImhwvH8ZO/pryFH56Qi0cDsZfylQa/t0jCzVQFNbNvM00HfHjkDPEuarKDSWQ==
 
 scrollbarwidth@^0.1.3:
   version "0.1.3"
@@ -16018,7 +16395,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.3.0:
+supports-color@^5.0.0, supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -16031,6 +16408,14 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+supports-hyperlinks@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz#71daedf36cc1060ac5100c351bb3da48c29c0ef7"
+  integrity sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==
+  dependencies:
+    has-flag "^2.0.0"
+    supports-color "^5.0.0"
 
 svgo@^1.0.0, svgo@^1.2.1:
   version "1.2.2"
@@ -16051,6 +16436,11 @@ svgo@^1.0.0, svgo@^1.2.1:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+  integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
 
 symbol-observable@1.2.0, symbol-observable@^1.0.3, symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
@@ -16174,6 +16564,14 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
+terminal-link@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-1.3.0.tgz#3e9a308289e13340053aaf40e8f1a06d1335646e"
+  integrity sha512-nFaWG/gs3brGi3opgWU2+dyFGbQ7tueSRYOBOD8URdDXCbAGqDEZzuskCc+okCClYcJFDPwn8e2mbv4FqAnWFA==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    supports-hyperlinks "^1.0.1"
+
 terser-webpack-plugin@1.2.3, terser-webpack-plugin@^1.1.0, terser-webpack-plugin@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz#3f98bc902fac3e5d0de730869f50668561262ec8"
@@ -16251,7 +16649,7 @@ through2@^3.0.0:
   dependencies:
     readable-stream "2 || 3"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
+through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -16326,6 +16724,11 @@ to-object-path@^0.3.0:
   integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
   dependencies:
     kind-of "^3.0.2"
+
+to-readable-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
+  integrity sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
 
 to-regex-range@^2.1.0:
   version "2.1.1"
@@ -16702,6 +17105,22 @@ update-notifier@2.3.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
+update-notifier@^2.1.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
+  integrity sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==
+  dependencies:
+    boxen "^1.2.1"
+    chalk "^2.0.1"
+    configstore "^3.0.0"
+    import-lazy "^2.1.0"
+    is-ci "^1.0.10"
+    is-installed-globally "^0.1.0"
+    is-npm "^1.0.0"
+    latest-version "^3.0.0"
+    semver-diff "^2.0.0"
+    xdg-basedir "^3.0.0"
+
 upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
@@ -16734,6 +17153,13 @@ url-parse-lax@^1.0.0:
   integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
   dependencies:
     prepend-http "^1.0.1"
+
+url-parse-lax@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
+  integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
+  dependencies:
+    prepend-http "^2.0.0"
 
 url-parse@^1.4.3:
   version "1.4.7"
@@ -17595,7 +18021,7 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
-yargs-parser@^10.1.0:
+yargs-parser@^10.0.0, yargs-parser@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
   integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==


### PR DESCRIPTION
The goal of this PR is to make use of React Final Form Hooks' new [useField](https://github.com/final-form/react-final-form-hooks#usefield) implementation so that the validation of Bierzo Wallet's payment form can be made in a more modular and decoupled fashion.

Medulas has been updated to provide validators that can be used independently or combined in its TextFieldForm component. This way, instead of having to wrap each component with a dummy form, each field has a `validate`attribute that can be set like this to use independently:

```typescript
<TextFieldForm
    name={TEXTNOTE_FIELD}
    form={props.form}
    validate={notLongerThan(150)}
    placeholder="Add a note"
    multiline
    rows="2"
    fullWidth
    margin="none"
/>
```

Or that can be composed in order to use several validators:

```typescript
<TextFieldForm
    name={QUANTITY_FIELD}
    form={props.form}
    validate={composeValidators(
        required,
        number,
        lowerOrEqualThan(balance),
        lowerOrEqualThan(QUANTITY_MAX),
        greaterOrEqualThan(QUANTITY_MIN)
     )}
     placeholder="0,00"
     fullWidth
     margin="none"
/>
```