### PR TITLE
Sorts Imports with TypeScript Import Sorter extension

### DIFF
--- a/packages/bierzo-wallet/src/communication/identities/index.ts
+++ b/packages/bierzo-wallet/src/communication/identities/index.ts
@@ -1,9 +1,10 @@
-/*global chrome*/
-import { JsonRpcRequest, parseJsonRpcResponse2, isJsonRpcErrorResponse, makeJsonRpcId } from '@iov/jsonrpc';
-import { TransactionEncoder } from '@iov/core';
 import { isPublicIdentity, PublicIdentity } from '@iov/bcp';
+import { TransactionEncoder } from '@iov/core';
 import { ethereumCodec } from '@iov/ethereum';
-import { extensionId } from '..';
+/*global chrome*/
+import { isJsonRpcErrorResponse, JsonRpcRequest, makeJsonRpcId, parseJsonRpcResponse2 } from '@iov/jsonrpc';
+
+import { extensionId } from '../';
 
 const generateGetIdentitiesRequest = (): JsonRpcRequest => ({
   jsonrpc: '2.0',

--- a/packages/bierzo-wallet/src/communication/signAndPost/index.ts
+++ b/packages/bierzo-wallet/src/communication/signAndPost/index.ts
@@ -1,9 +1,10 @@
-/*global chrome*/
-import { JsonRpcRequest, parseJsonRpcResponse2, isJsonRpcErrorResponse, makeJsonRpcId } from '@iov/jsonrpc';
+import { Address, PublicIdentity, SendTransaction, TokenTicker, TransactionId } from '@iov/bcp';
 import { TransactionEncoder } from '@iov/core';
-import { PublicIdentity, SendTransaction, Address, TokenTicker, TransactionId } from '@iov/bcp';
 import { EthereumConnection } from '@iov/ethereum';
-import { extensionId } from '..';
+/*global chrome*/
+import { isJsonRpcErrorResponse, JsonRpcRequest, makeJsonRpcId, parseJsonRpcResponse2 } from '@iov/jsonrpc';
+
+import { extensionId } from '../';
 
 async function withEthereumFee(transaction: SendTransaction): Promise<SendTransaction> {
   const connection = await EthereumConnection.establish('http://localhost:8545');

--- a/packages/bierzo-wallet/src/index.tsx
+++ b/packages/bierzo-wallet/src/index.tsx
@@ -1,9 +1,10 @@
 import { ConnectedRouter } from 'connected-react-router';
-import MedulasThemeProvider from 'medulas-react-components/lib/theme/MedulasThemeProvider';
 import { ToastProvider } from 'medulas-react-components/lib/context/ToastProvider';
+import MedulasThemeProvider from 'medulas-react-components/lib/theme/MedulasThemeProvider';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+
 import Router from './routes';
 import { configureStore } from './store';
 import { history } from './store/reducers';

--- a/packages/bierzo-wallet/src/routes/index.tsx
+++ b/packages/bierzo-wallet/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
+
 import { PAYMENT_ROUTE, WELCOME_ROUTE } from './paths';
 import Payment from './payment';
 import Welcome from './welcome';

--- a/packages/bierzo-wallet/src/routes/payment/components/CurrencyToSend/index.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/components/CurrencyToSend/index.tsx
@@ -1,8 +1,3 @@
-import { faUser } from '@fortawesome/free-regular-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import Avatar from '@material-ui/core/Avatar';
-import Paper from '@material-ui/core/Paper';
-import { makeStyles } from '@material-ui/styles';
 import { FormApi } from 'final-form';
 import Block from 'medulas-react-components/lib/components/Block';
 import SelectFieldForm, { Item } from 'medulas-react-components/lib/components/forms/SelectFieldForm';
@@ -16,6 +11,12 @@ import {
   required,
 } from 'medulas-react-components/lib/utils/forms/validators';
 import React, { useState } from 'react';
+
+import { faUser } from '@fortawesome/free-regular-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Avatar from '@material-ui/core/Avatar';
+import Paper from '@material-ui/core/Paper';
+import { makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles(() => ({
   avatar: {

--- a/packages/bierzo-wallet/src/routes/payment/components/ReceiverAddress/index.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/components/ReceiverAddress/index.tsx
@@ -1,4 +1,3 @@
-import Paper from '@material-ui/core/Paper';
 import { FormApi } from 'final-form';
 import Block from 'medulas-react-components/lib/components/Block';
 import TextFieldForm from 'medulas-react-components/lib/components/forms/TextFieldForm';
@@ -11,6 +10,8 @@ import {
   validAddress,
 } from 'medulas-react-components/lib/utils/forms/validators';
 import React from 'react';
+
+import Paper from '@material-ui/core/Paper';
 
 const ADDRESS_FIELD = 'addressField';
 const ADDRESS_MAX_LENGTH = 254;

--- a/packages/bierzo-wallet/src/routes/payment/components/TextNote/index.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/components/TextNote/index.tsx
@@ -1,11 +1,12 @@
-import { faStickyNote } from '@fortawesome/free-regular-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import Paper from '@material-ui/core/Paper';
 import { FormApi } from 'final-form';
 import Block from 'medulas-react-components/lib/components/Block';
 import TextFieldForm from 'medulas-react-components/lib/components/forms/TextFieldForm';
 import { notLongerThan } from 'medulas-react-components/lib/utils/forms/validators';
 import React from 'react';
+
+import { faStickyNote } from '@fortawesome/free-regular-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Paper from '@material-ui/core/Paper';
 
 const TEXTNOTE_FIELD = 'textNoteField';
 

--- a/packages/bierzo-wallet/src/routes/payment/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/index.stories.tsx
@@ -1,5 +1,7 @@
-import { storiesOf } from '@storybook/react';
 import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+
 import DecoratedStorybook, { WALLET_ROOT } from '../../utils/storybook';
 import Payment from './index';
 

--- a/packages/bierzo-wallet/src/routes/payment/index.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/index.tsx
@@ -1,9 +1,11 @@
-import { Theme } from '@material-ui/core';
-import { makeStyles } from '@material-ui/styles';
 import Block from 'medulas-react-components/lib/components/Block';
 import Button from 'medulas-react-components/lib/components/Button';
 import Form, { useForm } from 'medulas-react-components/lib/components/forms/Form';
 import React from 'react';
+
+import { Theme } from '@material-ui/core';
+import { makeStyles } from '@material-ui/styles';
+
 import CurrencyToSend from './components/CurrencyToSend';
 import ReceiverAddress from './components/ReceiverAddress';
 import TextNote from './components/TextNote';

--- a/packages/bierzo-wallet/src/routes/welcome/index.dom.spec.ts
+++ b/packages/bierzo-wallet/src/routes/welcome/index.dom.spec.ts
@@ -1,5 +1,6 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import { configureStore } from '../../store';
 import { RootState } from '../../store/reducers';
 import { expectRoute } from '../../utils/test/dom';

--- a/packages/bierzo-wallet/src/routes/welcome/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/welcome/index.stories.tsx
@@ -1,5 +1,7 @@
-import { storiesOf } from '@storybook/react';
 import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+
 import DecoratedStorybook, { WALLET_ROOT } from '../../utils/storybook';
 import Welcome from './index';
 

--- a/packages/bierzo-wallet/src/routes/welcome/index.tsx
+++ b/packages/bierzo-wallet/src/routes/welcome/index.tsx
@@ -1,17 +1,19 @@
-import { Theme } from '@material-ui/core';
-import { makeStyles } from '@material-ui/styles';
 import Block from 'medulas-react-components/lib/components/Block';
 import Button from 'medulas-react-components/lib/components/Button';
 import CircleImage from 'medulas-react-components/lib/components/Image/CircleImage';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider';
-import React from 'react';
-import icon from '../../assets/iov-logo.svg';
-import { history } from '../../store/reducers';
-import { PAYMENT_ROUTE } from '../paths';
 import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
+import React from 'react';
+
+import { Theme } from '@material-ui/core';
+import { makeStyles } from '@material-ui/styles';
+
+import icon from '../../assets/iov-logo.svg';
 import { sendGetIdentitiesRequest } from '../../communication/identities';
 import { sendSignAndPostRequest } from '../../communication/signAndPost';
+import { history } from '../../store/reducers';
+import { PAYMENT_ROUTE } from '../paths';
 
 const useStyles = makeStyles((theme: Theme) => ({
   welcome: {

--- a/packages/bierzo-wallet/src/routes/welcome/test/travelToWelcome.ts
+++ b/packages/bierzo-wallet/src/routes/welcome/test/travelToWelcome.ts
@@ -1,5 +1,6 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import { history } from '../../../store/reducers';
 import { createDom } from '../../../utils/test/dom';
 import { whenOnNavigatedToRoute } from '../../../utils/test/navigation';

--- a/packages/bierzo-wallet/src/store/index.tsx
+++ b/packages/bierzo-wallet/src/store/index.tsx
@@ -1,5 +1,6 @@
 import { routerMiddleware, RouterState } from 'connected-react-router';
 import { applyMiddleware, compose, createStore, Store } from 'redux';
+
 import reducer, { history } from './reducers';
 
 const composeEnhancers =

--- a/packages/bierzo-wallet/src/theme/globalStyles.ts
+++ b/packages/bierzo-wallet/src/theme/globalStyles.ts
@@ -1,5 +1,6 @@
-import makeStyles from 'medulas-react-components/lib/theme/utils/styles';
 import 'normalize.css';
+
+import makeStyles from 'medulas-react-components/lib/theme/utils/styles';
 
 export const globalStyles = makeStyles({
   '@global': {

--- a/packages/bierzo-wallet/src/utils/storybook/index.tsx
+++ b/packages/bierzo-wallet/src/utils/storybook/index.tsx
@@ -2,6 +2,7 @@ import { ConnectedRouter } from 'connected-react-router';
 import MedulasThemeProvider from 'medulas-react-components/lib/theme/MedulasThemeProvider';
 import * as React from 'react';
 import { Provider } from 'react-redux';
+
 import { configureStore } from '../../store';
 import { history } from '../../store/reducers';
 import { globalStyles } from '../../theme/globalStyles';

--- a/packages/bierzo-wallet/src/utils/test/dom.tsx
+++ b/packages/bierzo-wallet/src/utils/test/dom.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { Store } from 'redux';
+
 import Route from '../../routes';
 import { history } from '../../store/reducers';
 

--- a/packages/medulas-react-components/src/components/Block/index.tsx
+++ b/packages/medulas-react-components/src/components/Block/index.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+
 import Box from '@material-ui/core/Box';
+
 import { SizingBreakpoint } from '../Grid';
 
 export type Unit = 0 | 1 | 2 | 3 | 4;

--- a/packages/medulas-react-components/src/components/Button/Back.tsx
+++ b/packages/medulas-react-components/src/components/Button/Back.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import MuiButton, { ButtonProps } from '@material-ui/core/Button';
 
 const Back = ({ children, ...restProps }: ButtonProps): JSX.Element => (

--- a/packages/medulas-react-components/src/components/Button/Download.tsx
+++ b/packages/medulas-react-components/src/components/Button/Download.tsx
@@ -1,11 +1,13 @@
+import * as React from 'react';
+
 import { Fab, makeStyles } from '@material-ui/core';
 import { Theme } from '@material-ui/core/styles';
 import { useTheme } from '@material-ui/styles';
-import * as React from 'react';
+
+import download from '../../theme/assets/download.svg';
 import Block from '../Block';
 import CircleImage from '../Image/CircleImage';
 import Typography from '../Typography';
-import download from '../../theme/assets/download.svg';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {

--- a/packages/medulas-react-components/src/components/Button/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Button/index.stories.tsx
@@ -1,12 +1,14 @@
+import React from 'react';
+
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
-import React from 'react';
-import Button from './index';
-import Download from './Download';
-import Back from './Back';
+
 import { Storybook } from '../../utils/storybook';
 import Grid from '../Grid';
 import GridItem from '../GridItem';
+import Back from './Back';
+import Download from './Download';
+import Button from './index';
 
 storiesOf('Components', module).add(
   'Buttons',

--- a/packages/medulas-react-components/src/components/Button/index.tsx
+++ b/packages/medulas-react-components/src/components/Button/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import MuiButton, { ButtonProps } from '@material-ui/core/Button';
 
 const Button = ({ children, ...restProps }: ButtonProps): JSX.Element => (

--- a/packages/medulas-react-components/src/components/Drawer/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Drawer/index.stories.tsx
@@ -1,9 +1,11 @@
+import React from 'react';
+
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
-import React from 'react';
+
 import { Storybook } from '../../utils/storybook';
-import Typography from '../Typography';
 import PageLayout from '../PageLayout';
+import Typography from '../Typography';
 import Drawer from './index';
 
 storiesOf('Components', module).add(

--- a/packages/medulas-react-components/src/components/Drawer/index.tsx
+++ b/packages/medulas-react-components/src/components/Drawer/index.tsx
@@ -1,3 +1,6 @@
+import classNames from 'classnames';
+import React from 'react';
+
 import AppBar from '@material-ui/core/AppBar';
 import Divider from '@material-ui/core/Divider';
 import Drawer from '@material-ui/core/Drawer';
@@ -9,8 +12,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 import Toolbar from '@material-ui/core/Toolbar';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import MenuIcon from '@material-ui/icons/Menu';
-import classNames from 'classnames';
-import React from 'react';
+
 import Block from '../Block';
 
 const drawerWidth = 240;

--- a/packages/medulas-react-components/src/components/Grid/index.tsx
+++ b/packages/medulas-react-components/src/components/Grid/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import Box from '@material-ui/core/Box';
 
 export interface SizingBreakpoint {

--- a/packages/medulas-react-components/src/components/GridItem/index.tsx
+++ b/packages/medulas-react-components/src/components/GridItem/index.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+
 import Box from '@material-ui/core/Box';
+
 import { SizingBreakpoint } from '../Grid';
 
 // TODO: Remove those props after BoxProps will be properly implemented.

--- a/packages/medulas-react-components/src/components/Hairline/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Hairline/index.stories.tsx
@@ -1,9 +1,11 @@
-import { storiesOf } from '@storybook/react';
 import React from 'react';
-import Typography from '../Typography';
+
+import { storiesOf } from '@storybook/react';
+
 import { Storybook } from '../../utils/storybook';
-import Hairline from './index';
 import Block from '../Block';
+import Typography from '../Typography';
+import Hairline from './index';
 
 storiesOf('Components', module).add('Hairline', () => (
   <Storybook>

--- a/packages/medulas-react-components/src/components/Hairline/index.tsx
+++ b/packages/medulas-react-components/src/components/Hairline/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import Block, { Unit } from '../Block';
 
 interface Props {

--- a/packages/medulas-react-components/src/components/Image/CircleImage.tsx
+++ b/packages/medulas-react-components/src/components/Image/CircleImage.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import Image, { ImgProps } from '../Image';
+
 import theme from '../../theme/utils/mui';
 import Block from '../Block';
+import Image, { ImgProps } from '../Image';
 
 interface Props extends ImgProps {
   readonly icon: string;

--- a/packages/medulas-react-components/src/components/Image/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Image/index.stories.tsx
@@ -1,13 +1,15 @@
-import { storiesOf } from '@storybook/react';
 import React from 'react';
-import Image from './index';
-import CircleImage from './CircleImage';
-import { Storybook } from '../../utils/storybook';
-import iovLogo from './assets/iov-logo.png';
+
+import { storiesOf } from '@storybook/react';
+
 import download from '../../theme/assets/download.svg';
+import theme from '../../theme/utils/mui';
+import { Storybook } from '../../utils/storybook';
 import Grid from '../Grid';
 import GridItem from '../GridItem';
-import theme from '../../theme/utils/mui';
+import iovLogo from './assets/iov-logo.png';
+import CircleImage from './CircleImage';
+import Image from './index';
 
 storiesOf('Components', module).add(
   'Images',

--- a/packages/medulas-react-components/src/components/Image/index.tsx
+++ b/packages/medulas-react-components/src/components/Image/index.tsx
@@ -1,5 +1,6 @@
-import * as React from 'react';
 import classNames from 'classnames';
+import * as React from 'react';
+
 import { makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles({

--- a/packages/medulas-react-components/src/components/List/index.tsx
+++ b/packages/medulas-react-components/src/components/List/index.tsx
@@ -1,6 +1,6 @@
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
 
 export { List, ListItem, ListItemText, ListItemIcon };

--- a/packages/medulas-react-components/src/components/PageLayout/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/PageLayout/index.stories.tsx
@@ -1,9 +1,11 @@
-import { storiesOf } from '@storybook/react';
 import React from 'react';
+
+import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
+
+import { Storybook } from '../../utils/storybook';
 import Typography from '../Typography';
 import PageLayout from './index';
-import { Storybook } from '../../utils/storybook';
-import { action } from '@storybook/addon-actions';
 
 storiesOf('Components', module).add(
   'Layout',

--- a/packages/medulas-react-components/src/components/PageLayout/index.tsx
+++ b/packages/medulas-react-components/src/components/PageLayout/index.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
-import Block from '../Block';
-import Typography from '../Typography';
-import Image from '../Image';
-import iovLogo from '../../theme/assets/iov-logo.png';
-import ArrowBackIcon from '@material-ui/icons/ArrowBackIos';
+
 import IconButton from '@material-ui/core/IconButton';
+import ArrowBackIcon from '@material-ui/icons/ArrowBackIos';
+
+import iovLogo from '../../theme/assets/iov-logo.png';
+import Block from '../Block';
+import Image from '../Image';
+import Typography from '../Typography';
 
 interface Props {
   readonly id?: string;

--- a/packages/medulas-react-components/src/components/Switch/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Switch/index.stories.tsx
@@ -1,8 +1,10 @@
-import { storiesOf } from '@storybook/react';
 import React from 'react';
-import Switch from './index';
-import Block from '../Block';
+
+import { storiesOf } from '@storybook/react';
+
 import { Storybook } from '../../utils/storybook';
+import Block from '../Block';
+import Switch from './index';
 
 storiesOf('Components', module).add(
   'Switch',

--- a/packages/medulas-react-components/src/components/Switch/index.tsx
+++ b/packages/medulas-react-components/src/components/Switch/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import MuiSwitch, { SwitchProps } from '@material-ui/core/Switch';
+
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import MuiSwitch, { SwitchProps } from '@material-ui/core/Switch';
 
 interface Props extends SwitchProps {
   readonly label?: string;

--- a/packages/medulas-react-components/src/components/Tooltip/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Tooltip/index.stories.tsx
@@ -1,9 +1,11 @@
-import { storiesOf } from '@storybook/react';
 import React from 'react';
-import Tooltip from './index';
+
+import { storiesOf } from '@storybook/react';
+
+import { Storybook } from '../../utils/storybook';
 import Block from '../Block';
 import Typography from '../Typography';
-import { Storybook } from '../../utils/storybook';
+import Tooltip from './index';
 
 storiesOf('Components', module).add(
   'Tooltip',

--- a/packages/medulas-react-components/src/components/Tooltip/index.tsx
+++ b/packages/medulas-react-components/src/components/Tooltip/index.tsx
@@ -1,10 +1,12 @@
-import { Popper, createStyles, makeStyles, Theme } from '@material-ui/core';
-import Paper from '@material-ui/core/Paper';
 import * as React from 'react';
-import Image from '../Image';
+
+import { createStyles, makeStyles, Popper, Theme } from '@material-ui/core';
+import Paper from '@material-ui/core/Paper';
+
+import { useOpen } from '../../hooks/open';
 import infoNormal from '../../theme/assets/info_normal.svg';
 import theme from '../../theme/utils/mui';
-import { useOpen } from '../../hooks/open';
+import Image from '../Image';
 
 const DEFAULT_HEIGHT = 16;
 

--- a/packages/medulas-react-components/src/components/Typography/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Typography/index.stories.tsx
@@ -1,7 +1,9 @@
-import { storiesOf } from '@storybook/react';
 import React from 'react';
-import Typography from './index';
+
+import { storiesOf } from '@storybook/react';
+
 import { Storybook } from '../../utils/storybook';
+import Typography from './index';
 
 storiesOf('Components', module).add(
   'Typography',

--- a/packages/medulas-react-components/src/components/Typography/index.tsx
+++ b/packages/medulas-react-components/src/components/Typography/index.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react';
-import MuiTypography, { TypographyProps } from '@material-ui/core/Typography';
-import makeStyles from '@material-ui/styles/makeStyles';
-import { Theme } from '@material-ui/core/styles';
 import classNames from 'classnames';
 import { FontWeightProperty } from 'csstype';
+import * as React from 'react';
+
+import { Theme } from '@material-ui/core/styles';
+import MuiTypography, { TypographyProps } from '@material-ui/core/Typography';
+import makeStyles from '@material-ui/styles/makeStyles';
 
 type Weight = 'light' | 'regular' | 'semibold';
 

--- a/packages/medulas-react-components/src/components/forms/CheckboxField/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/CheckboxField/index.stories.tsx
@@ -1,9 +1,11 @@
-import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 import React from 'react';
-import CheckboxField from './index';
+
+import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
+
 import { Storybook } from '../../../utils/storybook';
 import Form, { useForm } from '../Form';
+import CheckboxField from './index';
 
 const CheckboxFieldForm = (): JSX.Element => {
   const { form, handleSubmit } = useForm({

--- a/packages/medulas-react-components/src/components/forms/CheckboxField/index.tsx
+++ b/packages/medulas-react-components/src/components/forms/CheckboxField/index.tsx
@@ -1,11 +1,12 @@
-import { FormApi, FieldSubscription } from 'final-form';
-import { useField } from 'react-final-form-hooks';
+import { FieldSubscription, FormApi } from 'final-form';
 import * as React from 'react';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
+import { useField } from 'react-final-form-hooks';
+
 import { Omit } from '@material-ui/core';
-import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import CheckBoxIcon from '@material-ui/icons/CheckBox';
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
 
 interface Props extends Omit<CheckboxProps, 'form'> {
   readonly fieldName: string;

--- a/packages/medulas-react-components/src/components/forms/Form/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/Form/index.stories.tsx
@@ -1,12 +1,14 @@
-import { storiesOf } from '@storybook/react';
 import * as React from 'react';
+
+import { storiesOf } from '@storybook/react';
+
 import { Storybook } from '../../../utils/storybook';
-import Button from '../../Button';
 import Block from '../../Block';
+import Button from '../../Button';
+import CheckboxField from '../CheckboxField';
 import SelectFieldForm, { Item } from '../SelectFieldForm';
 import TextFieldForm from '../TextFieldForm';
-import CheckboxField from '../CheckboxField';
-import Form, { useForm, FormValues, ValidationError } from './index';
+import Form, { FormValues, useForm, ValidationError } from './index';
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms)); // eslint-disable-line
 

--- a/packages/medulas-react-components/src/components/forms/Form/index.tsx
+++ b/packages/medulas-react-components/src/components/forms/Form/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useForm, useField } from 'react-final-form-hooks';
+import { useField, useForm } from 'react-final-form-hooks';
 
 export { useForm, useField };
 

--- a/packages/medulas-react-components/src/components/forms/SelectFieldForm/SelectItems.tsx
+++ b/packages/medulas-react-components/src/components/forms/SelectFieldForm/SelectItems.tsx
@@ -1,7 +1,9 @@
+import * as React from 'react';
+
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
-import * as React from 'react';
+
 import selectedTick from '../../../theme/assets/selectField/selectedTick.svg';
 import Block from '../../Block';
 import Hairline from '../../Hairline';

--- a/packages/medulas-react-components/src/components/forms/SelectFieldForm/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/SelectFieldForm/index.stories.tsx
@@ -1,10 +1,11 @@
-import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 import React from 'react';
-import SelectField from './index';
+
+import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
+
 import { Storybook } from '../../../utils/storybook';
 import Form, { useForm } from '../Form';
-import { Item } from './index';
+import SelectField, { Item } from './index';
 
 const SelectFieldForm = (): JSX.Element => {
   const { form, handleSubmit } = useForm({

--- a/packages/medulas-react-components/src/components/forms/SelectFieldForm/index.tsx
+++ b/packages/medulas-react-components/src/components/forms/SelectFieldForm/index.tsx
@@ -1,13 +1,15 @@
+import { FieldSubscription, FormApi } from 'final-form';
+import * as React from 'react';
+import { useField } from 'react-final-form-hooks';
+
 import InputBase, { InputBaseProps } from '@material-ui/core/InputBase';
 import Popper from '@material-ui/core/Popper';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import { FormApi, FieldSubscription } from 'final-form';
-import { useField } from 'react-final-form-hooks';
-import * as React from 'react';
-import selectChevron from '../../../theme/assets/selectField/selectChevron.svg';
+
 import { useOpen } from '../../../hooks/open';
-import Image from '../../Image';
+import selectChevron from '../../../theme/assets/selectField/selectChevron.svg';
 import Block from '../../Block';
+import Image from '../../Image';
 import SelectItems from './SelectItems';
 
 export interface Item {

--- a/packages/medulas-react-components/src/components/forms/TextFieldForm/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/TextFieldForm/index.stories.tsx
@@ -1,12 +1,14 @@
-import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 import React from 'react';
-import TextFieldForm from './index';
+
+import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
+
 import { Storybook } from '../../../utils/storybook';
+import Block from '../../Block';
 import Grid, { SizingBreakpoint } from '../../Grid';
 import GridItem from '../../GridItem';
 import Form, { useForm } from '../Form';
-import Block from '../../Block';
+import TextFieldForm from './index';
 
 interface Props {
   readonly name: string;

--- a/packages/medulas-react-components/src/components/forms/TextFieldForm/index.tsx
+++ b/packages/medulas-react-components/src/components/forms/TextFieldForm/index.tsx
@@ -1,7 +1,8 @@
-import MuiTextField, { TextFieldProps } from '@material-ui/core/TextField';
 import { FieldSubscription, FieldValidator, FormApi } from 'final-form';
 import * as React from 'react';
 import { useField } from 'react-final-form-hooks';
+
+import MuiTextField, { TextFieldProps } from '@material-ui/core/TextField';
 
 interface InnerProps {
   name: string;

--- a/packages/medulas-react-components/src/context/ToastProvider/Toast/ToastContent.tsx
+++ b/packages/medulas-react-components/src/context/ToastProvider/Toast/ToastContent.tsx
@@ -1,6 +1,8 @@
-import { IconButton, SnackbarContent, Theme, createStyles, makeStyles } from '@material-ui/core';
 import classNames from 'classnames';
 import * as React from 'react';
+
+import { createStyles, IconButton, makeStyles, SnackbarContent, Theme } from '@material-ui/core';
+
 import Block from '../../../components/Block';
 import Image from '../../../components/Image';
 import Typography from '../../../components/Typography';

--- a/packages/medulas-react-components/src/context/ToastProvider/Toast/index.tsx
+++ b/packages/medulas-react-components/src/context/ToastProvider/Toast/index.tsx
@@ -1,7 +1,9 @@
-import Snackbar, { SnackbarOrigin } from '@material-ui/core/Snackbar';
 import * as React from 'react';
-import ToastContent from './ToastContent';
+
+import Snackbar, { SnackbarOrigin } from '@material-ui/core/Snackbar';
 import SnackbarContent from '@material-ui/core/SnackbarContent';
+
+import ToastContent from './ToastContent';
 
 export enum ToastVariant {
   SUCCESS = 'success',

--- a/packages/medulas-react-components/src/context/ToastProvider/Toast/toast.stories.tsx
+++ b/packages/medulas-react-components/src/context/ToastProvider/Toast/toast.stories.tsx
@@ -1,13 +1,15 @@
-import { storiesOf } from '@storybook/react';
 import * as React from 'react';
+
+import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
+
 import Block from '../../../components/Block';
 import Button from '../../../components/Button';
-import { Storybook } from '../../../utils/storybook';
-import { ToastVariant } from './index';
-import { ToastContext, ToastProvider } from '../index';
 import Typography from '../../../components/Typography';
+import { Storybook } from '../../../utils/storybook';
+import { ToastContext, ToastProvider } from '../index';
+import { ToastVariant } from './index';
 import ToastContent from './ToastContent';
-import { action } from '@storybook/addon-actions';
 
 const ToastStorybook = (): JSX.Element => {
   const { show } = React.useContext(ToastContext);

--- a/packages/medulas-react-components/src/context/ToastProvider/index.tsx
+++ b/packages/medulas-react-components/src/context/ToastProvider/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Toast, ToastVariant } from './Toast';
+
 import { singleton } from '../../utils/singleton';
+import { Toast, ToastVariant } from './Toast';
 
 export interface ToastContextInterface {
   readonly show: (message: string, variant: ToastVariant) => void;

--- a/packages/medulas-react-components/src/react-app-env.d.ts
+++ b/packages/medulas-react-components/src/react-app-env.d.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 /// <reference types="node" />
 /// <reference types="react" />
 /// <reference types="react-dom" />
@@ -40,8 +42,6 @@ declare module '*.webp' {
 }
 
 declare module '*.svg' {
-  import * as React from 'react';
-
   export const ReactComponent: React.SFC<React.SVGProps<SVGSVGElement>>;
 
   const src: string;

--- a/packages/medulas-react-components/src/theme/MedulasThemeProvider.tsx
+++ b/packages/medulas-react-components/src/theme/MedulasThemeProvider.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
-import theme from './utils/mui';
+
 import { ThemeProvider } from '@material-ui/styles';
+
+import theme from './utils/mui';
 
 interface Props {
   readonly injectFonts?: boolean;

--- a/packages/medulas-react-components/src/theme/utils/mui.ts
+++ b/packages/medulas-react-components/src/theme/utils/mui.ts
@@ -1,6 +1,7 @@
 import grey from '@material-ui/core/colors/grey';
 import { createMuiTheme } from '@material-ui/core/styles';
 import { ThemeOptions } from '@material-ui/core/styles/createMuiTheme';
+
 import { lightFont, secondaryColor, white } from './variables';
 
 const theme = createMuiTheme({

--- a/packages/medulas-react-components/src/utils/storybook/index.tsx
+++ b/packages/medulas-react-components/src/utils/storybook/index.tsx
@@ -1,5 +1,6 @@
-import ThemeProvider from '../../theme/MedulasThemeProvider';
 import * as React from 'react';
+
+import ThemeProvider from '../../theme/MedulasThemeProvider';
 
 interface Props {
   readonly children: React.ReactNode;

--- a/packages/sanes-chrome-extension/src/context/PersonaProvider.tsx
+++ b/packages/sanes-chrome-extension/src/context/PersonaProvider.tsx
@@ -1,5 +1,6 @@
 /*global chrome*/
 import * as React from 'react';
+
 import {
   GetPersonaResponse,
   isMessageToForeground,

--- a/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestCallback.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestCallback.ts
@@ -1,4 +1,5 @@
 import { PublicIdentity, UnsignedTransaction } from '@iov/bcp';
+
 import { updateExtensionBadge } from './requestExtensionBadge';
 import { RequestHandler } from './requestHandler';
 import { SenderWhitelist } from './requestSenderWhitelist';

--- a/packages/sanes-chrome-extension/src/extension/background/handlers/externalHandler.unit.spec.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/handlers/externalHandler.unit.spec.ts
@@ -1,5 +1,6 @@
 import { TransactionEncoder } from '@iov/core';
 import { jsonRpcCode, JsonRpcRequest } from '@iov/jsonrpc';
+
 import { withChainsDescribe } from '../../../utils/test/testExecutor';
 import { createPersona, getCreatedPersona } from '../actions/createPersona';
 import * as txsUpdater from '../actions/createPersona/requestAppUpdater';

--- a/packages/sanes-chrome-extension/src/extension/background/handlers/internalHandler.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/handlers/internalHandler.ts
@@ -1,8 +1,8 @@
+import { createAccount } from '../actions/createAccount';
 /*global chrome*/
 import { createPersona } from '../actions/createPersona';
 import { getPersona } from '../actions/getPersona';
 import { MessageToBackground, MessageToBackgroundAction } from '../messages';
-import { createAccount } from '../actions/createAccount';
 
 export function internalHandler(
   message: MessageToBackground,

--- a/packages/sanes-chrome-extension/src/index.tsx
+++ b/packages/sanes-chrome-extension/src/index.tsx
@@ -4,6 +4,7 @@ import MedulasThemeProvider from 'medulas-react-components/lib/theme/MedulasThem
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+
 import { PersonaProvider } from './context/PersonaProvider';
 import { GetPersonaResponse, sendGetPersonaMessage } from './extension/background/messages';
 import Route from './routes';

--- a/packages/sanes-chrome-extension/src/logic/config/codec.ts
+++ b/packages/sanes-chrome-extension/src/logic/config/codec.ts
@@ -1,9 +1,9 @@
 import { Algorithm, ChainConnector } from '@iov/bcp';
-import { HdPaths } from '@iov/keycontrol';
-import { Slip10RawIndex } from '@iov/crypto';
 import { bnsConnector } from '@iov/bns';
-import { liskConnector } from '@iov/lisk';
+import { Slip10RawIndex } from '@iov/crypto';
 import { ethereumConnector } from '@iov/ethereum';
+import { HdPaths } from '@iov/keycontrol';
+import { liskConnector } from '@iov/lisk';
 
 import { CodecString } from './configurationfile';
 

--- a/packages/sanes-chrome-extension/src/logic/persona/accountManager.unit.spec.ts
+++ b/packages/sanes-chrome-extension/src/logic/persona/accountManager.unit.spec.ts
@@ -1,5 +1,6 @@
 import { Algorithm, ChainId } from '@iov/bcp';
 import { HdPaths } from '@iov/core';
+
 import { createUserProfile } from '../user/profile';
 import { AccountManager, AccountManagerChainConfig } from './accountManager';
 

--- a/packages/sanes-chrome-extension/src/logic/persona/persona.ts
+++ b/packages/sanes-chrome-extension/src/logic/persona/persona.ts
@@ -2,27 +2,27 @@ import { ReadonlyDate } from 'readonly-date';
 
 import { Amount, isSendTransaction } from '@iov/bcp';
 import {
-  MultiChainSigner,
-  UserProfile,
-  SigningServerCore,
-  SignAndPostAuthorization,
   GetIdentitiesAuthorization,
   JsonRpcSigningServer,
+  MultiChainSigner,
+  SignAndPostAuthorization,
   SignedAndPosted,
+  SigningServerCore,
+  UserProfile,
 } from '@iov/core';
 import { Bip39, Random } from '@iov/crypto';
-import { JsonRpcResponse, JsonRpcRequest } from '@iov/jsonrpc';
+import { Encoding } from '@iov/encoding';
+import { JsonRpcRequest, JsonRpcResponse } from '@iov/jsonrpc';
 
-import { createUserProfile } from '../user';
 import {
-  chainConnector,
-  getConfigurationFile,
-  codecTypeFromString,
   algorithmForCodec,
+  chainConnector,
+  codecTypeFromString,
+  getConfigurationFile,
   pathBuilderForCodec,
 } from '../config';
+import { createUserProfile } from '../user';
 import { AccountManager, AccountManagerChainConfig } from './accountManager';
-import { Encoding } from '@iov/encoding';
 
 /** Like JsonRpcSigningServer but without functionality to create or shutdown */
 export interface UseOnlyJsonRpcSigningServer {

--- a/packages/sanes-chrome-extension/src/logic/persona/persona.unit.spec.ts
+++ b/packages/sanes-chrome-extension/src/logic/persona/persona.unit.spec.ts
@@ -1,9 +1,9 @@
-import { TokenTicker, PublicIdentity } from '@iov/bcp';
-import { TransactionEncoder, GetIdentitiesAuthorization, SignAndPostAuthorization } from '@iov/core';
+import { PublicIdentity, TokenTicker } from '@iov/bcp';
+import { GetIdentitiesAuthorization, SignAndPostAuthorization, TransactionEncoder } from '@iov/core';
 import { EnglishMnemonic } from '@iov/crypto';
 
-import { Persona } from './persona';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
+import { Persona } from './persona';
 
 withChainsDescribe('Persona', () => {
   const revealAllIdentities: GetIdentitiesAuthorization = async (

--- a/packages/sanes-chrome-extension/src/logic/user/db.ts
+++ b/packages/sanes-chrome-extension/src/logic/user/db.ts
@@ -1,6 +1,7 @@
 import { AbstractLevelDOWN } from 'abstract-leveldown';
 import levelup, { LevelUp } from 'levelup';
 import MemDownConstructor from 'memdown';
+
 import { singleton } from '../../utils/singleton';
 
 export type DB<K, V> = LevelUp<AbstractLevelDOWN<K, V>>;

--- a/packages/sanes-chrome-extension/src/routes/account/components/Empty.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/components/Empty.tsx
@@ -1,8 +1,9 @@
-import * as React from 'react';
-import { makeStyles } from '@material-ui/core';
-import { ListItem, ListItemIcon, ListItemText } from 'medulas-react-components/lib/components/List';
 import Block from 'medulas-react-components/lib/components/Block';
 import Img from 'medulas-react-components/lib/components/Image';
+import { ListItem, ListItemIcon, ListItemText } from 'medulas-react-components/lib/components/List';
+import * as React from 'react';
+
+import { makeStyles } from '@material-ui/core';
 
 interface Props {
   readonly src: string;

--- a/packages/sanes-chrome-extension/src/routes/account/components/ListTxs.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/components/ListTxs.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
 import Block from 'medulas-react-components/lib/components/Block';
 import Hairline from 'medulas-react-components/lib/components/Hairline';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import { List, ListItem, ListItemText } from 'medulas-react-components/lib/components/List';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
 import { ProcessedTx } from '../../../logic/persona';
 import upToDate from '../assets/uptodate.svg';
-import Tx from './Tx';
 import EmptyList from './Empty';
+import Tx from './Tx';
 
 interface Props {
   readonly txs: ReadonlyArray<ProcessedTx>;

--- a/packages/sanes-chrome-extension/src/routes/account/components/Tx/MsgError.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/components/Tx/MsgError.tsx
@@ -1,5 +1,6 @@
-import * as React from 'react';
 import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
 import { elipsify } from '../../../../utils/strings';
 
 interface MsgErrorProps {

--- a/packages/sanes-chrome-extension/src/routes/account/components/Tx/MsgSuccess.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/components/Tx/MsgSuccess.tsx
@@ -1,6 +1,7 @@
-import * as React from 'react';
-import { elipsify } from '../../../../utils/strings';
 import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
+import { elipsify } from '../../../../utils/strings';
 
 interface MsgProps {
   readonly recipient: string;

--- a/packages/sanes-chrome-extension/src/routes/account/components/Tx/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/components/Tx/index.tsx
@@ -1,16 +1,18 @@
+import Block from 'medulas-react-components/lib/components/Block';
+import Hairline from 'medulas-react-components/lib/components/Hairline';
+import Img from 'medulas-react-components/lib/components/Image';
+import * as React from 'react';
+
 import { makeStyles, Theme } from '@material-ui/core';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
-import * as React from 'react';
+
+import { ProcessedTx } from '../../../../logic/persona';
+import { prettyAmount } from '../../../../utils/balances';
 import iconErrorTx from '../../assets/transactionError.svg';
 import iconSendTx from '../../assets/transactionSend.svg';
 import MsgError from './MsgError';
 import Msg from './MsgSuccess';
-import Block from 'medulas-react-components/lib/components/Block';
-import Hairline from 'medulas-react-components/lib/components/Hairline';
-import Img from 'medulas-react-components/lib/components/Image';
-import { prettyAmount } from '../../../../utils/balances';
-import { ProcessedTx } from '../../../../logic/persona';
 
 interface ItemProps {
   readonly item: ProcessedTx;

--- a/packages/sanes-chrome-extension/src/routes/account/index.e2e.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/account/index.e2e.spec.ts
@@ -1,9 +1,10 @@
 import { Browser, Page } from 'puppeteer';
+
 import { closeBrowser, createPage, launchBrowser } from '../../utils/test/e2e';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
+import { sleep } from '../../utils/timer';
 import { submitRecoveryPhraseE2E } from '../restore-account/test/fillRecoveryPhrase';
 import { travelToRestoreAccountStep } from '../restore-account/test/travelToRestoreAccount';
-import { sleep } from '../../utils/timer';
 
 withChainsDescribe('E2E > Account route', () => {
   let browser: Browser;

--- a/packages/sanes-chrome-extension/src/routes/account/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/index.stories.tsx
@@ -1,9 +1,11 @@
-import { storiesOf } from '@storybook/react';
-import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import { ToastProvider } from 'medulas-react-components/lib/context/ToastProvider';
+import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
-import Layout from './index';
+
+import { storiesOf } from '@storybook/react';
+
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
+import Layout from './index';
 
 export const ACCOUNT_STATUS_PAGE = 'Account Status page';
 

--- a/packages/sanes-chrome-extension/src/routes/account/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/index.tsx
@@ -7,6 +7,7 @@ import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
 import { useForm } from 'react-final-form-hooks';
+
 import { PersonaContext } from '../../context/PersonaProvider';
 import { sendCreateAccountMessage } from '../../extension/background/messages';
 import { history } from '../../store/reducers';

--- a/packages/sanes-chrome-extension/src/routes/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/index.tsx
@@ -1,23 +1,24 @@
 import * as React from 'react';
 import { Route, Switch } from 'react-router-dom';
-import Welcome from './welcome';
-import Signup from './signup';
+
+import AccountStatus from './account';
 import Login from './login';
+import {
+  ACCOUNT_STATUS_ROUTE,
+  LOGIN_ROUTE,
+  RECOVERY_PHRASE_ROUTE,
+  RESTORE_ACCOUNT,
+  SHARE_IDENTITY,
+  SIGNUP_ROUTE,
+  TX_REQUEST,
+  WELCOME_ROUTE,
+} from './paths';
 import RecoveryPhrase from './recovery-phrase';
 import RestoreAccount from './restore-account';
 import ShareIdentity from './share-identity';
+import Signup from './signup';
 import TxRequest from './tx-request';
-import AccountStatus from './account';
-import {
-  WELCOME_ROUTE,
-  SIGNUP_ROUTE,
-  LOGIN_ROUTE,
-  RECOVERY_PHRASE_ROUTE,
-  ACCOUNT_STATUS_ROUTE,
-  RESTORE_ACCOUNT,
-  SHARE_IDENTITY,
-  TX_REQUEST,
-} from './paths';
+import Welcome from './welcome';
 
 export const MainRouter = (): JSX.Element => (
   <Switch>

--- a/packages/sanes-chrome-extension/src/routes/login/components/LoginControls.tsx
+++ b/packages/sanes-chrome-extension/src/routes/login/components/LoginControls.tsx
@@ -2,6 +2,7 @@ import Block from 'medulas-react-components/lib/components/Block';
 import Link from 'medulas-react-components/lib/components/Link';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+
 import { RESTORE_ACCOUNT } from '../../paths';
 
 const LoginControls = (): JSX.Element => {

--- a/packages/sanes-chrome-extension/src/routes/login/components/LoginForm.tsx
+++ b/packages/sanes-chrome-extension/src/routes/login/components/LoginForm.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
-import Button from 'medulas-react-components/lib/components/Button';
 import Block from 'medulas-react-components/lib/components/Block';
+import Button from 'medulas-react-components/lib/components/Button';
 import Form, { useForm } from 'medulas-react-components/lib/components/forms/Form';
 import TextFieldForm from 'medulas-react-components/lib/components/forms/TextFieldForm';
+import * as React from 'react';
 
 export const PASSWORD_FIELD = 'passwordInputField';
 

--- a/packages/sanes-chrome-extension/src/routes/login/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/login/index.dom.spec.ts
@@ -1,5 +1,6 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import { aNewStore } from '../../store';
 import { RootState } from '../../store/reducers';
 import { randomString } from '../../utils/test/random';

--- a/packages/sanes-chrome-extension/src/routes/login/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/login/index.stories.tsx
@@ -1,6 +1,8 @@
-import { storiesOf } from '@storybook/react';
-import { SanesStorybook, CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+
+import { CHROME_EXTENSION_ROOT, SanesStorybook } from '../../utils/storybook';
 import Layout from './index';
 
 storiesOf(CHROME_EXTENSION_ROOT, module).add(

--- a/packages/sanes-chrome-extension/src/routes/login/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/login/index.tsx
@@ -3,6 +3,7 @@ import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider';
 import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
 import * as React from 'react';
+
 import { history } from '../../store/reducers';
 import { LOGIN_ROUTE } from '../paths';
 import { PASSWORD_FIELD } from '../signup/components/NewAccountForm';

--- a/packages/sanes-chrome-extension/src/routes/login/test/travelToLogin.ts
+++ b/packages/sanes-chrome-extension/src/routes/login/test/travelToLogin.ts
@@ -1,9 +1,10 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { LOGIN_ROUTE } from '../../paths';
-import { createDom } from '../../../utils/test/dom';
+
 import { history } from '../../../store/reducers';
+import { createDom } from '../../../utils/test/dom';
 import { whenOnNavigatedToRoute } from '../../../utils/test/navigation';
+import { LOGIN_ROUTE } from '../../paths';
 
 export const travelToLogin = async (store: Store): Promise<React.Component> => {
   const dom = createDom(store);

--- a/packages/sanes-chrome-extension/src/routes/recovery-phrase/components/PdfDownload.tsx
+++ b/packages/sanes-chrome-extension/src/routes/recovery-phrase/components/PdfDownload.tsx
@@ -1,5 +1,6 @@
-import * as React from 'react';
 import DownloadButton from 'medulas-react-components/lib/components/Button/Download';
+import * as React from 'react';
+
 import PDFGenerator from '../utils/pdfGenerator';
 
 export interface Props {

--- a/packages/sanes-chrome-extension/src/routes/recovery-phrase/components/ShowRecoveryPhrase.tsx
+++ b/packages/sanes-chrome-extension/src/routes/recovery-phrase/components/ShowRecoveryPhrase.tsx
@@ -1,7 +1,8 @@
-import * as React from 'react';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Block from 'medulas-react-components/lib/components/Block';
 import Back from 'medulas-react-components/lib/components/Button/Back';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
 import PdfDownload from './PdfDownload';
 
 export interface Props {

--- a/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.dom.spec.ts
@@ -1,12 +1,12 @@
-import { Store } from 'redux';
-import { RootState } from '../../store/reducers';
-import { aNewStore } from '../../store';
 import TestUtils from 'react-dom/test-utils';
+import { Store } from 'redux';
+
+import { aNewStore } from '../../store';
+import { RootState } from '../../store/reducers';
 import { whenOnNavigatedToRoute } from '../../utils/test/navigation';
+import { withChainsDescribe } from '../../utils/test/testExecutor';
 import { WELCOME_ROUTE } from '../paths';
 import { travelToRecoveryPhrase } from './test/travelToRecoveryPhrase';
-
-import { withChainsDescribe } from '../../utils/test/testExecutor';
 
 withChainsDescribe('DOM > Feature > Recovery Phrase', () => {
   let store: Store<RootState>;

--- a/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.stories.tsx
@@ -1,8 +1,10 @@
-import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
-import RecoveryPhrase from './index';
+
+import { storiesOf } from '@storybook/react';
+
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
+import RecoveryPhrase from './index';
 
 storiesOf(CHROME_EXTENSION_ROOT, module).add(
   'Recovery Phrase page',

--- a/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
-import ShowRecoveryPhrase from './components/ShowRecoveryPhrase';
-import { RECOVERY_PHRASE_ROUTE } from '../paths';
-import { history } from '../../store/reducers';
+import * as React from 'react';
+
 import { PersonaContext } from '../../context/PersonaProvider';
+import { history } from '../../store/reducers';
+import { RECOVERY_PHRASE_ROUTE } from '../paths';
+import ShowRecoveryPhrase from './components/ShowRecoveryPhrase';
 
 const onBack = (): void => {
   history.goBack();

--- a/packages/sanes-chrome-extension/src/routes/recovery-phrase/test/travelToRecoveryPhrase.ts
+++ b/packages/sanes-chrome-extension/src/routes/recovery-phrase/test/travelToRecoveryPhrase.ts
@@ -1,10 +1,11 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { RECOVERY_PHRASE_ROUTE, WELCOME_ROUTE } from '../../paths';
-import { createDom } from '../../../utils/test/dom';
+
 import { history } from '../../../store/reducers';
+import { createDom } from '../../../utils/test/dom';
 import { whenOnNavigatedToRoute } from '../../../utils/test/navigation';
 import { sleep } from '../../../utils/timer';
+import { RECOVERY_PHRASE_ROUTE, WELCOME_ROUTE } from '../../paths';
 
 export const travelToRecoveryPhrase = async (store: Store): Promise<React.Component> => {
   const dom = createDom(store);

--- a/packages/sanes-chrome-extension/src/routes/restore-account/components/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/components/index.tsx
@@ -1,15 +1,16 @@
-import * as React from 'react';
-import Button from 'medulas-react-components/lib/components/Button';
 import Block from 'medulas-react-components/lib/components/Block';
+import Button from 'medulas-react-components/lib/components/Button';
 import Back from 'medulas-react-components/lib/components/Button/Back';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Form, {
-  useForm,
   FormValues,
+  useForm,
   ValidationError,
 } from 'medulas-react-components/lib/components/forms/Form';
 import TextFieldForm from 'medulas-react-components/lib/components/forms/TextFieldForm';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
 import { RESTORE_ACCOUNT } from '../../paths';
 
 export const RECOVERY_PHRASE = 'recoveryPhraseField';

--- a/packages/sanes-chrome-extension/src/routes/restore-account/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/index.dom.spec.ts
@@ -1,4 +1,5 @@
 import { Store } from 'redux';
+
 import * as messages from '../../extension/background/messages';
 import { aNewStore } from '../../store';
 import { RootState } from '../../store/reducers';

--- a/packages/sanes-chrome-extension/src/routes/restore-account/index.e2e.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/index.e2e.spec.ts
@@ -1,8 +1,9 @@
 import { Browser, Page } from 'puppeteer';
+
+import { closeBrowser, createPage, launchBrowser } from '../../utils/test/e2e';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
-import { launchBrowser, createPage, closeBrowser } from '../../utils/test/e2e';
-import { travelToRestoreAccountStep } from './test/travelToRestoreAccount';
 import { submitRecoveryPhraseE2E } from './test/fillRecoveryPhrase';
+import { travelToRestoreAccountStep } from './test/travelToRestoreAccount';
 
 withChainsDescribe(
   'E2E > Restore Account route',

--- a/packages/sanes-chrome-extension/src/routes/restore-account/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/index.stories.tsx
@@ -1,9 +1,11 @@
-import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
-import RestoreAccountForm from './components';
+
+import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
+
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
+import RestoreAccountForm from './components';
 
 storiesOf(CHROME_EXTENSION_ROOT, module).add(
   'Restore Account page',

--- a/packages/sanes-chrome-extension/src/routes/restore-account/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/index.tsx
@@ -1,5 +1,6 @@
 import { FormValues } from 'medulas-react-components/lib/components/forms/Form';
 import * as React from 'react';
+
 import { PersonaContext } from '../../context/PersonaProvider';
 import { sendCreatePersonaMessage } from '../../extension/background/messages';
 import { history } from '../../store/reducers';

--- a/packages/sanes-chrome-extension/src/routes/restore-account/test/fillRecoveryPhrase.ts
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/test/fillRecoveryPhrase.ts
@@ -1,11 +1,12 @@
+import { Page } from 'puppeteer';
 import TestUtils from 'react-dom/test-utils';
+
 import {
   findRenderedDOMComponentWithId,
   findRenderedE2EComponentWithId,
 } from '../../../utils/test/reactElemFinder';
 import { ACCOUNT_STATUS_ROUTE } from '../../paths';
 import { RECOVERY_PHRASE } from '../components';
-import { Page } from 'puppeteer';
 
 export const submitRecoveryPhrase = async (
   AccountSubmitDom: React.Component,

--- a/packages/sanes-chrome-extension/src/routes/restore-account/test/travelToRestoreAccount.ts
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/test/travelToRestoreAccount.ts
@@ -1,11 +1,12 @@
+import { Page } from 'puppeteer';
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { RESTORE_ACCOUNT, LOGIN_ROUTE } from '../../paths';
-import { createDom } from '../../../utils/test/dom';
+
 import { history } from '../../../store/reducers';
+import { createDom } from '../../../utils/test/dom';
 import { whenOnNavigatedToRoute } from '../../../utils/test/navigation';
-import { Page } from 'puppeteer';
 import { findRenderedE2EComponentWithId } from '../../../utils/test/reactElemFinder';
+import { LOGIN_ROUTE, RESTORE_ACCOUNT } from '../../paths';
 
 export const travelToRestoreAccount = async (store: Store): Promise<React.Component> => {
   const dom = createDom(store);

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Button from 'medulas-react-components/lib/components/Button';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Block from 'medulas-react-components/lib/components/Block';
-import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Button from 'medulas-react-components/lib/components/Button';
 import Back from 'medulas-react-components/lib/components/Button/Back';
-import Form, { useForm, FormValues } from 'medulas-react-components/lib/components/forms/Form';
 import CheckboxField from 'medulas-react-components/lib/components/forms/CheckboxField';
+import Form, { FormValues, useForm } from 'medulas-react-components/lib/components/forms/Form';
+import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
 import { SHARE_IDENTITY } from '../../paths';
 
 const PERMANENT_REJECT = 'permanentRejectField';

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
@@ -1,8 +1,9 @@
-import * as React from 'react';
-import Button from 'medulas-react-components/lib/components/Button';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Block from 'medulas-react-components/lib/components/Block';
+import Button from 'medulas-react-components/lib/components/Button';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
 import { SHARE_IDENTITY } from '../../paths';
 
 export const SHARE_IDENTITY_SHOW = `${SHARE_IDENTITY}_show`;

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.dom.spec.ts
@@ -1,15 +1,16 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { RootState } from '../../store/reducers';
+
 import { aNewStore } from '../../store';
-import { travelToShareIdentity } from './test/travelToShareIdentity';
+import { RootState } from '../../store/reducers';
+import { sleep } from '../../utils/timer';
 import {
+  checkPermanentRejection,
   clickOnBackButton,
   clickOnRejectButton,
-  checkPermanentRejection,
   confirmRejectButton,
 } from './test/operateShareIdentity';
-import { sleep } from '../../utils/timer';
+import { travelToShareIdentity } from './test/travelToShareIdentity';
 
 describe('DOM > Feature > Share Identity', (): void => {
   let store: Store<RootState>;

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
@@ -1,12 +1,14 @@
-import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
-import ShowRequest from './components/ShowRequest';
-import RejectRequest from './components/RejectRequest';
+
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
+import { storiesOf } from '@storybook/react';
+
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 import { ACCOUNT_STATUS_PAGE } from '../account/index.stories';
+import RejectRequest from './components/RejectRequest';
+import ShowRequest from './components/ShowRequest';
 
 const SHARE_IDENTITY_PATH = `${CHROME_EXTENSION_ROOT}/Share Identity`;
 const SHOW_REQUEST_PAGE = 'Show Request page';

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import RejectRequest from './components/RejectRequest';
 import ShowRequest from './components/ShowRequest';
 

--- a/packages/sanes-chrome-extension/src/routes/share-identity/test/operateShareIdentity.ts
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/test/operateShareIdentity.ts
@@ -1,7 +1,8 @@
 import TestUtils from 'react-dom/test-utils';
+
 import { findRenderedDOMComponentWithId } from '../../../utils/test/reactElemFinder';
-import { SHARE_IDENTITY_SHOW } from '../components/ShowRequest';
 import { SHARE_IDENTITY_REJECT } from '../components/RejectRequest';
+import { SHARE_IDENTITY_SHOW } from '../components/ShowRequest';
 
 export const clickOnRejectButton = async (ShareIdentityDom: React.Component): Promise<void> => {
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(ShareIdentityDom, 'button');

--- a/packages/sanes-chrome-extension/src/routes/share-identity/test/travelToShareIdentity.ts
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/test/travelToShareIdentity.ts
@@ -1,9 +1,10 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { SHARE_IDENTITY } from '../../paths';
-import { createDom } from '../../../utils/test/dom';
+
 import { history } from '../../../store/reducers';
+import { createDom } from '../../../utils/test/dom';
 import { whenOnNavigatedToRoute } from '../../../utils/test/navigation';
+import { SHARE_IDENTITY } from '../../paths';
 
 export const travelToShareIdentity = async (store: Store): Promise<React.Component> => {
   const dom = createDom(store);

--- a/packages/sanes-chrome-extension/src/routes/signup/components/NewAccountForm.tsx
+++ b/packages/sanes-chrome-extension/src/routes/signup/components/NewAccountForm.tsx
@@ -1,14 +1,15 @@
-import * as React from 'react';
+import Block from 'medulas-react-components/lib/components/Block';
 import Button from 'medulas-react-components/lib/components/Button';
 import Back from 'medulas-react-components/lib/components/Button/Back';
-import Block from 'medulas-react-components/lib/components/Block';
 import Form, {
-  useForm,
   FormValues,
+  useForm,
   ValidationError,
 } from 'medulas-react-components/lib/components/forms/Form';
 import TextFieldForm from 'medulas-react-components/lib/components/forms/TextFieldForm';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import * as React from 'react';
+
 import { SIGNUP_ROUTE } from '../../paths';
 
 export const ACCOUNT_NAME_FIELD = 'accountNameField';

--- a/packages/sanes-chrome-extension/src/routes/signup/components/SecurityHintForm.tsx
+++ b/packages/sanes-chrome-extension/src/routes/signup/components/SecurityHintForm.tsx
@@ -1,15 +1,16 @@
-import * as React from 'react';
-import Button from 'medulas-react-components/lib/components/Button';
 import Block from 'medulas-react-components/lib/components/Block';
+import Button from 'medulas-react-components/lib/components/Button';
 import Back from 'medulas-react-components/lib/components/Button/Back';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Form, {
-  useForm,
   FormValues,
+  useForm,
   ValidationError,
 } from 'medulas-react-components/lib/components/forms/Form';
 import TextFieldForm from 'medulas-react-components/lib/components/forms/TextFieldForm';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
 import { SIGNUP_ROUTE } from '../../paths';
 
 export const SECURITY_HINT = 'securityHintField';

--- a/packages/sanes-chrome-extension/src/routes/signup/components/ShowPhraseForm.tsx
+++ b/packages/sanes-chrome-extension/src/routes/signup/components/ShowPhraseForm.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Block from 'medulas-react-components/lib/components/Block';
 import Button from 'medulas-react-components/lib/components/Button';
 import Back from 'medulas-react-components/lib/components/Button/Back';
+import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import Switch from 'medulas-react-components/lib/components/Switch';
 import Tooltip from 'medulas-react-components/lib/components/Tooltip';
-import PageLayout from 'medulas-react-components/lib/components/PageLayout';
-import { SIGNUP_ROUTE } from '../../paths';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
 import { PersonaContext } from '../../../context/PersonaProvider';
+import { SIGNUP_ROUTE } from '../../paths';
 
 export const SECOND_STEP_SIGNUP_ROUTE = `${SIGNUP_ROUTE}2`;
 

--- a/packages/sanes-chrome-extension/src/routes/signup/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/signup/index.dom.spec.ts
@@ -1,4 +1,5 @@
 import { Store } from 'redux';
+
 import * as messages from '../../extension/background/messages';
 import { aNewStore } from '../../store';
 import { RootState } from '../../store/reducers';

--- a/packages/sanes-chrome-extension/src/routes/signup/index.e2e.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/signup/index.e2e.spec.ts
@@ -1,9 +1,10 @@
 import { Browser, Page } from 'puppeteer';
-import { travelToSignupNewAccountStep } from './test/travelToSignup';
-import { submitAccountFormE2E, handlePassPhrase2E, handleSecurityHintE2E } from './test/fillSignupForm';
+
+import { closeBrowser, createPage, launchBrowser } from '../../utils/test/e2e';
 import { randomString } from '../../utils/test/random';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
-import { launchBrowser, createPage, closeBrowser } from '../../utils/test/e2e';
+import { handlePassPhrase2E, handleSecurityHintE2E, submitAccountFormE2E } from './test/fillSignupForm';
+import { travelToSignupNewAccountStep } from './test/travelToSignup';
 
 withChainsDescribe(
   'DOM > Signup route',

--- a/packages/sanes-chrome-extension/src/routes/signup/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/signup/index.stories.tsx
@@ -1,11 +1,13 @@
-import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
-import NewAccountForm from './components/NewAccountForm';
-import ShowPhraseForm from './components/ShowPhraseForm';
-import SecurityHintForm from './components/SecurityHintForm';
+
+import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
+
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
+import NewAccountForm from './components/NewAccountForm';
+import SecurityHintForm from './components/SecurityHintForm';
+import ShowPhraseForm from './components/ShowPhraseForm';
 
 storiesOf(`${CHROME_EXTENSION_ROOT}/Signup`, module)
   .add(

--- a/packages/sanes-chrome-extension/src/routes/signup/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/signup/index.tsx
@@ -1,5 +1,6 @@
 import { FormValues } from 'medulas-react-components/lib/components/forms/Form';
 import * as React from 'react';
+
 import { PersonaContext } from '../../context/PersonaProvider';
 import { sendCreatePersonaMessage } from '../../extension/background/messages';
 import { history } from '../../store/reducers';

--- a/packages/sanes-chrome-extension/src/routes/signup/test/fillSignupForm.ts
+++ b/packages/sanes-chrome-extension/src/routes/signup/test/fillSignupForm.ts
@@ -1,15 +1,16 @@
+import { Page } from 'puppeteer';
 import TestUtils from 'react-dom/test-utils';
+
+import { getHintPhrase } from '../../../utils/localstorage/hint';
 import { randomString } from '../../../utils/test/random';
-import { SECOND_STEP_SIGNUP_ROUTE } from '../components/ShowPhraseForm';
 import {
   findRenderedDOMComponentWithId,
   findRenderedE2EComponentWithId,
 } from '../../../utils/test/reactElemFinder';
-import { SECURITY_HINT_STEP_SIGNUP_ROUTE, SECURITY_HINT } from '../components/SecurityHintForm';
 import { sleep } from '../../../utils/timer';
-import { getHintPhrase } from '../../../utils/localstorage/hint';
-import { Page } from 'puppeteer';
-import { ACCOUNT_NAME_FIELD, PASSWORD_FIELD, PASSWORD_CONFIRM_FIELD } from '../components/NewAccountForm';
+import { ACCOUNT_NAME_FIELD, PASSWORD_CONFIRM_FIELD, PASSWORD_FIELD } from '../components/NewAccountForm';
+import { SECURITY_HINT, SECURITY_HINT_STEP_SIGNUP_ROUTE } from '../components/SecurityHintForm';
+import { SECOND_STEP_SIGNUP_ROUTE } from '../components/ShowPhraseForm';
 
 export const submitAccountFormE2E = async (
   page: Page,

--- a/packages/sanes-chrome-extension/src/routes/signup/test/travelToSignup.ts
+++ b/packages/sanes-chrome-extension/src/routes/signup/test/travelToSignup.ts
@@ -1,12 +1,13 @@
+import { Page } from 'puppeteer';
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { SIGNUP_ROUTE } from '../../paths';
-import { createDom } from '../../../utils/test/dom';
+
 import { history } from '../../../store/reducers';
+import { createDom } from '../../../utils/test/dom';
 import { whenOnNavigatedToRoute } from '../../../utils/test/navigation';
-import { Page } from 'puppeteer';
-import { FIRST_STEP_SIGNUP_ROUTE } from '../components/NewAccountForm';
 import { findRenderedE2EComponentWithId } from '../../../utils/test/reactElemFinder';
+import { SIGNUP_ROUTE } from '../../paths';
+import { FIRST_STEP_SIGNUP_ROUTE } from '../components/NewAccountForm';
 
 export const travelToSignup = async (store: Store): Promise<React.Component> => {
   const dom = createDom(store);

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/RejectRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/RejectRequest.tsx
@@ -7,6 +7,7 @@ import Hairline from 'medulas-react-components/lib/components/Hairline';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+
 import { TX_REQUEST } from '../../paths';
 
 const PERMANENT_REJECT = 'permanentRejectField';

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Button from 'medulas-react-components/lib/components/Button';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Block from 'medulas-react-components/lib/components/Block';
-import PageLayout from 'medulas-react-components/lib/components/PageLayout';
-import { TX_REQUEST } from '../../paths';
+import Button from 'medulas-react-components/lib/components/Button';
 import Hairline from 'medulas-react-components/lib/components/Hairline';
+import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
+import { TX_REQUEST } from '../../paths';
 
 export const TX_REQUEST_SHOW = `${TX_REQUEST}_show`;
 

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.dom.spec.ts
@@ -1,15 +1,16 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { RootState } from '../../store/reducers';
+
 import { aNewStore } from '../../store';
-import { travelToTXRequest } from './test/travelToTXRequest';
+import { RootState } from '../../store/reducers';
+import { sleep } from '../../utils/timer';
 import {
+  checkPermanentRejection,
   clickOnBackButton,
   clickOnRejectButton,
-  checkPermanentRejection,
   confirmRejectButton,
 } from './test/operateTXRequest';
-import { sleep } from '../../utils/timer';
+import { travelToTXRequest } from './test/travelToTXRequest';
 
 describe('DOM > Feature > Transaction Request', (): void => {
   let store: Store<RootState>;

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.stories.tsx
@@ -1,12 +1,14 @@
-import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
-import ShowRequest from './components/ShowRequest';
-import RejectRequest from './components/RejectRequest';
+
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
+import { storiesOf } from '@storybook/react';
+
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 import { ACCOUNT_STATUS_PAGE } from '../account/index.stories';
+import RejectRequest from './components/RejectRequest';
+import ShowRequest from './components/ShowRequest';
 
 const TX_REQUEST_PATH = `${CHROME_EXTENSION_ROOT}/Transaction Request`;
 const SHOW_REQUEST_PAGE = 'Show Request page';

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import RejectRequest from './components/RejectRequest';
 import ShowRequest from './components/ShowRequest';
 

--- a/packages/sanes-chrome-extension/src/routes/tx-request/test/operateTXRequest.ts
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/test/operateTXRequest.ts
@@ -1,7 +1,8 @@
 import TestUtils from 'react-dom/test-utils';
+
 import { findRenderedDOMComponentWithId } from '../../../utils/test/reactElemFinder';
-import { TX_REQUEST_SHOW } from '../components/ShowRequest';
 import { TX_REQUEST_REJECT } from '../components/RejectRequest';
+import { TX_REQUEST_SHOW } from '../components/ShowRequest';
 
 export const clickOnRejectButton = async (TXRequestDom: React.Component): Promise<void> => {
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(TXRequestDom, 'button');

--- a/packages/sanes-chrome-extension/src/routes/tx-request/test/travelToTXRequest.ts
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/test/travelToTXRequest.ts
@@ -1,9 +1,10 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { TX_REQUEST } from '../../paths';
-import { createDom } from '../../../utils/test/dom';
+
 import { history } from '../../../store/reducers';
+import { createDom } from '../../../utils/test/dom';
 import { whenOnNavigatedToRoute } from '../../../utils/test/navigation';
+import { TX_REQUEST } from '../../paths';
 
 export const travelToTXRequest = async (store: Store): Promise<React.Component> => {
   const dom = createDom(store);

--- a/packages/sanes-chrome-extension/src/routes/welcome/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/welcome/index.dom.spec.ts
@@ -1,11 +1,12 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { WELCOME_ROUTE, LOGIN_ROUTE, SIGNUP_ROUTE, RESTORE_ACCOUNT } from '../paths';
+
+import { aNewStore } from '../../store';
 import { history, RootState } from '../../store/reducers';
 import { createDom } from '../../utils/test/dom';
-import { aNewStore } from '../../store';
 import { whenOnNavigatedToRoute } from '../../utils/test/navigation';
 import { sleep } from '../../utils/timer';
+import { LOGIN_ROUTE, RESTORE_ACCOUNT, SIGNUP_ROUTE, WELCOME_ROUTE } from '../paths';
 
 describe('DOM > Feature > Welcome', () => {
   let store: Store<RootState>;

--- a/packages/sanes-chrome-extension/src/routes/welcome/index.e2e.spec.tsx
+++ b/packages/sanes-chrome-extension/src/routes/welcome/index.e2e.spec.tsx
@@ -1,6 +1,7 @@
 import { Browser, Page } from 'puppeteer';
+
+import { closeBrowser, createPage, launchBrowser } from '../../utils/test/e2e';
 import { WELCOME_ROUTE } from '../paths';
-import { launchBrowser, createPage, closeBrowser } from '../../utils/test/e2e';
 
 describe('DOM > Welcome route', (): void => {
   let browser: Browser;

--- a/packages/sanes-chrome-extension/src/routes/welcome/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/welcome/index.stories.tsx
@@ -1,8 +1,10 @@
-import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
-import Layout from './index';
+
+import { storiesOf } from '@storybook/react';
+
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
+import Layout from './index';
 
 storiesOf(CHROME_EXTENSION_ROOT, module).add(
   'Welcome page',

--- a/packages/sanes-chrome-extension/src/routes/welcome/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/welcome/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Button from 'medulas-react-components/lib/components/Button';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Block from 'medulas-react-components/lib/components/Block';
+import Button from 'medulas-react-components/lib/components/Button';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
 import { history } from '../../store/reducers';
-import { SIGNUP_ROUTE, LOGIN_ROUTE, WELCOME_ROUTE, RESTORE_ACCOUNT } from '../paths';
+import { LOGIN_ROUTE, RESTORE_ACCOUNT, SIGNUP_ROUTE, WELCOME_ROUTE } from '../paths';
 
 const createNewAccount = (): void => {
   history.push(SIGNUP_ROUTE);

--- a/packages/sanes-chrome-extension/src/store/index.ts
+++ b/packages/sanes-chrome-extension/src/store/index.ts
@@ -1,6 +1,7 @@
 import { routerMiddleware } from 'connected-react-router';
-import { createStore, applyMiddleware, compose, Middleware, Store } from 'redux';
+import { applyMiddleware, compose, createStore, Middleware, Store } from 'redux';
 import thunk from 'redux-thunk';
+
 import { history, reducer, RootState } from './reducers';
 
 const middlewares: ReadonlyArray<Middleware> = [thunk, routerMiddleware(history)];

--- a/packages/sanes-chrome-extension/src/store/reducers/index.ts
+++ b/packages/sanes-chrome-extension/src/store/reducers/index.ts
@@ -1,6 +1,5 @@
-import { createBrowserHistory } from 'history';
 import { connectRouter } from 'connected-react-router';
-import { History } from 'history';
+import { createBrowserHistory, History } from 'history';
 import { combineReducers } from 'redux';
 import { StateType } from 'typesafe-actions';
 

--- a/packages/sanes-chrome-extension/src/theme/globalStyles.ts
+++ b/packages/sanes-chrome-extension/src/theme/globalStyles.ts
@@ -1,6 +1,7 @@
-import makeStyles from 'medulas-react-components/lib/theme/utils/styles';
 import theme from 'medulas-react-components/lib/theme/utils/mui';
-import { EXTENSION_WIDTH, EXTENSION_HEIGHT } from './constants';
+import makeStyles from 'medulas-react-components/lib/theme/utils/styles';
+
+import { EXTENSION_HEIGHT, EXTENSION_WIDTH } from './constants';
 
 export const globalStyles = makeStyles({
   '@global': {

--- a/packages/sanes-chrome-extension/src/utils/balances/index.ts
+++ b/packages/sanes-chrome-extension/src/utils/balances/index.ts
@@ -1,5 +1,6 @@
-import { Amount, TokenTicker } from '@iov/bcp';
 import { Omit } from 'react-router';
+
+import { Amount, TokenTicker } from '@iov/bcp';
 
 export type Figures = Omit<Amount, 'tokenTicker'>;
 

--- a/packages/sanes-chrome-extension/src/utils/storybook/index.tsx
+++ b/packages/sanes-chrome-extension/src/utils/storybook/index.tsx
@@ -1,10 +1,11 @@
-import { Storybook } from 'medulas-react-components/lib/utils/storybook';
-import { ToastProvider } from 'medulas-react-components/lib/context/ToastProvider';
-import { Provider } from 'react-redux';
-import { createMemoryHistory, History } from 'history';
 import { ConnectedRouter, connectRouter } from 'connected-react-router';
-import { createStore, combineReducers } from 'redux';
+import { createMemoryHistory, History } from 'history';
+import { ToastProvider } from 'medulas-react-components/lib/context/ToastProvider';
+import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import * as React from 'react';
+import { Provider } from 'react-redux';
+import { combineReducers, createStore } from 'redux';
+
 import { PersonaProvider } from '../../context/PersonaProvider';
 
 export const CHROME_EXTENSION_ROOT = 'Extension';

--- a/packages/sanes-chrome-extension/src/utils/test/dom.tsx
+++ b/packages/sanes-chrome-extension/src/utils/test/dom.tsx
@@ -1,13 +1,14 @@
 import { ConnectedRouter } from 'connected-react-router';
-import * as React from 'react';
-import MedulasThemeProvider from 'medulas-react-components/lib/theme/MedulasThemeProvider';
-import TestUtils from 'react-dom/test-utils';
 import { ToastProvider } from 'medulas-react-components/lib/context/ToastProvider';
+import MedulasThemeProvider from 'medulas-react-components/lib/theme/MedulasThemeProvider';
+import * as React from 'react';
+import TestUtils from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { Store } from 'redux';
+
+import { PersonaProvider } from '../../context/PersonaProvider';
 import Route from '../../routes';
 import { history } from '../../store/reducers';
-import { PersonaProvider } from '../../context/PersonaProvider';
 
 export const createDom = (store: Store): React.Component =>
   TestUtils.renderIntoDocument(

--- a/packages/sanes-chrome-extension/src/utils/test/e2e.ts
+++ b/packages/sanes-chrome-extension/src/utils/test/e2e.ts
@@ -1,4 +1,5 @@
-import puppeteer, { Page, Browser } from 'puppeteer';
+import puppeteer, { Browser, Page } from 'puppeteer';
+
 import { EXTENSION_HEIGHT, EXTENSION_WIDTH } from '../../theme/constants';
 
 export function launchBrowser(slowMo: number = 0): Promise<Browser> {

--- a/packages/sanes-chrome-extension/src/utils/test/reactElemFinder.ts
+++ b/packages/sanes-chrome-extension/src/utils/test/reactElemFinder.ts
@@ -1,5 +1,5 @@
-import TestUtils from 'react-dom/test-utils';
 import { Page } from 'puppeteer';
+import TestUtils from 'react-dom/test-utils';
 
 const MAX_TIMES_EXECUTED = 35;
 const INTERVAL = 500;


### PR DESCRIPTION
**Description**
The goal of this PR is to discuss whether [TypeScript Import Sorter](https://marketplace.visualstudio.com/items?itemName=mike-co.import-sorter) should be used in order to automatically sort the imports statements of the project or not, [as previously discussed on PR#179](https://github.com/iov-one/ponferrada/pull/179#discussion_r283741231).

The extension has been tested as-is without any kind of configuration. It has also been tested that Sort on Save is available and reliable.

Below you can find a before/after example for *bierzo-wallet/src/routes/payment/index.tsx*.

**Current behaviour with Visual Studio Code's Organize Imports command:**
```typescript
import { Theme } from '@material-ui/core';
import { makeStyles } from '@material-ui/styles';
import Block from 'medulas-react-components/lib/components/Block';
import Button from 'medulas-react-components/lib/components/Button';
import Form, { useForm } from 'medulas-react-components/lib/components/forms/Form';
import React from 'react';
import CurrencyToSend from './components/CurrencyToSend';
import ReceiverAddress from './components/ReceiverAddress';
import TextNote from './components/TextNote';
```
**Proposed behaviour with TypeScript Import Sorter extension for Visual Studio Code:**
```typescript
import Block from 'medulas-react-components/lib/components/Block';
import Button from 'medulas-react-components/lib/components/Button';
import Form, { useForm } from 'medulas-react-components/lib/components/forms/Form';
import React from 'react';

import { Theme } from '@material-ui/core';
import { makeStyles } from '@material-ui/styles';

import CurrencyToSend from './components/CurrencyToSend';
import ReceiverAddress from './components/ReceiverAddress';
import TextNote from './components/TextNote';
```