### PR TITLE
Task #176 - Remove getBalances code from persona

### DIFF
--- a/packages/sanes-chrome-extension/src/logic/persona/persona.ts
+++ b/packages/sanes-chrome-extension/src/logic/persona/persona.ts
@@ -168,27 +168,6 @@ export class Persona {
     return filtered;
   }
 
-  public async getBalances(accountIndex: number): Promise<ReadonlyArray<Amount>> {
-    const accounts = await this.accountManager.accounts();
-    if (accounts.length <= accountIndex) {
-      throw new Error('Account does not exist');
-    }
-    const account = accounts[accountIndex];
-    const pendingAccountResults = account.identities.map(identity => {
-      const { chainId, pubkey } = identity;
-      return this.signer.connection(chainId).getAccount({ pubkey });
-    });
-    const accountResults = await Promise.all(pendingAccountResults);
-
-    const out: Amount[] = [];
-    for (const result of accountResults) {
-      if (result) {
-        out.push(...result.balance);
-      }
-    }
-    return out;
-  }
-
   public startSigningServer(
     authorizeGetIdentities: GetIdentitiesAuthorization,
     authorizeSignAndPost: SignAndPostAuthorization,

--- a/packages/sanes-chrome-extension/src/logic/persona/persona.unit.spec.ts
+++ b/packages/sanes-chrome-extension/src/logic/persona/persona.unit.spec.ts
@@ -58,41 +58,6 @@ withChainsDescribe('Persona', () => {
     });
   });
 
-  describe('getBalances', () => {
-    it('can get balances of first account', async () => {
-      const persona = await Persona.create();
-
-      const balances = await persona.getBalances(0);
-      // no address exists on chain, so balance exists
-      expect(balances.length).toEqual(0);
-
-      persona.destroy();
-    });
-
-    it('gets proper balance for Ethereum account', async () => {
-      const persona = await Persona.create(
-        'oxygen fall sure lava energy veteran enroll frown question detail include maximum',
-      );
-
-      const balances = await persona.getBalances(0);
-      const ethBalance = balances.find(b => b.tokenTicker === ('ETH' as TokenTicker));
-      if (!ethBalance) {
-        throw new Error('Did not find an ETH balance');
-      }
-      const approxEther = Number.parseInt(ethBalance.quantity, 10) / 1e18;
-
-      expect(approxEther).toBeCloseTo(100, -1);
-
-      persona.destroy();
-    });
-
-    it('throws when calling for non-existing account', async () => {
-      const persona = await Persona.create();
-      await expect(persona.getBalances(42)).rejects.toThrowError(/account does not exist/i);
-      persona.destroy();
-    });
-  });
-
   describe('startSigningServer', () => {
     it('can start the signing server', async () => {
       const persona = await Persona.create();


### PR DESCRIPTION
**Description**
This PR removes the getBalances code from `persona` because we do not display balances for now.

It closes #176 
