### PR TITLE
Fix - Set default viewport  of the Wallet to the responsive value

### DIFF
--- a/packages/bierzo-wallet/src/routes/payment/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/index.stories.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import DecoratedStorybook, { WALLET_ROOT } from '../../utils/storybook';
 import Payment from './index';
 
-storiesOf(WALLET_ROOT, module).add(
-  'Payment page',
-  (): JSX.Element => (
-    <DecoratedStorybook>
-      <Payment />
-    </DecoratedStorybook>
-  )
-);
+storiesOf(WALLET_ROOT, module)
+  .addParameters({ viewport: { defaultViewport: 'responsive' } })
+  .add(
+    'Payment page',
+    (): JSX.Element => (
+      <DecoratedStorybook>
+        <Payment />
+      </DecoratedStorybook>
+    )
+  );

--- a/packages/bierzo-wallet/src/routes/welcome/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/welcome/index.stories.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import DecoratedStorybook, { WALLET_ROOT } from '../../utils/storybook';
 import Welcome from './index';
 
-storiesOf(WALLET_ROOT, module).add(
-  'Welcome page',
-  (): JSX.Element => (
-    <DecoratedStorybook>
-      <Welcome />
-    </DecoratedStorybook>
-  )
-);
+storiesOf(WALLET_ROOT, module)
+  .addParameters({ viewport: { defaultViewport: 'responsive' } })
+  .add(
+    'Welcome page',
+    (): JSX.Element => (
+      <DecoratedStorybook>
+        <Welcome />
+      </DecoratedStorybook>
+    )
+  );


### PR DESCRIPTION
**Description**
This PR will set default viewport value to 'responsive' because Bierzo Wallet doesn't need to use `chromExtension` viewport.