### PR TITLE
Fix - Simplifies access to blocked list in SenderWhitelist unit test

### DIFF
--- a/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestSenderWhitelist/index.unit.spec.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestSenderWhitelist/index.unit.spec.ts
@@ -1,8 +1,6 @@
 import { SenderWhitelist } from './index';
 
 describe('SenderWhitelist', () => {
-  const BLOCKED_URLS_KEY = 'buk';
-  const SEPARATOR = ',';
   const SENDER_ONE = 'Example Sender 1';
   const SENDER_TWO = 'Example Sender 2';
 
@@ -19,9 +17,7 @@ describe('SenderWhitelist', () => {
     SenderWhitelist.block(SENDER_TWO);
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const numBlocked = localStorage.getItem(BLOCKED_URLS_KEY)!.split(SEPARATOR).length;
-
-    expect(numBlocked).toBe(2);
+    expect(SenderWhitelist['blocked']!.length).toBe(2);
   });
 
   it('persists blocked senders to localStorage so that they survive a reload', () => {

--- a/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestSenderWhitelist/index.unit.spec.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/requestSenderWhitelist/index.unit.spec.ts
@@ -16,8 +16,9 @@ describe('SenderWhitelist', () => {
     SenderWhitelist.block(SENDER_ONE);
     SenderWhitelist.block(SENDER_TWO);
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    expect(SenderWhitelist['blocked']!.length).toBe(2);
+    // SenderWhitelist does not expose the array of blocked domains, so this is an exceptional
+    // use case which can not be used in regular code because it violates private modifier of blocked variable.
+    expect(SenderWhitelist['blocked']!.length).toBe(2); // eslint-disable-line
   });
 
   it('persists blocked senders to localStorage so that they survive a reload', () => {


### PR DESCRIPTION
This PR refactors the unit testing suite for `SenderWhitelist` in order to:

- Make use of array access notation to simplify the access to `SenderWhitelist`'s blocked senders list.
- Removes no longer needed constants that are, additionaly, duplicated from `SenderWhitelist`.