### PR TITLE
Feature - Redirect requests to their views

### DIFF
--- a/packages/sanes-chrome-extension/src/context/RequestProvider.tsx
+++ b/packages/sanes-chrome-extension/src/context/RequestProvider.tsx
@@ -9,10 +9,12 @@ type Requests = ReadonlyArray<Request>;
 
 export interface RequestContextInterface {
   readonly requests: Requests;
+  readonly firstRequest: Request | undefined;
 }
 
 export const RequestContext = React.createContext<RequestContextInterface>({
   requests: [],
+  firstRequest: undefined,
 });
 
 interface Props {
@@ -51,6 +53,7 @@ export const RequestProvider = ({ children, initialRequests }: Props): JSX.Eleme
 
   const requestContextValue = {
     requests,
+    firstRequest: requests.length > 0 ? requests[0] : undefined,
   };
 
   return <RequestContext.Provider value={requestContextValue}>{children}</RequestContext.Provider>;

--- a/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestCallback.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestCallback.ts
@@ -19,6 +19,7 @@ function isRequestMeta(data: unknown): data is RequestMeta {
 
 async function requestCallback<T>(
   reason: string,
+  type: 'getIdentities' | 'signAndPost',
   meta: any, // eslint-disable-line
   acceptResponse: T,
   rejectResponse: T,
@@ -46,7 +47,7 @@ async function requestCallback<T>(
       resolve(rejectResponse);
     };
 
-    RequestHandler.add({ reason, sender: senderUrl, accept, reject });
+    RequestHandler.add({ reason, type, sender: senderUrl, accept, reject });
     updateExtensionBadge(RequestHandler.requests().length);
     requestUpdater();
   });
@@ -57,7 +58,7 @@ export async function getIdentitiesCallback(
   matchingIdentities: ReadonlyArray<PublicIdentity>,
   meta: any, // eslint-disable-line
 ): Promise<ReadonlyArray<PublicIdentity>> {
-  return requestCallback(reason, meta, matchingIdentities, []);
+  return requestCallback(reason, 'getIdentities', meta, matchingIdentities, []);
 }
 
 export async function signAndPostCallback(
@@ -65,5 +66,5 @@ export async function signAndPostCallback(
   _transaction: UnsignedTransaction,
   meta: any, // eslint-disable-line
 ): Promise<boolean> {
-  return requestCallback(reason, meta, true, false);
+  return requestCallback(reason, 'signAndPost', meta, true, false);
 }

--- a/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestHandler.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestHandler.ts
@@ -1,4 +1,7 @@
+import { Omit } from '@material-ui/core';
+
 export interface Request {
+  readonly id: number;
   readonly type: 'getIdentities' | 'signAndPost';
   readonly reason: string;
   readonly sender: string;
@@ -8,9 +11,11 @@ export interface Request {
 
 export class RequestHandler {
   private static instance: Request[] = [];
+  private static counter = 0;
 
   public static load(): void {
     RequestHandler.instance = [];
+    RequestHandler.counter = 0;
   }
 
   public static requests(): Request[] {
@@ -37,7 +42,11 @@ export class RequestHandler {
     }
   }
 
-  public static add(req: Request): number {
-    return RequestHandler.instance.push(req);
+  // TODO use Omit included in TS when upgrade to 3.5
+  public static add(req: Omit<Request, 'id'>): number {
+    const size = RequestHandler.instance.push({ ...req, id: RequestHandler.counter });
+    RequestHandler.counter = RequestHandler.counter + 1;
+
+    return size;
   }
 }

--- a/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestHandler.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestHandler.ts
@@ -1,4 +1,5 @@
 export interface Request {
+  readonly type: 'getIdentities' | 'signAndPost';
   readonly reason: string;
   readonly sender: string;
   readonly accept: () => void;

--- a/packages/sanes-chrome-extension/src/routes/requests/components/RequestList.tsx
+++ b/packages/sanes-chrome-extension/src/routes/requests/components/RequestList.tsx
@@ -38,7 +38,7 @@ function buildClickHandlerFrom(request: Request): () => void {
     history.push({
       pathname,
       state: {
-        [REQUEST_FIELD]: request,
+        [REQUEST_FIELD]: request.id,
       },
     });
 }

--- a/packages/sanes-chrome-extension/src/routes/requests/components/RequestList.tsx
+++ b/packages/sanes-chrome-extension/src/routes/requests/components/RequestList.tsx
@@ -61,6 +61,7 @@ const RequestList = ({ requests }: Props): JSX.Element => {
           const first = index === 0;
           const firstElemClass = first ? classes.first : undefined;
           const onRequestClick = buildClickHandlerFrom(req);
+          const text = req.type === 'getIdentities' ? 'Get Identities Request' : 'Sign Request';
 
           return (
             <React.Fragment>
@@ -71,7 +72,7 @@ const RequestList = ({ requests }: Props): JSX.Element => {
                 onClick={first ? onRequestClick : undefined}
               >
                 <ListItemText
-                  primary="Type of request"
+                  primary={text}
                   secondary={req.reason}
                   secondaryTypographyProps={secondaryProps}
                 />

--- a/packages/sanes-chrome-extension/src/routes/requests/components/RequestList.tsx
+++ b/packages/sanes-chrome-extension/src/routes/requests/components/RequestList.tsx
@@ -1,4 +1,5 @@
 import { makeStyles, Theme } from '@material-ui/core';
+import { TypographyProps } from '@material-ui/core/Typography';
 import CompareArrows from '@material-ui/icons/CompareArrows';
 import Avatar from 'medulas-react-components/lib/components/Avatar';
 import Block from 'medulas-react-components/lib/components/Block';
@@ -7,6 +8,8 @@ import { List, ListItem, ListItemAvatar, ListItemText } from 'medulas-react-comp
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
 import { Request } from '../../../extension/background/actions/createPersona/requestHandler';
+import { history } from '../../../store/reducers';
+import { SHARE_IDENTITY, TX_REQUEST } from '../../paths';
 
 interface Props {
   readonly requests: ReadonlyArray<Request>;
@@ -26,9 +29,23 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+export const REQUEST_FIELD = 'req';
+
+function buildClickHandlerFrom(request: Request): () => void {
+  const pathname = request.type === 'getIdentities' ? SHARE_IDENTITY : TX_REQUEST;
+
+  return () =>
+    history.push({
+      pathname,
+      state: {
+        [REQUEST_FIELD]: request,
+      },
+    });
+}
+
 const RequestList = ({ requests }: Props): JSX.Element => {
   const classes = useStyles();
-  const secondaryProps = {
+  const secondaryProps: TypographyProps = {
     color: 'textPrimary',
   };
 
@@ -43,10 +60,16 @@ const RequestList = ({ requests }: Props): JSX.Element => {
         {requests.map((req: Request, index: number) => {
           const first = index === 0;
           const firstElemClass = first ? classes.first : undefined;
+          const onRequestClick = buildClickHandlerFrom(req);
 
           return (
             <React.Fragment>
-              <ListItem key={`${index}`} className={firstElemClass} disabled={!first}>
+              <ListItem
+                key={`${index}`}
+                className={firstElemClass}
+                disabled={!first}
+                onClick={first ? onRequestClick : undefined}
+              >
                 <ListItemText
                   primary="Type of request"
                   secondary={req.reason}

--- a/packages/sanes-chrome-extension/src/routes/requests/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/requests/index.tsx
@@ -1,11 +1,35 @@
+import { Location } from 'history';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import Typography from 'medulas-react-components/lib/components/Typography';
+import { ToastContextInterface } from 'medulas-react-components/lib/context/ToastProvider';
+import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
 import * as React from 'react';
 import { RequestContext } from '../../context/RequestProvider';
+import { Request } from '../../extension/background/actions/createPersona/requestHandler';
 import { history } from '../../store/reducers';
 import { ACCOUNT_STATUS_ROUTE, REQUEST_ROUTE } from '../paths';
-import RequestList from './components/RequestList';
+import RequestList, { REQUEST_FIELD } from './components/RequestList';
 
+function getIdFrom(location: Location): number | undefined {
+  if (!location || !location.state) {
+    return undefined;
+  }
+
+  return location.state[REQUEST_FIELD];
+}
+
+export function checkRequest(
+  request: Request | undefined,
+  location: Location,
+  toast: ToastContextInterface,
+): void {
+  const expectedId = getIdFrom(location);
+
+  if (!request || typeof expectedId === undefined || expectedId !== request.id) {
+    toast.show('Error: Request not identified', ToastVariant.ERROR);
+    history.push(REQUEST_ROUTE);
+  }
+}
 const Requests = (): JSX.Element => {
   const requestContext = React.useContext(RequestContext);
   const { requests } = requestContext;

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.dom.spec.ts
@@ -1,15 +1,16 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { RootState } from '../../store/reducers';
+import { Request } from '../../extension/background/actions/createPersona/requestHandler';
 import { aNewStore } from '../../store';
-import { travelToShareIdentity } from './test/travelToShareIdentity';
+import { RootState } from '../../store/reducers';
+import { sleep } from '../../utils/timer';
 import {
+  checkPermanentRejection,
   clickOnBackButton,
   clickOnRejectButton,
-  checkPermanentRejection,
   confirmRejectButton,
 } from './test/operateShareIdentity';
-import { sleep } from '../../utils/timer';
+import { travelToShareIdentity } from './test/travelToShareIdentity';
 
 describe('DOM > Feature > Share Identity', (): void => {
   let store: Store<RootState>;
@@ -17,8 +18,18 @@ describe('DOM > Feature > Share Identity', (): void => {
 
   beforeEach(async () => {
     store = aNewStore();
-    identityDOM = await travelToShareIdentity(store);
-  });
+    const requests: ReadonlyArray<Request> = [
+      {
+        id: 1,
+        type: 'getIdentities',
+        reason: 'Test get Identities',
+        sender: 'http://finnex.com',
+        accept: jest.fn(),
+        reject: jest.fn(),
+      },
+    ];
+    identityDOM = await travelToShareIdentity(store, requests);
+  }, 250000);
 
   it('should accept incoming request and redirect to account status view', async (): Promise<void> => {
     const inputs = TestUtils.scryRenderedDOMComponentsWithTag(identityDOM, 'button');

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
@@ -1,19 +1,47 @@
+import { Location } from 'history';
+import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider';
+import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
 import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router';
+import { RequestContext } from '../../context/RequestProvider';
+import { history } from '../../store/reducers';
+import { REQUEST_ROUTE } from '../paths';
+import { REQUEST_FIELD } from '../requests/components/RequestList';
 import RejectRequest from './components/RejectRequest';
 import ShowRequest from './components/ShowRequest';
 
-const ShareIdentity = (): JSX.Element => {
+function getIdFrom(location: Location): number | undefined {
+  if (!location || !location.state) {
+    return undefined;
+  }
+
+  return location.state[REQUEST_FIELD];
+}
+
+const ShareIdentity = ({ location }: RouteComponentProps): JSX.Element => {
   const [action, setAction] = React.useState<'show' | 'reject'>('show');
+  const toast = React.useContext(ToastContext);
+  const requestContext = React.useContext(RequestContext);
+
+  const request = requestContext.firstRequest;
+  const expectedId = getIdFrom(location);
+
+  if (!request || typeof expectedId === undefined || expectedId !== request.id) {
+    toast.show('Error: Request not identified', ToastVariant.ERROR);
+    history.push(REQUEST_ROUTE);
+  }
 
   const showRequestView = (): void => setAction('show');
   const showRejectView = (): void => setAction('reject');
 
   const onAcceptRequest = (): void => {
-    console.log('Accept request');
+    request!.accept(); // eslint-disable-line
+    history.push(REQUEST_ROUTE);
   };
 
   const onRejectRequest = (permanent: boolean): void => {
-    console.log(`Reject request. Permanent ${permanent ? 'yes' : 'no'}`);
+    request!.reject(permanent); // eslint-disable-line
+    history.push(REQUEST_ROUTE);
   };
 
   return (
@@ -24,4 +52,4 @@ const ShareIdentity = (): JSX.Element => {
   );
 };
 
-export default ShareIdentity;
+export default withRouter(ShareIdentity);

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
@@ -1,22 +1,12 @@
-import { Location } from 'history';
 import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider';
-import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { RequestContext } from '../../context/RequestProvider';
 import { history } from '../../store/reducers';
 import { REQUEST_ROUTE } from '../paths';
-import { REQUEST_FIELD } from '../requests/components/RequestList';
+import { checkRequest } from '../requests';
 import RejectRequest from './components/RejectRequest';
 import ShowRequest from './components/ShowRequest';
-
-function getIdFrom(location: Location): number | undefined {
-  if (!location || !location.state) {
-    return undefined;
-  }
-
-  return location.state[REQUEST_FIELD];
-}
 
 const ShareIdentity = ({ location }: RouteComponentProps): JSX.Element => {
   const [action, setAction] = React.useState<'show' | 'reject'>('show');
@@ -24,12 +14,7 @@ const ShareIdentity = ({ location }: RouteComponentProps): JSX.Element => {
   const requestContext = React.useContext(RequestContext);
 
   const request = requestContext.firstRequest;
-  const expectedId = getIdFrom(location);
-
-  if (!request || typeof expectedId === undefined || expectedId !== request.id) {
-    toast.show('Error: Request not identified', ToastVariant.ERROR);
-    history.push(REQUEST_ROUTE);
-  }
+  checkRequest(request, location, toast);
 
   const showRequestView = (): void => setAction('show');
   const showRejectView = (): void => setAction('reject');

--- a/packages/sanes-chrome-extension/src/routes/share-identity/test/travelToShareIdentity.ts
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/test/travelToShareIdentity.ts
@@ -1,17 +1,30 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { SHARE_IDENTITY } from '../../paths';
-import { createDom } from '../../../utils/test/dom';
+import { Request } from '../../../extension/background/actions/createPersona/requestHandler';
 import { history } from '../../../store/reducers';
+import { createDom } from '../../../utils/test/dom';
 import { whenOnNavigatedToRoute } from '../../../utils/test/navigation';
+import { SHARE_IDENTITY } from '../../paths';
+import { REQUEST_FIELD } from '../../requests/components/RequestList';
 
-export const travelToShareIdentity = async (store: Store): Promise<React.Component> => {
-  const dom = createDom(store);
+export const travelToShareIdentity = async (
+  store: Store,
+  initialRequests: ReadonlyArray<Request>,
+): Promise<React.Component> => {
+  expect(initialRequests.length).toBeGreaterThanOrEqual(1);
+
+  const dom = createDom(store, initialRequests);
   TestUtils.act(
     (): void => {
-      history.push(SHARE_IDENTITY);
+      history.push({
+        pathname: SHARE_IDENTITY,
+        state: {
+          [REQUEST_FIELD]: initialRequests[0].id,
+        },
+      });
     },
   );
+
   await whenOnNavigatedToRoute(store, SHARE_IDENTITY);
 
   return dom;

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.dom.spec.ts
@@ -1,15 +1,16 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { RootState } from '../../store/reducers';
+import { Request } from '../../extension/background/actions/createPersona/requestHandler';
 import { aNewStore } from '../../store';
-import { travelToTXRequest } from './test/travelToTXRequest';
+import { RootState } from '../../store/reducers';
+import { sleep } from '../../utils/timer';
 import {
+  checkPermanentRejection,
   clickOnBackButton,
   clickOnRejectButton,
-  checkPermanentRejection,
   confirmRejectButton,
 } from './test/operateTXRequest';
-import { sleep } from '../../utils/timer';
+import { travelToTXRequest } from './test/travelToTXRequest';
 
 describe('DOM > Feature > Transaction Request', (): void => {
   let store: Store<RootState>;
@@ -17,7 +18,17 @@ describe('DOM > Feature > Transaction Request', (): void => {
 
   beforeEach(async () => {
     store = aNewStore();
-    identityDOM = await travelToTXRequest(store);
+    const requests: ReadonlyArray<Request> = [
+      {
+        id: 1,
+        type: 'signAndPost',
+        reason: 'Test get Identities',
+        sender: 'http://finnex.com',
+        accept: jest.fn(),
+        reject: jest.fn(),
+      },
+    ];
+    identityDOM = await travelToTXRequest(store, requests);
   });
 
   it('should accept incoming request and redirect to account status view', async (): Promise<void> => {

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.tsx
@@ -1,19 +1,32 @@
+import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider';
 import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router';
+import { RequestContext } from '../../context/RequestProvider';
+import { history } from '../../store/reducers';
+import { REQUEST_ROUTE } from '../paths';
+import { checkRequest } from '../requests';
 import RejectRequest from './components/RejectRequest';
 import ShowRequest from './components/ShowRequest';
 
-const TxRequest = (): JSX.Element => {
+const TxRequest = ({ location }: RouteComponentProps): JSX.Element => {
   const [action, setAction] = React.useState<'show' | 'reject'>('show');
+  const toast = React.useContext(ToastContext);
+  const requestContext = React.useContext(RequestContext);
+
+  const request = requestContext.firstRequest;
+  checkRequest(request, location, toast);
 
   const showRequestView = (): void => setAction('show');
   const showRejectView = (): void => setAction('reject');
 
   const onAcceptRequest = (): void => {
-    console.log('Accept request');
+    request!.accept(); // eslint-disable-line
+    history.push(REQUEST_ROUTE);
   };
 
   const onRejectRequest = (permanent: boolean): void => {
-    console.log(`Reject request. Permanent ${permanent ? 'yes' : 'no'}`);
+    request!.reject(permanent); // eslint-disable-line
+    history.push(REQUEST_ROUTE);
   };
 
   return (
@@ -24,4 +37,4 @@ const TxRequest = (): JSX.Element => {
   );
 };
 
-export default TxRequest;
+export default withRouter(TxRequest);

--- a/packages/sanes-chrome-extension/src/routes/tx-request/test/travelToTXRequest.ts
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/test/travelToTXRequest.ts
@@ -1,15 +1,27 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { TX_REQUEST } from '../../paths';
-import { createDom } from '../../../utils/test/dom';
+import { Request } from '../../../extension/background/actions/createPersona/requestHandler';
 import { history } from '../../../store/reducers';
+import { createDom } from '../../../utils/test/dom';
 import { whenOnNavigatedToRoute } from '../../../utils/test/navigation';
+import { TX_REQUEST } from '../../paths';
+import { REQUEST_FIELD } from '../../requests/components/RequestList';
 
-export const travelToTXRequest = async (store: Store): Promise<React.Component> => {
-  const dom = createDom(store);
+export const travelToTXRequest = async (
+  store: Store,
+  initialRequests: ReadonlyArray<Request>,
+): Promise<React.Component> => {
+  expect(initialRequests.length).toBeGreaterThanOrEqual(1);
+
+  const dom = createDom(store, initialRequests);
   TestUtils.act(
     (): void => {
-      history.push(TX_REQUEST);
+      history.push({
+        pathname: TX_REQUEST,
+        state: {
+          [REQUEST_FIELD]: initialRequests[0].id,
+        },
+      });
     },
   );
   await whenOnNavigatedToRoute(store, TX_REQUEST);

--- a/packages/sanes-chrome-extension/src/utils/test/dom.tsx
+++ b/packages/sanes-chrome-extension/src/utils/test/dom.tsx
@@ -1,25 +1,34 @@
 import { ConnectedRouter } from 'connected-react-router';
-import * as React from 'react';
-import MedulasThemeProvider from 'medulas-react-components/lib/theme/MedulasThemeProvider';
-import TestUtils from 'react-dom/test-utils';
 import { ToastProvider } from 'medulas-react-components/lib/context/ToastProvider';
+import MedulasThemeProvider from 'medulas-react-components/lib/theme/MedulasThemeProvider';
+import * as React from 'react';
+import TestUtils from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { Store } from 'redux';
+import { PersonaProvider } from '../../context/PersonaProvider';
+import { RequestProvider } from '../../context/RequestProvider';
+import { Request } from '../../extension/background/actions/createPersona/requestHandler';
+import { GetPersonaResponse } from '../../extension/background/messages';
 import Route from '../../routes';
 import { history } from '../../store/reducers';
-import { PersonaProvider } from '../../context/PersonaProvider';
 
-export const createDom = (store: Store): React.Component =>
+export const createDom = (
+  store: Store,
+  requests: ReadonlyArray<Request> = [],
+  persona: GetPersonaResponse = null,
+): React.Component =>
   TestUtils.renderIntoDocument(
     <Provider store={store}>
       <MedulasThemeProvider>
-        <ConnectedRouter history={history}>
-          <ToastProvider>
-            <PersonaProvider persona={null}>
-              <Route />
-            </PersonaProvider>
-          </ToastProvider>
-        </ConnectedRouter>
+        <ToastProvider>
+          <PersonaProvider persona={persona}>
+            <RequestProvider initialRequests={requests}>
+              <ConnectedRouter history={history}>
+                <Route />
+              </ConnectedRouter>
+            </RequestProvider>
+          </PersonaProvider>
+        </ToastProvider>
       </MedulasThemeProvider>
     </Provider>,
   ) as any; // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2872,6 +2872,7 @@ exports[`Storyshots Extension Request queue page 1`] = `
       <li
         className="MuiListItem-root MuiListItem-default MuiListItem-dense MuiListItem-gutters makeStyles-first-1744"
         disabled={false}
+        onClick={[Function]}
       >
         <div
           className="MuiListItemText-root"
@@ -2879,7 +2880,7 @@ exports[`Storyshots Extension Request queue page 1`] = `
           <span
             className="MuiTypography-root MuiTypography-body1 MuiListItemText-primary"
           >
-            Type of request
+            Sign Request
           </span>
           <p
             className="MuiTypography-root MuiTypography-body2 MuiTypography-colorTextPrimary MuiListItemText-secondary"
@@ -2923,7 +2924,7 @@ exports[`Storyshots Extension Request queue page 1`] = `
           <span
             className="MuiTypography-root MuiTypography-body1 MuiListItemText-primary"
           >
-            Type of request
+            Sign Request
           </span>
           <p
             className="MuiTypography-root MuiTypography-body2 MuiTypography-colorTextPrimary MuiListItemText-secondary"
@@ -2942,7 +2943,7 @@ exports[`Storyshots Extension Request queue page 1`] = `
           <span
             className="MuiTypography-root MuiTypography-body1 MuiListItemText-primary"
           >
-            Type of request
+            Sign Request
           </span>
           <p
             className="MuiTypography-root MuiTypography-body2 MuiTypography-colorTextPrimary MuiListItemText-secondary"


### PR DESCRIPTION
**Description**
With this PR when a request is enqueued the UI knows the destination route of each request.

<img width="428" alt="Screenshot 2019-05-20 23 28 29" src="https://user-images.githubusercontent.com/4266059/58053948-57fcc580-7b59-11e9-90f2-c2b13d0d91bc.png">

**DONE**
- Added counter for identifying correctly requests in UI (unfortunately requests cannot be passed in the location' state
- Implemented logic handling of requests in share identify and tx-request views
- Added type to Request interface for dispatching them to their correct view.
- Added firstRequest to RequestContext
