### PR TITLE
Fix – Use stronger linting settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,10 +2,10 @@ module.exports = {
   //https://codequs.com/p/rk7e07UBV/using-eslint-and-prettier-in-a-typescript-project
   parser: '@typescript-eslint/parser',
   extends: [
-      'plugin:@typescript-eslint/recommended',
-      'react-app',
-      'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
-      'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    'plugin:@typescript-eslint/recommended',
+    'react-app',
+    'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+    'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],
   rules: {
     "@typescript-eslint/explicit-function-return-type": [ "error", {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,12 +2,15 @@ module.exports = {
   //https://codequs.com/p/rk7e07UBV/using-eslint-and-prettier-in-a-typescript-project
   parser: '@typescript-eslint/parser',
   extends: [
+    'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'react-app',
     'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],
   rules: {
+    "no-empty": "off",
+    "no-console": "warn",
     "@typescript-eslint/explicit-function-return-type": [ "error", {
       allowExpressions: true,
     }]

--- a/packages/bierzo-wallet/.eslintrc.js
+++ b/packages/bierzo-wallet/.eslintrc.js
@@ -1,5 +1,6 @@
-const baseConfig = require("../../.eslintrc");
-
 module.exports = {
-  ...baseConfig
+  extends: "../../.eslintrc.js",
+  rules: {
+    "no-console": "off",
+  }
 };

--- a/packages/bierzo-wallet/package.json
+++ b/packages/bierzo-wallet/package.json
@@ -24,7 +24,7 @@
     "@types/chrome": "^0.0.82"
   },
   "scripts": {
-    "lint": "eslint -c .eslintrc.js --max-warnings 1 'src/**/*.ts{,x}'",
+    "lint": "eslint -c .eslintrc.js --max-warnings 0 'src/**/*.ts{,x}'",
     "format": "prettier --write --loglevel warn './src/**/*.{ts,tsx,json,md,css}'",
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/packages/medulas-react-components/package.json
+++ b/packages/medulas-react-components/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "shx rm -rf ./lib/* && tsc && cp ./src/theme/utils/fonts.css ./lib/theme/utils/fonts.css && cp -R ./src/theme/assets ./lib/theme/",
     "format": "prettier --write --loglevel warn './src/**/*.{ts,tsx,json,md,css}'",
-    "lint": "eslint -c .eslintrc.js --max-warnings 1 'src/**/*.ts{,x}'"
+    "lint": "eslint -c .eslintrc.js --max-warnings 0 'src/**/*.ts{,x}'"
   },
   "browserslist": [
     ">0.2%",

--- a/packages/medulas-react-components/src/components/forms/CheckboxField/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/CheckboxField/index.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import React from 'react';

--- a/packages/medulas-react-components/src/components/forms/CheckboxField/index.tsx
+++ b/packages/medulas-react-components/src/components/forms/CheckboxField/index.tsx
@@ -29,7 +29,7 @@ const CheckboxField = ({ fieldName, form, initial, onChangeCallback, label }: Pr
         onChange(initial);
       }
     } catch (err) {}
-  }, [input]);
+  }, [initial, input, onChange, value]);
 
   const onCheckBoxChange = (_: React.ChangeEvent<HTMLInputElement>, checked: boolean): void => {
     onChange(checked);

--- a/packages/medulas-react-components/src/components/forms/Form/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/Form/index.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { Storybook } from '../../../utils/storybook';

--- a/packages/medulas-react-components/src/components/forms/SelectFieldForm/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/SelectFieldForm/index.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import React from 'react';

--- a/packages/sanes-chrome-extension/package.json
+++ b/packages/sanes-chrome-extension/package.json
@@ -10,7 +10,7 @@
     "build": "react-scripts build src/extension/contentscript.ts src/extension/backgroundscript.ts",
     "export": "yarn use-config-production && yarn build && web-ext build --source-dir ./build/ --artifacts-dir ./exports --overwrite-dest",
     "format": "prettier --write --loglevel warn './src/**/*.{ts,tsx,json,md,css}'",
-    "lint": "eslint -c .eslintrc.js --max-warnings 1 'src/**/*.ts{,x}'",
+    "lint": "eslint -c .eslintrc.js --max-warnings 0 'src/**/*.ts{,x}'",
     "start": "yarn use-config-test && react-scripts start src/extension/contentscript.ts src/extension/backgroundscript.ts",
     "start:firefox:test": "yarn use-config-test && yarn build && web-ext run --source-dir ./build/",
     "start:firefox:development": "yarn use-config-development && yarn build && web-ext run --source-dir ./build/",

--- a/packages/sanes-chrome-extension/src/context/PersonaProvider.tsx
+++ b/packages/sanes-chrome-extension/src/context/PersonaProvider.tsx
@@ -45,7 +45,6 @@ export const PersonaProvider = ({ children, persona }: Props): JSX.Element => {
       return;
     }
 
-    console.log('PersonaProvider registering listener');
     chrome.runtime.onMessage.addListener((msg, sender, _sendResponse) => {
       const sameTarget = sender.id === chrome.runtime.id;
       const msgToForeground = isMessageToForeground(msg);

--- a/packages/sanes-chrome-extension/src/context/RequestProvider.tsx
+++ b/packages/sanes-chrome-extension/src/context/RequestProvider.tsx
@@ -40,11 +40,12 @@ export const RequestProvider = ({ children, initialRequests }: Props): JSX.Eleme
       }
 
       switch (message.action) {
-        case MessageToForegroundAction.RequestsChanged:
+        case MessageToForegroundAction.RequestsChanged: {
           const extensionWindow = chrome.extension.getBackgroundPage() as IovWindowExtension;
           const requests = extensionWindow.getQueuedRequests();
           setRequests([...requests]);
           break;
+        }
         default:
           throw new Error('Unknown action');
       }

--- a/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/index.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/actions/createPersona/index.ts
@@ -29,7 +29,6 @@ export async function createPersona(mnemonic?: string): Promise<CreatePersonaRes
   clear(); // Assure we start from clean instances
   persona = await Persona.create(mnemonic);
   signingServer = persona.startSigningServer(getIdentitiesCallback, signAndPostCallback, transactionsUpdater);
-  console.log('Signing server ready to handle requests');
 
   SenderWhitelist.load();
   RequestHandler.load();

--- a/packages/sanes-chrome-extension/src/extension/background/handlers/internalHandler.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/handlers/internalHandler.ts
@@ -9,8 +9,6 @@ export function internalHandler(
   sender: chrome.runtime.MessageSender,
   sendResponse: (response?: any) => void, // eslint-disable-line
 ): boolean {
-  console.log(message, sender);
-
   if (sender.id !== chrome.runtime.id) {
     throw new Error('Sender is not allowed to perform this action');
   }
@@ -19,16 +17,19 @@ export function internalHandler(
     case MessageToBackgroundAction.GetPersona:
       getPersona()
         .then(sendResponse)
+        // eslint-disable-next-line no-console
         .catch(console.error);
       break;
     case MessageToBackgroundAction.CreatePersona:
       createPersona()
         .then(sendResponse)
+        // eslint-disable-next-line no-console
         .catch(console.error);
       break;
     case MessageToBackgroundAction.CreateAccount:
       createAccount()
         .then(sendResponse)
+        // eslint-disable-next-line no-console
         .catch(console.error);
       break;
     default:

--- a/packages/sanes-chrome-extension/src/extension/background/messages/index.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/messages/index.ts
@@ -46,7 +46,6 @@ export async function sendCreatePersonaMessage(mnemonic?: string): Promise<Creat
         return;
       }
 
-      console.log(response);
       resolve({
         accounts: response.accounts,
         mnemonic: response.mnemonic,

--- a/packages/sanes-chrome-extension/src/index.tsx
+++ b/packages/sanes-chrome-extension/src/index.tsx
@@ -24,8 +24,6 @@ const render = (
   persona: GetPersonaResponse,
   requests: ReadonlyArray<Request>,
 ): void => {
-  console.log('root index.tsx with requests: ' + requests.length);
-
   ReactDOM.render(
     <Provider store={store}>
       <MedulasThemeProvider injectFonts injectStyles={globalStyles}>

--- a/packages/sanes-chrome-extension/src/logic/config/codec.ts
+++ b/packages/sanes-chrome-extension/src/logic/config/codec.ts
@@ -64,9 +64,10 @@ export function chainConnector(codec: CodecType, nodes: ReadonlyArray<string>): 
       return bnsConnector(url);
     case CodecType.Lisk:
       return liskConnector(url);
-    case CodecType.Ethereum:
+    case CodecType.Ethereum: {
       const scraperApiUrl = nodes[1];
       return ethereumConnector(url, { scraperApiUrl });
+    }
     default:
       throw new Error('No connector for this codec found');
   }

--- a/packages/sanes-chrome-extension/src/logic/persona/persona.unit.spec.ts
+++ b/packages/sanes-chrome-extension/src/logic/persona/persona.unit.spec.ts
@@ -1,4 +1,4 @@
-import { TokenTicker, PublicIdentity } from '@iov/bcp';
+import { PublicIdentity } from '@iov/bcp';
 import { TransactionEncoder, GetIdentitiesAuthorization, SignAndPostAuthorization } from '@iov/core';
 import { EnglishMnemonic } from '@iov/crypto';
 

--- a/packages/sanes-chrome-extension/src/utils/test/e2e.ts
+++ b/packages/sanes-chrome-extension/src/utils/test/e2e.ts
@@ -20,6 +20,7 @@ export async function createPage(browser: Browser): Promise<Page> {
   await page.goto('chrome-extension://dafekhlcpidfaopcimocbcpciholgkkb/index.html', {
     waitUntil: 'networkidle2',
   });
+  // eslint-disable-next-line no-console
   page.on('console', msg => console.log('PAGE LOG:', msg.text()));
   page.bringToFront();
 


### PR DESCRIPTION
Before, we used `--max-warnings 1`, which was a stupid mistake by me as it allowsed up to 1 warning per package.

Also added `eslint:recommended` as a baseline ruleset.