### PR TITLE
Feature #201 - Show real data tx-request and share-identity requests 

### DIFF
--- a/packages/sanes-chrome-extension/src/routes/requests/components/RequestList.tsx
+++ b/packages/sanes-chrome-extension/src/routes/requests/components/RequestList.tsx
@@ -64,9 +64,8 @@ const RequestList = ({ requests }: Props): JSX.Element => {
           const text = req.type === 'getIdentities' ? 'Get Identities Request' : 'Sign Request';
 
           return (
-            <React.Fragment>
+            <React.Fragment key={`${index}`}>
               <ListItem
-                key={`${index}`}
                 className={firstElemClass}
                 disabled={!first}
                 onClick={first ? onRequestClick : undefined}

--- a/packages/sanes-chrome-extension/src/routes/requests/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/requests/index.tsx
@@ -18,17 +18,20 @@ function getIdFrom(location: Location): number | undefined {
   return location.state[REQUEST_FIELD];
 }
 
-export function checkRequest(
+export function validRequest(
   request: Request | undefined,
   location: Location,
   toast: ToastContextInterface,
-): void {
+): boolean {
   const expectedId = getIdFrom(location);
 
   if (!request || typeof expectedId === undefined || expectedId !== request.id) {
     toast.show('Error: Request not identified', ToastVariant.ERROR);
     history.push(REQUEST_ROUTE);
+    return false;
   }
+
+  return true;
 }
 const Requests = (): JSX.Element => {
   const requestContext = React.useContext(RequestContext);

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
@@ -6,6 +6,7 @@ import Form, { FormValues, useForm } from 'medulas-react-components/lib/componen
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+import { Request } from '../../../extension/background/actions/createPersona/requestHandler';
 import { SHARE_IDENTITY } from '../../paths';
 
 const PERMANENT_REJECT = 'permanentRejectField';
@@ -14,9 +15,10 @@ export const SHARE_IDENTITY_REJECT = `${SHARE_IDENTITY}_reject`;
 interface Props {
   readonly onRejectRequest: (permanent: boolean) => void;
   readonly onBack: () => void;
+  readonly request: Request;
 }
 
-const Layout = ({ onBack, onRejectRequest }: Props): JSX.Element => {
+const Layout = ({ request, onBack, onRejectRequest }: Props): JSX.Element => {
   const onSubmit = async (values: object): Promise<void> => {
     const formValues = values as FormValues;
     const permanentReject = `${formValues[PERMANENT_REJECT]}` === 'true';
@@ -34,7 +36,7 @@ const Layout = ({ onBack, onRejectRequest }: Props): JSX.Element => {
         <Block textAlign="center">
           <Typography variant="body1">The following site:</Typography>
           <Typography variant="body1" color="primary">
-            http://finex.com
+            {request.sender}
           </Typography>
           <Typography variant="body1" inline color="error">
             would not be able to request

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
@@ -22,11 +22,7 @@ const Layout = ({ request, onAcceptRequest, showRejectView }: Props): JSX.Elemen
         {request.sender}
       </Typography>
       <Typography variant="body1" inline>
-        wants to see your identity on
-      </Typography>
-      <Typography variant="body1" inline color="primary">
-        {' '}
-        ETH
+        wants to see your identity
       </Typography>
     </Block>
     <Block marginTop={10} />

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
@@ -22,7 +22,7 @@ const Layout = ({ request, onAcceptRequest, showRejectView }: Props): JSX.Elemen
         {request.sender}
       </Typography>
       <Typography variant="body1" inline>
-        wants to see your identity
+        wants to see your identity.
       </Typography>
     </Block>
     <Block marginTop={10} />

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
@@ -3,6 +3,7 @@ import Button from 'medulas-react-components/lib/components/Button';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import Block from 'medulas-react-components/lib/components/Block';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import { Request } from '../../../extension/background/actions/createPersona/requestHandler';
 import { SHARE_IDENTITY } from '../../paths';
 
 export const SHARE_IDENTITY_SHOW = `${SHARE_IDENTITY}_show`;
@@ -10,14 +11,15 @@ export const SHARE_IDENTITY_SHOW = `${SHARE_IDENTITY}_show`;
 interface Props {
   readonly onAcceptRequest: () => void;
   readonly showRejectView: () => void;
+  readonly request: Request;
 }
 
-const Layout = ({ onAcceptRequest, showRejectView }: Props): JSX.Element => (
+const Layout = ({ request, onAcceptRequest, showRejectView }: Props): JSX.Element => (
   <PageLayout id={SHARE_IDENTITY_SHOW} primaryTitle="Share" title="Identity">
     <Block textAlign="center">
       <Typography variant="body1">The following site:</Typography>
       <Typography variant="body1" color="primary">
-        http://finex.com
+        {request.sender}
       </Typography>
       <Typography variant="body1" inline>
         wants to see your identity on

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
@@ -5,6 +5,7 @@ import ShowRequest from './components/ShowRequest';
 import RejectRequest from './components/RejectRequest';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
+import { Request } from '../../extension/background/actions/createPersona/requestHandler';
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 import { ACCOUNT_STATUS_PAGE } from '../account/index.stories';
 
@@ -12,12 +13,22 @@ const SHARE_IDENTITY_PATH = `${CHROME_EXTENSION_ROOT}/Share Identity`;
 const SHOW_REQUEST_PAGE = 'Show Request page';
 const REJECT_REQUEST_PAGE = 'Reject Request page';
 
+const request: Request = {
+  id: 0,
+  accept: () => action('accept request'),
+  reject: (permanent: boolean) => action(`reject request. Permanently: ${permanent ? 'yes' : 'no'}`),
+  reason: 'I would like to know who you are on Ethereum"',
+  sender: 'http://localhost/',
+  type: 'getIdentities',
+};
+
 storiesOf(SHARE_IDENTITY_PATH, module)
   .add(
     SHOW_REQUEST_PAGE,
     (): JSX.Element => (
       <Storybook>
         <ShowRequest
+          request={request}
           onAcceptRequest={linkTo(CHROME_EXTENSION_ROOT, ACCOUNT_STATUS_PAGE)}
           showRejectView={linkTo(SHARE_IDENTITY_PATH, REJECT_REQUEST_PAGE)}
         />
@@ -29,6 +40,7 @@ storiesOf(SHARE_IDENTITY_PATH, module)
     (): JSX.Element => (
       <Storybook>
         <RejectRequest
+          request={request}
           onBack={linkTo(SHARE_IDENTITY_PATH, SHOW_REQUEST_PAGE)}
           onRejectRequest={action('onAcceptRequest')}
         />

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
@@ -4,7 +4,7 @@ import { RouteComponentProps, withRouter } from 'react-router';
 import { RequestContext } from '../../context/RequestProvider';
 import { history } from '../../store/reducers';
 import { REQUEST_ROUTE } from '../paths';
-import { checkRequest } from '../requests';
+import { validRequest } from '../requests';
 import RejectRequest from './components/RejectRequest';
 import ShowRequest from './components/ShowRequest';
 
@@ -14,30 +14,37 @@ const ShareIdentity = ({ location }: RouteComponentProps): JSX.Element => {
   const requestContext = React.useContext(RequestContext);
 
   const request = requestContext.firstRequest;
-  checkRequest(request, location, toast);
+  const isValid = validRequest(request, location, toast);
+  if (!isValid) {
+    return <React.Fragment />;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const requestValid = request!;
 
   const showRequestView = (): void => setAction('show');
   const showRejectView = (): void => setAction('reject');
 
   const onAcceptRequest = (): void => {
-    request!.accept(); // eslint-disable-line
+    requestValid.accept();
     history.push(REQUEST_ROUTE);
   };
 
   const onRejectRequest = (permanent: boolean): void => {
-    request!.reject(permanent); // eslint-disable-line
+    requestValid.reject(permanent);
     history.push(REQUEST_ROUTE);
   };
 
   return (
     <React.Fragment>
       {action === 'show' && (
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        <ShowRequest request={request!} onAcceptRequest={onAcceptRequest} showRejectView={showRejectView} />
+        <ShowRequest
+          request={requestValid}
+          onAcceptRequest={onAcceptRequest}
+          showRejectView={showRejectView}
+        />
       )}
       {action === 'reject' && (
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        <RejectRequest request={request!} onBack={showRequestView} onRejectRequest={onRejectRequest} />
+        <RejectRequest request={requestValid} onBack={showRequestView} onRejectRequest={onRejectRequest} />
       )}
     </React.Fragment>
   );

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
@@ -31,8 +31,14 @@ const ShareIdentity = ({ location }: RouteComponentProps): JSX.Element => {
 
   return (
     <React.Fragment>
-      {action === 'show' && <ShowRequest onAcceptRequest={onAcceptRequest} showRejectView={showRejectView} />}
-      {action === 'reject' && <RejectRequest onBack={showRequestView} onRejectRequest={onRejectRequest} />}
+      {action === 'show' && (
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        <ShowRequest request={request!} onAcceptRequest={onAcceptRequest} showRejectView={showRejectView} />
+      )}
+      {action === 'reject' && (
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        <RejectRequest request={request!} onBack={showRequestView} onRejectRequest={onRejectRequest} />
+      )}
     </React.Fragment>
   );
 };

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/RejectRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/RejectRequest.tsx
@@ -40,7 +40,7 @@ const Layout = ({ request, onBack, onRejectRequest }: Props): JSX.Element => {
             {request.sender}
           </Typography>
           <Typography variant="body1" inline>
-            to perform the following transaction to be made
+            to perform the following transaction to be made.
           </Typography>
 
           <Block marginTop={1} />

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/RejectRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/RejectRequest.tsx
@@ -51,31 +51,7 @@ const Layout = ({ request, onBack, onRejectRequest }: Props): JSX.Element => {
             label="Don't ask me again"
           />
         </Block>
-        <Hairline />
-        <Block marginTop={2} marginBottom={2}>
-          <Block display="flex" alignItems="center">
-            <Block flex="1 0 1px">
-              <Block marginLeft={6}>
-                <Typography variant="body1">Fee</Typography>
-              </Block>
-            </Block>
-            <Block flex="1 0 1px">
-              <Typography variant="h6">0,0288 ETH</Typography>
-            </Block>
-          </Block>
-          <Block display="flex" alignItems="center">
-            <Block flex="1 0 1px">
-              <Block marginLeft={6}>
-                <Typography variant="body1">Register</Typography>
-              </Block>
-            </Block>
-            <Block flex="1 0 1px">
-              <Typography variant="h6">billy*iov</Typography>
-            </Block>
-          </Block>
-        </Block>
-        <Hairline />
-        <Block marginTop={4} />
+        <Block marginTop={6} />
         <Button variant="contained" fullWidth type="submit" disabled={pristine || submitting}>
           Reject
         </Button>

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/RejectRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/RejectRequest.tsx
@@ -7,6 +7,7 @@ import Hairline from 'medulas-react-components/lib/components/Hairline';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+import { Request } from '../../../extension/background/actions/createPersona/requestHandler';
 import { TX_REQUEST } from '../../paths';
 
 const PERMANENT_REJECT = 'permanentRejectField';
@@ -15,9 +16,10 @@ export const TX_REQUEST_REJECT = `${TX_REQUEST}_reject`;
 interface Props {
   readonly onRejectRequest: (permanent: boolean) => void;
   readonly onBack: () => void;
+  readonly request: Request;
 }
 
-const Layout = ({ onBack, onRejectRequest }: Props): JSX.Element => {
+const Layout = ({ request, onBack, onRejectRequest }: Props): JSX.Element => {
   const onSubmit = async (values: object): Promise<void> => {
     const formValues = values as FormValues;
     const permanentReject = `${formValues[PERMANENT_REJECT]}` === 'true';
@@ -35,7 +37,7 @@ const Layout = ({ onBack, onRejectRequest }: Props): JSX.Element => {
         <Block textAlign="center" marginTop={2}>
           <Typography variant="body1">You are not allowing</Typography>
           <Typography variant="body1" color="primary">
-            http://finex.com
+            {request.sender}
           </Typography>
           <Typography variant="body1" inline>
             to perform the following transaction to be made

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest.tsx
@@ -27,31 +27,7 @@ const Layout = ({ request, onAcceptRequest, showRejectView }: Props): JSX.Elemen
         is asking for the following transactions to be made.
       </Typography>
     </Block>
-    <Hairline />
-    <Block marginTop={2} marginBottom={2}>
-      <Block display="flex" alignItems="center">
-        <Block flex="1 0 1px">
-          <Block marginLeft={6}>
-            <Typography variant="body1">Fee</Typography>
-          </Block>
-        </Block>
-        <Block flex="1 0 1px">
-          <Typography variant="h6">0,0288 ETH</Typography>
-        </Block>
-      </Block>
-      <Block display="flex" alignItems="center">
-        <Block flex="1 0 1px">
-          <Block marginLeft={6}>
-            <Typography variant="body1">Register</Typography>
-          </Block>
-        </Block>
-        <Block flex="1 0 1px">
-          <Typography variant="h6">billy*iov</Typography>
-        </Block>
-      </Block>
-    </Block>
-    <Hairline />
-    <Block marginTop={4} />
+    <Block marginTop={6} />
     <Button variant="contained" fullWidth onClick={onAcceptRequest}>
       Approve
     </Button>

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest.tsx
@@ -5,21 +5,23 @@ import Block from 'medulas-react-components/lib/components/Block';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import { TX_REQUEST } from '../../paths';
 import Hairline from 'medulas-react-components/lib/components/Hairline';
+import { Request } from '../../../extension/background/actions/createPersona/requestHandler';
 
 export const TX_REQUEST_SHOW = `${TX_REQUEST}_show`;
 
 interface Props {
   readonly onAcceptRequest: () => void;
   readonly showRejectView: () => void;
+  readonly request: Request;
 }
 
-const Layout = ({ onAcceptRequest, showRejectView }: Props): JSX.Element => (
+const Layout = ({ request, onAcceptRequest, showRejectView }: Props): JSX.Element => (
   <PageLayout id={TX_REQUEST_SHOW} primaryTitle="Transaction" title="Request">
     <Hairline />
     <Block textAlign="center" marginTop={2} marginBottom={2}>
       <Typography variant="body1">The following site:</Typography>
       <Typography variant="body1" color="primary">
-        http://finex.com
+        {request.sender}
       </Typography>
       <Typography variant="body1" inline>
         is asking for the following transactions to be made.

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.stories.tsx
@@ -5,6 +5,7 @@ import ShowRequest from './components/ShowRequest';
 import RejectRequest from './components/RejectRequest';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
+import { Request } from '../../extension/background/actions/createPersona/requestHandler';
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 import { ACCOUNT_STATUS_PAGE } from '../account/index.stories';
 
@@ -12,12 +13,22 @@ const TX_REQUEST_PATH = `${CHROME_EXTENSION_ROOT}/Transaction Request`;
 const SHOW_REQUEST_PAGE = 'Show Request page';
 const REJECT_REQUEST_PAGE = 'Reject Request page';
 
+const request: Request = {
+  id: 0,
+  accept: () => action('accept request'),
+  reject: (permanent: boolean) => action(`reject request. Permanently: ${permanent ? 'yes' : 'no'}`),
+  reason: 'I would like to know who you are on Ethereum"',
+  sender: 'http://localhost/',
+  type: 'getIdentities',
+};
+
 storiesOf(TX_REQUEST_PATH, module)
   .add(
     SHOW_REQUEST_PAGE,
     (): JSX.Element => (
       <Storybook>
         <ShowRequest
+          request={request}
           onAcceptRequest={linkTo(CHROME_EXTENSION_ROOT, ACCOUNT_STATUS_PAGE)}
           showRejectView={linkTo(TX_REQUEST_PATH, REJECT_REQUEST_PAGE)}
         />
@@ -29,6 +40,7 @@ storiesOf(TX_REQUEST_PATH, module)
     (): JSX.Element => (
       <Storybook>
         <RejectRequest
+          request={request}
           onBack={linkTo(TX_REQUEST_PATH, SHOW_REQUEST_PAGE)}
           onRejectRequest={action('onAcceptRequest')}
         />

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.tsx
@@ -4,7 +4,7 @@ import { RouteComponentProps, withRouter } from 'react-router';
 import { RequestContext } from '../../context/RequestProvider';
 import { history } from '../../store/reducers';
 import { REQUEST_ROUTE } from '../paths';
-import { checkRequest } from '../requests';
+import { validRequest } from '../requests';
 import RejectRequest from './components/RejectRequest';
 import ShowRequest from './components/ShowRequest';
 
@@ -14,30 +14,37 @@ const TxRequest = ({ location }: RouteComponentProps): JSX.Element => {
   const requestContext = React.useContext(RequestContext);
 
   const request = requestContext.firstRequest;
-  checkRequest(request, location, toast);
+  const isValid = validRequest(request, location, toast);
+  if (!isValid) {
+    return <React.Fragment />;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const requestValid = request!;
 
   const showRequestView = (): void => setAction('show');
   const showRejectView = (): void => setAction('reject');
 
   const onAcceptRequest = (): void => {
-    request!.accept(); // eslint-disable-line
+    requestValid.accept();
     history.push(REQUEST_ROUTE);
   };
 
   const onRejectRequest = (permanent: boolean): void => {
-    request!.reject(permanent); // eslint-disable-line
+    requestValid.reject(permanent);
     history.push(REQUEST_ROUTE);
   };
 
   return (
     <React.Fragment>
       {action === 'show' && (
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        <ShowRequest request={request!} onAcceptRequest={onAcceptRequest} showRejectView={showRejectView} />
+        <ShowRequest
+          request={requestValid}
+          onAcceptRequest={onAcceptRequest}
+          showRejectView={showRejectView}
+        />
       )}
       {action === 'reject' && (
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        <RejectRequest request={request!} onBack={showRequestView} onRejectRequest={onRejectRequest} />
+        <RejectRequest request={requestValid} onBack={showRequestView} onRejectRequest={onRejectRequest} />
       )}
     </React.Fragment>
   );

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.tsx
@@ -31,8 +31,14 @@ const TxRequest = ({ location }: RouteComponentProps): JSX.Element => {
 
   return (
     <React.Fragment>
-      {action === 'show' && <ShowRequest onAcceptRequest={onAcceptRequest} showRejectView={showRejectView} />}
-      {action === 'reject' && <RejectRequest onBack={showRequestView} onRejectRequest={onRejectRequest} />}
+      {action === 'show' && (
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        <ShowRequest request={request!} onAcceptRequest={onAcceptRequest} showRejectView={showRejectView} />
+      )}
+      {action === 'reject' && (
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        <RejectRequest request={request!} onBack={showRequestView} onRejectRequest={onRejectRequest} />
+      )}
     </React.Fragment>
   );
 };

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -4182,7 +4182,7 @@ exports[`Storyshots Extension/Transaction Request Reject Request page 1`] = `
         <p
           className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2592 makeStyles-weight-2630 makeStyles-inline-2590"
         >
-          to perform the following transaction to be made
+          to perform the following transaction to be made.
         </p>
         <div
           className="MuiBox-root MuiBox-root-2631"

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -3249,7 +3249,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
         <p
           className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2043 makeStyles-weight-2079"
         >
-          http://finex.com
+          http://localhost/
         </p>
         <p
           className="MuiTypography-root MuiTypography-body1 MuiTypography-colorError makeStyles-weight-2043 makeStyles-weight-2080 makeStyles-inline-2041"
@@ -3425,7 +3425,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1968 makeStyles-weight-2004"
       >
-        http://finex.com
+        http://localhost/
       </p>
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1968 makeStyles-weight-2005 makeStyles-inline-1966"
@@ -4177,7 +4177,7 @@ exports[`Storyshots Extension/Transaction Request Reject Request page 1`] = `
         <p
           className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2592 makeStyles-weight-2629"
         >
-          http://finex.com
+          http://localhost/
         </p>
         <p
           className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2592 makeStyles-weight-2630 makeStyles-inline-2590"
@@ -4412,7 +4412,7 @@ exports[`Storyshots Extension/Transaction Request Show Request page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2502 makeStyles-weight-2539"
       >
-        http://finex.com
+        http://localhost/
       </p>
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2502 makeStyles-weight-2540 makeStyles-inline-2500"

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -141,9 +141,9 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
             <h6
               className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextSecondary makeStyles-weight-43 makeStyles-weight-126"
             >
-              balance: 
+              balance:
               24
-               
+
               IOV
             </h6>
           </div>
@@ -862,7 +862,7 @@ exports[`Storyshots Components Drawer 1`] = `
           <h4
             className="MuiTypography-root MuiTypography-h4 makeStyles-weight-410 makeStyles-weight-442 makeStyles-inline-408"
           >
-             
+
             drawer
           </h4>
         </div>
@@ -1045,7 +1045,7 @@ exports[`Storyshots Components Layout 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-598 makeStyles-weight-653 makeStyles-inline-596"
     >
-       
+
       storybook
     </h4>
   </div>
@@ -1729,7 +1729,7 @@ Array [
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-775 makeStyles-weight-821 makeStyles-inline-773"
   >
-    First part of the text. 
+    First part of the text.
   </h6>,
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-775 makeStyles-weight-822 makeStyles-inline-773"
@@ -2317,7 +2317,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
           <h4
             className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1356 makeStyles-weight-1388 makeStyles-inline-1354"
           >
-             
+
             Status
           </h4>
         </div>
@@ -2466,7 +2466,7 @@ exports[`Storyshots Extension Login page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1457 makeStyles-weight-1512 makeStyles-inline-1455"
     >
-       
+
       In
     </h4>
   </div>
@@ -2656,7 +2656,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1588 makeStyles-weight-1643 makeStyles-inline-1586"
     >
-       
+
       phrase
     </h4>
   </div>
@@ -2725,7 +2725,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1588 makeStyles-weight-1671 makeStyles-inline-1586"
       >
-        
+
       </p>
     </div>
   </div>
@@ -2808,7 +2808,7 @@ exports[`Storyshots Extension Request queue page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1681 makeStyles-weight-1736 makeStyles-inline-1679"
     >
-       
+
       queue
     </h4>
   </div>
@@ -2945,7 +2945,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1786 makeStyles-weight-1818 makeStyles-inline-1784"
     >
-       
+
       Account
     </h4>
   </div>
@@ -3104,7 +3104,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1896 makeStyles-weight-1928 makeStyles-inline-1894"
     >
-       
+
       to your IOV manager
     </h4>
   </div>
@@ -3228,7 +3228,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2043 makeStyles-weight-2075 makeStyles-inline-2041"
     >
-       
+
       Identity
     </h4>
   </div>
@@ -3259,7 +3259,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
         <p
           className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2043 makeStyles-weight-2081 makeStyles-inline-2041"
         >
-           
+
           your identity.
         </p>
         <div
@@ -3407,7 +3407,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1968 makeStyles-weight-2000 makeStyles-inline-1966"
     >
-       
+
       Identity
     </h4>
   </div>
@@ -3435,7 +3435,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1968 makeStyles-weight-2006 makeStyles-inline-1966"
       >
-         
+
         ETH
       </p>
     </div>
@@ -3525,7 +3525,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2153 makeStyles-weight-2185 makeStyles-inline-2151"
     >
-       
+
       Account
     </h4>
   </div>
@@ -3814,7 +3814,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2283 makeStyles-weight-2315 makeStyles-inline-2281"
     >
-       
+
       Account
     </h4>
   </div>
@@ -3898,7 +3898,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2283 makeStyles-weight-2362 makeStyles-inline-2281"
       >
-        
+
       </p>
     </div>
     <div
@@ -3994,7 +3994,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2392 makeStyles-weight-2424 makeStyles-inline-2390"
     >
-       
+
       Account
     </h4>
   </div>
@@ -4153,7 +4153,7 @@ exports[`Storyshots Extension/Transaction Request Reject Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2592 makeStyles-weight-2624 makeStyles-inline-2590"
     >
-       
+
       Request
     </h4>
   </div>
@@ -4391,7 +4391,7 @@ exports[`Storyshots Extension/Transaction Request Show Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2502 makeStyles-weight-2534 makeStyles-inline-2500"
     >
-       
+
       Request
     </h4>
   </div>

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -141,9 +141,9 @@ exports[`Storyshots Bierzo wallet Payment page 1`] = `
             <h6
               className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextSecondary makeStyles-weight-43 makeStyles-weight-126"
             >
-              balance:
+              balance: 
               24
-
+               
               IOV
             </h6>
           </div>
@@ -862,7 +862,7 @@ exports[`Storyshots Components Drawer 1`] = `
           <h4
             className="MuiTypography-root MuiTypography-h4 makeStyles-weight-410 makeStyles-weight-442 makeStyles-inline-408"
           >
-
+             
             drawer
           </h4>
         </div>
@@ -1045,7 +1045,7 @@ exports[`Storyshots Components Layout 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-598 makeStyles-weight-653 makeStyles-inline-596"
     >
-
+       
       storybook
     </h4>
   </div>
@@ -1729,7 +1729,7 @@ Array [
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorPrimary makeStyles-weight-775 makeStyles-weight-821 makeStyles-inline-773"
   >
-    First part of the text.
+    First part of the text. 
   </h6>,
   <h6
     className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-775 makeStyles-weight-822 makeStyles-inline-773"
@@ -2317,7 +2317,7 @@ exports[`Storyshots Extension Account Status page 1`] = `
           <h4
             className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1356 makeStyles-weight-1388 makeStyles-inline-1354"
           >
-
+             
             Status
           </h4>
         </div>
@@ -2466,7 +2466,7 @@ exports[`Storyshots Extension Login page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1457 makeStyles-weight-1512 makeStyles-inline-1455"
     >
-
+       
       In
     </h4>
   </div>
@@ -2656,7 +2656,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1588 makeStyles-weight-1643 makeStyles-inline-1586"
     >
-
+       
       phrase
     </h4>
   </div>
@@ -2725,7 +2725,7 @@ exports[`Storyshots Extension Recovery Phrase page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1588 makeStyles-weight-1671 makeStyles-inline-1586"
       >
-
+        
       </p>
     </div>
   </div>
@@ -2808,7 +2808,7 @@ exports[`Storyshots Extension Request queue page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1681 makeStyles-weight-1736 makeStyles-inline-1679"
     >
-
+       
       queue
     </h4>
   </div>
@@ -2945,7 +2945,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1786 makeStyles-weight-1818 makeStyles-inline-1784"
     >
-
+       
       Account
     </h4>
   </div>
@@ -3104,7 +3104,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1896 makeStyles-weight-1928 makeStyles-inline-1894"
     >
-
+       
       to your IOV manager
     </h4>
   </div>
@@ -3214,56 +3214,56 @@ exports[`Storyshots Extension Welcome page 1`] = `
 
 exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2039 makeStyles-root-2036 makeStyles-root-2037"
+  className="MuiBox-root MuiBox-root-2038 makeStyles-root-2035 makeStyles-root-2036"
   id="/share-identity_reject"
 >
   <div
-    className="MuiBox-root MuiBox-root-2040"
+    className="MuiBox-root MuiBox-root-2039"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2043 makeStyles-weight-2044 makeStyles-inline-2041"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2042 makeStyles-weight-2043 makeStyles-inline-2040"
     >
       Share
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2043 makeStyles-weight-2075 makeStyles-inline-2041"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2042 makeStyles-weight-2074 makeStyles-inline-2040"
     >
-
+       
       Identity
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2076"
+    className="MuiBox-root MuiBox-root-2075"
   >
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-2077"
+        className="MuiBox-root MuiBox-root-2076"
       >
         <p
-          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2043 makeStyles-weight-2078"
+          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2042 makeStyles-weight-2077"
         >
           The following site:
         </p>
         <p
-          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2043 makeStyles-weight-2079"
+          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2042 makeStyles-weight-2078"
         >
           http://localhost/
         </p>
         <p
-          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorError makeStyles-weight-2043 makeStyles-weight-2080 makeStyles-inline-2041"
+          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorError makeStyles-weight-2042 makeStyles-weight-2079 makeStyles-inline-2040"
         >
           would not be able to request
         </p>
         <p
-          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2043 makeStyles-weight-2081 makeStyles-inline-2041"
+          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2042 makeStyles-weight-2080 makeStyles-inline-2040"
         >
-
+           
           your identity.
         </p>
         <div
-          className="MuiBox-root MuiBox-root-2082"
+          className="MuiBox-root MuiBox-root-2081"
         />
         <label
           className="MuiFormControlLabel-root"
@@ -3321,7 +3321,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
         </label>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2120"
+        className="MuiBox-root MuiBox-root-2119"
       />
       <button
         className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
@@ -3346,7 +3346,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
         </span>
       </button>
       <div
-        className="MuiBox-root MuiBox-root-2138"
+        className="MuiBox-root MuiBox-root-2137"
       />
       <button
         aria-label="Go back"
@@ -3375,14 +3375,14 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2139"
+    className="MuiBox-root MuiBox-root-2138"
   />
   <div
-    className="MuiBox-root MuiBox-root-2140"
+    className="MuiBox-root MuiBox-root-2139"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2141"
+      className="makeStyles-root-2140"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3407,7 +3407,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1968 makeStyles-weight-2000 makeStyles-inline-1966"
     >
-
+       
       Identity
     </h4>
   </div>
@@ -3430,17 +3430,11 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       <p
         className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1968 makeStyles-weight-2005 makeStyles-inline-1966"
       >
-        wants to see your identity on
-      </p>
-      <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1968 makeStyles-weight-2006 makeStyles-inline-1966"
-      >
-
-        ETH
+        wants to see your identity.
       </p>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-2007"
+      className="MuiBox-root MuiBox-root-2006"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -3466,7 +3460,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       </span>
     </button>
     <div
-      className="MuiBox-root MuiBox-root-2028"
+      className="MuiBox-root MuiBox-root-2027"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-fullWidth"
@@ -3493,14 +3487,14 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
     </button>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2029"
+    className="MuiBox-root MuiBox-root-2028"
   />
   <div
-    className="MuiBox-root MuiBox-root-2030"
+    className="MuiBox-root MuiBox-root-2029"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2031"
+      className="makeStyles-root-2030"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3511,32 +3505,32 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
 
 exports[`Storyshots Extension/Signup New Account page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2149 makeStyles-root-2146 makeStyles-root-2147"
+  className="MuiBox-root MuiBox-root-2148 makeStyles-root-2145 makeStyles-root-2146"
   id="/signup1"
 >
   <div
-    className="MuiBox-root MuiBox-root-2150"
+    className="MuiBox-root MuiBox-root-2149"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2153 makeStyles-weight-2154 makeStyles-inline-2151"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2152 makeStyles-weight-2153 makeStyles-inline-2150"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2153 makeStyles-weight-2185 makeStyles-inline-2151"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2152 makeStyles-weight-2184 makeStyles-inline-2150"
     >
-
+       
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2186"
+    className="MuiBox-root MuiBox-root-2185"
   >
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-2187"
+        className="MuiBox-root MuiBox-root-2186"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3598,7 +3592,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2244"
+        className="MuiBox-root MuiBox-root-2243"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3660,7 +3654,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2245"
+        className="MuiBox-root MuiBox-root-2244"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3722,10 +3716,10 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2246"
+        className="MuiBox-root MuiBox-root-2245"
       >
         <div
-          className="MuiBox-root MuiBox-root-2247"
+          className="MuiBox-root MuiBox-root-2246"
         >
           <button
             aria-label="Go back"
@@ -3753,7 +3747,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
           </button>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-2268"
+          className="MuiBox-root MuiBox-root-2267"
         >
           <button
             className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
@@ -3782,14 +3776,14 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2269"
+    className="MuiBox-root MuiBox-root-2268"
   />
   <div
-    className="MuiBox-root MuiBox-root-2270"
+    className="MuiBox-root MuiBox-root-2269"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2271"
+      className="makeStyles-root-2270"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3800,49 +3794,49 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
 
 exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2279 makeStyles-root-2276 makeStyles-root-2277"
+  className="MuiBox-root MuiBox-root-2278 makeStyles-root-2275 makeStyles-root-2276"
   id="/signup2"
 >
   <div
-    className="MuiBox-root MuiBox-root-2280"
+    className="MuiBox-root MuiBox-root-2279"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2283 makeStyles-weight-2284 makeStyles-inline-2281"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2282 makeStyles-weight-2283 makeStyles-inline-2280"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2283 makeStyles-weight-2315 makeStyles-inline-2281"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2282 makeStyles-weight-2314 makeStyles-inline-2280"
     >
-
+       
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2316"
+    className="MuiBox-root MuiBox-root-2315"
   >
     <div
-      className="MuiBox-root MuiBox-root-2317"
+      className="MuiBox-root MuiBox-root-2316"
     >
       <div
-        className="MuiBox-root MuiBox-root-2318"
+        className="MuiBox-root MuiBox-root-2317"
       >
         <div
-          className="MuiBox-root MuiBox-root-2319"
+          className="MuiBox-root MuiBox-root-2318"
         >
           <h6
-            className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-2283 makeStyles-weight-2320 makeStyles-inline-2281"
+            className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-2282 makeStyles-weight-2319 makeStyles-inline-2280"
           >
             Activate Recovery Phrase?
           </h6>
         </div>
         <div
-          className="makeStyles-container-2322"
+          className="makeStyles-container-2321"
           onClick={[Function]}
         >
           <img
             alt="Info"
-            className="makeStyles-root-2325"
+            className="makeStyles-root-2324"
             height={16}
             src="info_normal.svg"
             width={16}
@@ -3893,19 +3887,19 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
       </label>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-2361"
+      className="MuiBox-root MuiBox-root-2360"
     >
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2283 makeStyles-weight-2362 makeStyles-inline-2281"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2282 makeStyles-weight-2361 makeStyles-inline-2280"
       >
-
+        
       </p>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-2363"
+      className="MuiBox-root MuiBox-root-2362"
     >
       <div
-        className="MuiBox-root MuiBox-root-2364"
+        className="MuiBox-root MuiBox-root-2363"
       >
         <button
           aria-label="Go back"
@@ -3933,7 +3927,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
         </button>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2382"
+        className="MuiBox-root MuiBox-root-2381"
       >
         <button
           className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -3962,14 +3956,14 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2383"
+    className="MuiBox-root MuiBox-root-2382"
   />
   <div
-    className="MuiBox-root MuiBox-root-2384"
+    className="MuiBox-root MuiBox-root-2383"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2325"
+      className="makeStyles-root-2324"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3980,29 +3974,29 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
 
 exports[`Storyshots Extension/Signup Security Hint page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2388 makeStyles-root-2385 makeStyles-root-2386"
+  className="MuiBox-root MuiBox-root-2387 makeStyles-root-2384 makeStyles-root-2385"
   id="/signup3"
 >
   <div
-    className="MuiBox-root MuiBox-root-2389"
+    className="MuiBox-root MuiBox-root-2388"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2392 makeStyles-weight-2393 makeStyles-inline-2390"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2391 makeStyles-weight-2392 makeStyles-inline-2389"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2392 makeStyles-weight-2424 makeStyles-inline-2390"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2391 makeStyles-weight-2423 makeStyles-inline-2389"
     >
-
+       
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2425"
+    className="MuiBox-root MuiBox-root-2424"
   >
     <h6
-      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-2392 makeStyles-weight-2426 makeStyles-inline-2390"
+      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-2391 makeStyles-weight-2425 makeStyles-inline-2389"
     >
       To help you remember your details in the future please provide a security hint:
     </h6>
@@ -4010,7 +4004,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-2427"
+        className="MuiBox-root MuiBox-root-2426"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -4061,10 +4055,10 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2465"
+        className="MuiBox-root MuiBox-root-2464"
       >
         <div
-          className="MuiBox-root MuiBox-root-2466"
+          className="MuiBox-root MuiBox-root-2465"
         >
           <button
             aria-label="Go back"
@@ -4092,7 +4086,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
           </button>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-2487"
+          className="MuiBox-root MuiBox-root-2486"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -4121,14 +4115,14 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2488"
+    className="MuiBox-root MuiBox-root-2487"
   />
   <div
-    className="MuiBox-root MuiBox-root-2489"
+    className="MuiBox-root MuiBox-root-2488"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2490"
+      className="makeStyles-root-2489"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -4139,53 +4133,53 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
 
 exports[`Storyshots Extension/Transaction Request Reject Request page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2588 makeStyles-root-2585 makeStyles-root-2586"
+  className="MuiBox-root MuiBox-root-2572 makeStyles-root-2569 makeStyles-root-2570"
   id="/tx-request_reject"
 >
   <div
-    className="MuiBox-root MuiBox-root-2589"
+    className="MuiBox-root MuiBox-root-2573"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2592 makeStyles-weight-2593 makeStyles-inline-2590"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2576 makeStyles-weight-2577 makeStyles-inline-2574"
     >
       Transaction
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2592 makeStyles-weight-2624 makeStyles-inline-2590"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2576 makeStyles-weight-2608 makeStyles-inline-2574"
     >
-
+       
       Request
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2625"
+    className="MuiBox-root MuiBox-root-2609"
   >
     <div
-      className="MuiBox-root MuiBox-root-2626"
+      className="MuiBox-root MuiBox-root-2610"
     />
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-2627"
+        className="MuiBox-root MuiBox-root-2611"
       >
         <p
-          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2592 makeStyles-weight-2628"
+          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2576 makeStyles-weight-2612"
         >
           You are not allowing
         </p>
         <p
-          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2592 makeStyles-weight-2629"
+          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2576 makeStyles-weight-2613"
         >
           http://localhost/
         </p>
         <p
-          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2592 makeStyles-weight-2630 makeStyles-inline-2590"
+          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2576 makeStyles-weight-2614 makeStyles-inline-2574"
         >
           to perform the following transaction to be made.
         </p>
         <div
-          className="MuiBox-root MuiBox-root-2631"
+          className="MuiBox-root MuiBox-root-2615"
         />
         <label
           className="MuiFormControlLabel-root"
@@ -4243,69 +4237,7 @@ exports[`Storyshots Extension/Transaction Request Reject Request page 1`] = `
         </label>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2669"
-      />
-      <div
-        className="MuiBox-root MuiBox-root-2670"
-      >
-        <div
-          className="MuiBox-root MuiBox-root-2671"
-        >
-          <div
-            className="MuiBox-root MuiBox-root-2672"
-          >
-            <div
-              className="MuiBox-root MuiBox-root-2673"
-            >
-              <p
-                className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2592 makeStyles-weight-2674"
-              >
-                Fee
-              </p>
-            </div>
-          </div>
-          <div
-            className="MuiBox-root MuiBox-root-2675"
-          >
-            <h6
-              className="MuiTypography-root MuiTypography-h6 makeStyles-weight-2592 makeStyles-weight-2676"
-            >
-              0,0288 ETH
-            </h6>
-          </div>
-        </div>
-        <div
-          className="MuiBox-root MuiBox-root-2677"
-        >
-          <div
-            className="MuiBox-root MuiBox-root-2678"
-          >
-            <div
-              className="MuiBox-root MuiBox-root-2679"
-            >
-              <p
-                className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2592 makeStyles-weight-2680"
-              >
-                Register
-              </p>
-            </div>
-          </div>
-          <div
-            className="MuiBox-root MuiBox-root-2681"
-          >
-            <h6
-              className="MuiTypography-root MuiTypography-h6 makeStyles-weight-2592 makeStyles-weight-2682"
-            >
-              billy*iov
-            </h6>
-          </div>
-        </div>
-      </div>
-      <div
-        className="MuiBox-root MuiBox-root-2683"
-      />
-      <div
-        className="MuiBox-root MuiBox-root-2684"
+        className="MuiBox-root MuiBox-root-2653"
       />
       <button
         className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
@@ -4330,7 +4262,7 @@ exports[`Storyshots Extension/Transaction Request Reject Request page 1`] = `
         </span>
       </button>
       <div
-        className="MuiBox-root MuiBox-root-2702"
+        className="MuiBox-root MuiBox-root-2671"
       />
       <button
         aria-label="Go back"
@@ -4359,14 +4291,14 @@ exports[`Storyshots Extension/Transaction Request Reject Request page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2703"
+    className="MuiBox-root MuiBox-root-2672"
   />
   <div
-    className="MuiBox-root MuiBox-root-2704"
+    className="MuiBox-root MuiBox-root-2673"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2705"
+      className="makeStyles-root-2674"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -4377,113 +4309,51 @@ exports[`Storyshots Extension/Transaction Request Reject Request page 1`] = `
 
 exports[`Storyshots Extension/Transaction Request Show Request page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2498 makeStyles-root-2495 makeStyles-root-2496"
+  className="MuiBox-root MuiBox-root-2497 makeStyles-root-2494 makeStyles-root-2495"
   id="/tx-request_show"
 >
   <div
-    className="MuiBox-root MuiBox-root-2499"
+    className="MuiBox-root MuiBox-root-2498"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2502 makeStyles-weight-2503 makeStyles-inline-2500"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2501 makeStyles-weight-2502 makeStyles-inline-2499"
     >
       Transaction
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2502 makeStyles-weight-2534 makeStyles-inline-2500"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2501 makeStyles-weight-2533 makeStyles-inline-2499"
     >
-
+       
       Request
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2535"
+    className="MuiBox-root MuiBox-root-2534"
   >
     <div
-      className="MuiBox-root MuiBox-root-2536"
+      className="MuiBox-root MuiBox-root-2535"
     />
     <div
-      className="MuiBox-root MuiBox-root-2537"
+      className="MuiBox-root MuiBox-root-2536"
     >
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2502 makeStyles-weight-2538"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2501 makeStyles-weight-2537"
       >
         The following site:
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2502 makeStyles-weight-2539"
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2501 makeStyles-weight-2538"
       >
         http://localhost/
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2502 makeStyles-weight-2540 makeStyles-inline-2500"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2501 makeStyles-weight-2539 makeStyles-inline-2499"
       >
         is asking for the following transactions to be made.
       </p>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-2541"
-    />
-    <div
-      className="MuiBox-root MuiBox-root-2542"
-    >
-      <div
-        className="MuiBox-root MuiBox-root-2543"
-      >
-        <div
-          className="MuiBox-root MuiBox-root-2544"
-        >
-          <div
-            className="MuiBox-root MuiBox-root-2545"
-          >
-            <p
-              className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2502 makeStyles-weight-2546"
-            >
-              Fee
-            </p>
-          </div>
-        </div>
-        <div
-          className="MuiBox-root MuiBox-root-2547"
-        >
-          <h6
-            className="MuiTypography-root MuiTypography-h6 makeStyles-weight-2502 makeStyles-weight-2548"
-          >
-            0,0288 ETH
-          </h6>
-        </div>
-      </div>
-      <div
-        className="MuiBox-root MuiBox-root-2549"
-      >
-        <div
-          className="MuiBox-root MuiBox-root-2550"
-        >
-          <div
-            className="MuiBox-root MuiBox-root-2551"
-          >
-            <p
-              className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2502 makeStyles-weight-2552"
-            >
-              Register
-            </p>
-          </div>
-        </div>
-        <div
-          className="MuiBox-root MuiBox-root-2553"
-        >
-          <h6
-            className="MuiTypography-root MuiTypography-h6 makeStyles-weight-2502 makeStyles-weight-2554"
-          >
-            billy*iov
-          </h6>
-        </div>
-      </div>
-    </div>
-    <div
-      className="MuiBox-root MuiBox-root-2555"
-    />
-    <div
-      className="MuiBox-root MuiBox-root-2556"
+      className="MuiBox-root MuiBox-root-2540"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -4509,7 +4379,7 @@ exports[`Storyshots Extension/Transaction Request Show Request page 1`] = `
       </span>
     </button>
     <div
-      className="MuiBox-root MuiBox-root-2577"
+      className="MuiBox-root MuiBox-root-2561"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-fullWidth"
@@ -4536,14 +4406,14 @@ exports[`Storyshots Extension/Transaction Request Show Request page 1`] = `
     </button>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2578"
+    className="MuiBox-root MuiBox-root-2562"
   />
   <div
-    className="MuiBox-root MuiBox-root-2579"
+    className="MuiBox-root MuiBox-root-2563"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2580"
+      className="makeStyles-root-2564"
       height={39}
       src="iov-logo.png"
       width={84}


### PR DESCRIPTION
**Description**
This PR will show real data from requests to appropriate views.
It will close #201 

**Screens**
Transaction request
![tx-req-show](https://user-images.githubusercontent.com/3502260/58109780-e6735480-7bf6-11e9-82fb-a0713570af61.png)
Transaction reject
![tx-req-reject](https://user-images.githubusercontent.com/3502260/58109779-e6735480-7bf6-11e9-9c77-8db01497786f.png)

Share identity
![share-identity-main](https://user-images.githubusercontent.com/3502260/58109793-ec693580-7bf6-11e9-9c28-68f82b013367.png)
Share identity reject
![share-identity-reject](https://user-images.githubusercontent.com/3502260/58109796-ec693580-7bf6-11e9-9e76-64a1d1f6feef.png)

**Developer notes**
This PR was not fully completed because of lack of data in request object