### PR TITLE
Feature #193 - DOM tests for Requests view

### DIFF
--- a/packages/sanes-chrome-extension/src/routes/requests/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/requests/index.dom.spec.ts
@@ -1,6 +1,6 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import { Request } from '../../extension/background/actions/createPersona/requestHandler';
+import { Request } from '../../extension/background/model/signingServer/requestQueueManager';
 import { aNewStore } from '../../store';
 import { RootState } from '../../store/reducers';
 import { whenOnNavigatedToRoute } from '../../utils/test/navigation';

--- a/packages/sanes-chrome-extension/src/routes/requests/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/requests/index.dom.spec.ts
@@ -42,7 +42,7 @@ describe('DOM > Feature > Requests', () => {
     });
 
     await whenOnNavigatedToRoute(store, SHARE_IDENTITY);
-  });
+  }, 55000);
 
   it('redirects to the TX Request view when a Request of type "signAndPost" is clicked', async () => {
     requestsDom = await travelToRequests(store, [REQUEST_TWO, REQUEST_ONE]);
@@ -53,5 +53,5 @@ describe('DOM > Feature > Requests', () => {
     });
 
     await whenOnNavigatedToRoute(store, TX_REQUEST);
-  });
+  }, 55000);
 });

--- a/packages/sanes-chrome-extension/src/routes/requests/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/requests/index.dom.spec.ts
@@ -2,7 +2,7 @@ import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
 import { Request } from '../../extension/background/model/signingServer/requestQueueManager';
 import { aNewStore } from '../../store';
-import { RootState } from '../../store/reducers';
+import { resetHistory, RootState } from '../../store/reducers';
 import { whenOnNavigatedToRoute } from '../../utils/test/navigation';
 import { SHARE_IDENTITY, TX_REQUEST } from '../paths';
 import { travelToRequests } from './test/travelToRequests';
@@ -30,6 +30,7 @@ describe('DOM > Feature > Requests', () => {
   let requestsDom: React.Component;
 
   beforeEach(() => {
+    resetHistory();
     store = aNewStore();
   });
 

--- a/packages/sanes-chrome-extension/src/routes/requests/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/requests/index.dom.spec.ts
@@ -1,0 +1,57 @@
+import TestUtils from 'react-dom/test-utils';
+import { Store } from 'redux';
+import { Request } from '../../extension/background/actions/createPersona/requestHandler';
+import { aNewStore } from '../../store';
+import { RootState } from '../../store/reducers';
+import { whenOnNavigatedToRoute } from '../../utils/test/navigation';
+import { SHARE_IDENTITY, TX_REQUEST } from '../paths';
+import { travelToRequests } from './test/travelToRequests';
+
+describe('DOM > Feature > Requests', () => {
+  const REQUEST_ONE: Request = {
+    id: 1,
+    type: 'getIdentities',
+    reason: 'Reason 1',
+    data: { senderUrl: 'www.sender1.com', requestedIdentities: [] },
+    accept: jest.fn(),
+    reject: jest.fn(),
+  };
+
+  const REQUEST_TWO: Request = {
+    id: 2,
+    type: 'signAndPost',
+    reason: 'Reason 2',
+    data: { senderUrl: 'www.sender2.com', tx: '' },
+    accept: jest.fn(),
+    reject: jest.fn(),
+  };
+
+  let store: Store<RootState>;
+  let requestsDom: React.Component;
+
+  beforeEach(() => {
+    store = aNewStore();
+  });
+
+  it('redirects to the Share Identity view when a Request of type "getIdentities" is clicked', async () => {
+    requestsDom = await travelToRequests(store, [REQUEST_ONE, REQUEST_TWO]);
+    const identityRequest = TestUtils.scryRenderedDOMComponentsWithTag(requestsDom, 'li')[0];
+
+    TestUtils.act(() => {
+      TestUtils.Simulate.click(identityRequest);
+    });
+
+    await whenOnNavigatedToRoute(store, SHARE_IDENTITY);
+  });
+
+  it('redirects to the TX Request view when a Request of type "signAndPost" is clicked', async () => {
+    requestsDom = await travelToRequests(store, [REQUEST_TWO, REQUEST_ONE]);
+    const txRequest = TestUtils.scryRenderedDOMComponentsWithTag(requestsDom, 'li')[0];
+
+    TestUtils.act(() => {
+      TestUtils.Simulate.click(txRequest);
+    });
+
+    await whenOnNavigatedToRoute(store, TX_REQUEST);
+  });
+});

--- a/packages/sanes-chrome-extension/src/routes/requests/test/travelToRequests.ts
+++ b/packages/sanes-chrome-extension/src/routes/requests/test/travelToRequests.ts
@@ -1,0 +1,27 @@
+import TestUtils from 'react-dom/test-utils';
+import { Store } from 'redux';
+import { Request } from '../../../extension/background/actions/createPersona/requestHandler';
+import { history } from '../../../store/reducers';
+import { createDom } from '../../../utils/test/dom';
+import { whenOnNavigatedToRoute } from '../../../utils/test/navigation';
+import { sleep } from '../../../utils/timer';
+import { REQUEST_ROUTE } from '../../paths';
+
+export const travelToRequests = async (
+  store: Store,
+  requests: ReadonlyArray<Request>,
+): Promise<React.Component> => {
+  expect(requests.length).toBeGreaterThanOrEqual(1);
+
+  const dom = createDom(store, requests);
+
+  const navigate = async (): Promise<void> => {
+    history.push(REQUEST_ROUTE);
+    await whenOnNavigatedToRoute(store, REQUEST_ROUTE);
+    await sleep(1000);
+  };
+  // FIXME  Once this is updated https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-dom/test-utils/index.d.ts#L296
+  await TestUtils.act(navigate as any); //eslint-disable-line @typescript-eslint/no-explicit-any
+
+  return dom;
+};

--- a/packages/sanes-chrome-extension/src/store/reducers/index.ts
+++ b/packages/sanes-chrome-extension/src/store/reducers/index.ts
@@ -1,10 +1,16 @@
-import { createBrowserHistory } from 'history';
 import { connectRouter } from 'connected-react-router';
-import { History } from 'history';
+import { createBrowserHistory, History } from 'history';
 import { combineReducers } from 'redux';
 import { StateType } from 'typesafe-actions';
 
 export let history = createBrowserHistory();
+
+/**
+ * This method can only be used in test enviromnets
+ */
+export const resetHistory = (): void => {
+  history = createBrowserHistory();
+};
 
 // eslint-disable-next-line
 const createRootReducer = (history: History) =>


### PR DESCRIPTION
**Description**
In the Requests view, the user can click on the first request to solve it. Depending on the type of the request, it will be redirected to a different rout. If the request is of type "getIdentities" it will be redirected to the Share Identity view, whereas if it is of type "signAndPost" it will be redirected to the TX Request view.

The tests that have been implemented aim to check that each type of request redirect to its corresponding view when clicked.

**Bug**
There is currently a bug that makes the test not pass if executed on the same run. That is to say, the tests pass if executed individually by setting `it.only()`.

It closes #193.