### PR TITLE
Feature #111 - DOM tests for Account Status view

### DIFF
--- a/packages/sanes-chrome-extension/src/routes/account/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/account/index.dom.spec.ts
@@ -1,18 +1,13 @@
 import { TokenTicker } from '@iov/bcp';
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
-import * as messages from '../../extension/background/messages';
-import { CreatePersonaResponse, GetPersonaResponse } from '../../extension/background/messages';
+import { GetPersonaResponse } from '../../extension/background/messages';
 import { PersonaAcccount, ProcessedTx } from '../../logic/persona';
 import { aNewStore } from '../../store';
 import { RootState } from '../../store/reducers';
-import { whenOnNavigatedToRoute } from '../../utils/test/navigation';
-import { withChainsDescribe } from '../../utils/test/testExecutor';
-import { ACCOUNT_STATUS_ROUTE } from '../paths';
-import { processSignUp } from '../signup/test/travelToSignup';
 import { travelToAccount } from './test/travelToAccount';
 
-withChainsDescribe('DOM > Feature > Account Status', () => {
+describe('DOM > Feature > Account Status', () => {
   const accountMock: PersonaAcccount = { label: 'Account 0' };
   const mnemonic = 'badge cattle stool execute involve main mirror envelope brave scrap involve simple';
   const txMock: ProcessedTx = {
@@ -24,13 +19,7 @@ withChainsDescribe('DOM > Feature > Account Status', () => {
     error: null,
   };
 
-  const createPersonaResponse: CreatePersonaResponse = {
-    accounts: [accountMock],
-    mnemonic,
-    txs: [txMock],
-  };
-
-  const getPersonaResponse: GetPersonaResponse = {
+  const personaMock: GetPersonaResponse = {
     accounts: [accountMock],
     mnemonic,
     txs: [txMock],
@@ -41,13 +30,7 @@ withChainsDescribe('DOM > Feature > Account Status', () => {
 
   beforeEach(async () => {
     store = aNewStore();
-
-    jest.spyOn(messages, 'sendCreatePersonaMessage').mockResolvedValue(createPersonaResponse);
-
-    await processSignUp(store);
-    await whenOnNavigatedToRoute(store, ACCOUNT_STATUS_ROUTE);
-
-    accountStatusDom = await travelToAccount(store, getPersonaResponse);
+    accountStatusDom = await travelToAccount(store, personaMock);
   });
 
   it('has a hamburger button', () => {

--- a/packages/sanes-chrome-extension/src/routes/account/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/account/index.dom.spec.ts
@@ -1,0 +1,69 @@
+import { TokenTicker } from '@iov/bcp';
+import TestUtils from 'react-dom/test-utils';
+import { Store } from 'redux';
+import * as messages from '../../extension/background/messages';
+import { CreatePersonaResponse, GetPersonaResponse } from '../../extension/background/messages';
+import { PersonaAcccount, ProcessedTx } from '../../logic/persona';
+import { aNewStore } from '../../store';
+import { RootState } from '../../store/reducers';
+import { whenOnNavigatedToRoute } from '../../utils/test/navigation';
+import { withChainsDescribe } from '../../utils/test/testExecutor';
+import { ACCOUNT_STATUS_ROUTE } from '../paths';
+import { processSignUp } from '../signup/test/travelToSignup';
+import { travelToAccount } from './test/travelToAccount';
+
+withChainsDescribe('DOM > Feature > Account Status', () => {
+  const accountMock: PersonaAcccount = { label: 'Account 0' };
+  const mnemonic = 'badge cattle stool execute involve main mirror envelope brave scrap involve simple';
+  const txMock: ProcessedTx = {
+    id: '111',
+    recipient: 'Example Recipient',
+    signer: 'Example Signer',
+    amount: { quantity: '10', fractionalDigits: 3, tokenTicker: 'ETH' as TokenTicker },
+    time: 'Sat May 25 10:10:00 2019 +0200',
+    error: null,
+  };
+
+  const createPersonaResponse: CreatePersonaResponse = {
+    accounts: [accountMock],
+    mnemonic,
+    txs: [txMock],
+  };
+
+  const getPersonaResponse: GetPersonaResponse = {
+    accounts: [accountMock],
+    mnemonic,
+    txs: [txMock],
+  };
+
+  let store: Store<RootState>;
+  let accountStatusDom: React.Component;
+
+  beforeEach(async () => {
+    store = aNewStore();
+
+    jest.spyOn(messages, 'sendCreatePersonaMessage').mockResolvedValue(createPersonaResponse);
+
+    await processSignUp(store);
+    await whenOnNavigatedToRoute(store, ACCOUNT_STATUS_ROUTE);
+
+    accountStatusDom = await travelToAccount(store, getPersonaResponse);
+    await whenOnNavigatedToRoute(store, ACCOUNT_STATUS_ROUTE);
+  });
+
+  it('has a hamburger button', () => {
+    const hamburgerButton = TestUtils.scryRenderedDOMComponentsWithTag(accountStatusDom, 'button')[0];
+    expect(hamburgerButton.getAttribute('aria-label')).toBe('Open drawer');
+  });
+
+  it('has a select dropdown with one account', () => {
+    const accountInput = TestUtils.findRenderedDOMComponentWithTag(accountStatusDom, 'input');
+    expect(accountInput.getAttribute('value')).toBe('Account 0');
+  });
+
+  it('has a transactions box with one transaction', () => {
+    const tx = TestUtils.scryRenderedDOMComponentsWithTag(accountStatusDom, 'li')[1];
+    const txTime = tx.children[1].children[1].textContent;
+    expect(txTime).toBe(txMock.time);
+  });
+});

--- a/packages/sanes-chrome-extension/src/routes/account/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/account/index.dom.spec.ts
@@ -48,7 +48,6 @@ withChainsDescribe('DOM > Feature > Account Status', () => {
     await whenOnNavigatedToRoute(store, ACCOUNT_STATUS_ROUTE);
 
     accountStatusDom = await travelToAccount(store, getPersonaResponse);
-    await whenOnNavigatedToRoute(store, ACCOUNT_STATUS_ROUTE);
   });
 
   it('has a hamburger button', () => {

--- a/packages/sanes-chrome-extension/src/routes/account/test/travelToAccount.ts
+++ b/packages/sanes-chrome-extension/src/routes/account/test/travelToAccount.ts
@@ -1,12 +1,16 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+import { GetPersonaResponse } from '../../../extension/background/messages';
 import { history } from '../../../store/reducers';
 import { createDom } from '../../../utils/test/dom';
 import { whenOnNavigatedToRoute } from '../../../utils/test/navigation';
 import { ACCOUNT_STATUS_ROUTE } from '../../paths';
 
-export const travelToAccount = async (store: Store): Promise<React.Component> => {
-  const dom = createDom(store);
+export const travelToAccount = async (
+  store: Store,
+  persona?: GetPersonaResponse,
+): Promise<React.Component> => {
+  const dom = createDom(store, [], persona);
   TestUtils.act(
     (): void => {
       history.push(ACCOUNT_STATUS_ROUTE);


### PR DESCRIPTION
**Description**
This PR aims to add DOM testing to the Account Status view in order to test that the basic UI elements are present and that the transaction box works as expected.

- Test that the hamburger button is present.
- Test that the Account dropdown has an account.
- Test that the transaction box has the expected mocked transaction.

It closes #111.