### PR TITLE
Feature #207 Reject automatically enqueued txs

### DIFF
--- a/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestCallback.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestCallback.ts
@@ -38,6 +38,7 @@ async function requestCallback<T>(
     };
 
     const reject = (permanent: boolean): void => {
+      RequestHandler.solved();
       if (permanent) {
         SenderWhitelist.block(senderUrl);
       }

--- a/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestCallback.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestCallback.ts
@@ -41,8 +41,8 @@ async function requestCallback<T>(
       RequestHandler.solved();
       if (permanent) {
         SenderWhitelist.block(senderUrl);
+        RequestHandler.purge(senderUrl);
       }
-      RequestHandler.solved();
       updateExtensionBadge(RequestHandler.requests().length);
       requestUpdater();
       resolve(rejectResponse);

--- a/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestHandler.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestHandler.ts
@@ -49,4 +49,22 @@ export class RequestHandler {
 
     return size;
   }
+
+  public static purge(senderUrl: string): void {
+    const initialSize = RequestHandler.instance.length;
+    for (let i = 0; i < initialSize; i++) {
+      const req = RequestHandler.instance[i];
+      if (req.sender !== senderUrl) {
+        continue;
+      }
+
+      // Note here we are mutating the array placing in first positions request to be rejected
+      RequestHandler.instance.splice(i, 1);
+      RequestHandler.instance.splice(0, 0, req);
+    }
+
+    // Note here we only get references
+    const reqToCancel = RequestHandler.instance.filter(req => req.sender === senderUrl);
+    reqToCancel.forEach(req => req.reject(false));
+  }
 }

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
-import Button from 'medulas-react-components/lib/components/Button';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Block from 'medulas-react-components/lib/components/Block';
-import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Button from 'medulas-react-components/lib/components/Button';
 import Back from 'medulas-react-components/lib/components/Button/Back';
-import Form, { useForm, FormValues } from 'medulas-react-components/lib/components/forms/Form';
 import CheckboxField from 'medulas-react-components/lib/components/forms/CheckboxField';
+import Form, { FormValues, useForm } from 'medulas-react-components/lib/components/forms/Form';
+import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
 import { SHARE_IDENTITY } from '../../paths';
 
 const PERMANENT_REJECT = 'permanentRejectField';
@@ -19,7 +19,9 @@ interface Props {
 const Layout = ({ onBack, onRejectRequest }: Props): JSX.Element => {
   const onSubmit = async (values: object): Promise<void> => {
     const formValues = values as FormValues;
-    onRejectRequest(formValues[PERMANENT_REJECT] === 'true');
+    const permanentReject = `${formValues[PERMANENT_REJECT]}` === 'true';
+
+    onRejectRequest(permanentReject);
   };
 
   const { form, handleSubmit, pristine, submitting } = useForm({

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/RejectRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/RejectRequest.tsx
@@ -20,7 +20,8 @@ interface Props {
 const Layout = ({ onBack, onRejectRequest }: Props): JSX.Element => {
   const onSubmit = async (values: object): Promise<void> => {
     const formValues = values as FormValues;
-    onRejectRequest(formValues[PERMANENT_REJECT] === 'true');
+    const permanentReject = `${formValues[PERMANENT_REJECT]}` === 'true';
+    onRejectRequest(permanentReject);
   };
 
   const { form, handleSubmit, pristine, submitting } = useForm({


### PR DESCRIPTION
**Description**
This PR removes from the background script's request queue all requests belonging to a permanently blocked sender.

It closes #207 

See this [feature in action](https://drive.google.com/open?id=1Z5WypTDvHHp56GnQDLOuPFR94NhgYKfE)

**Note for developers**
- Found a bug doing the conversion of permanent value from the form. Take a look!