### PR TITLE
Feature #217 - Password fields for Restore Account view

### DIFF
--- a/packages/medulas-react-components/src/utils/forms/validators/index.tsx
+++ b/packages/medulas-react-components/src/utils/forms/validators/index.tsx
@@ -57,3 +57,23 @@ export const notLongerThan = (maxLength: number): FieldValidator => {
     return undefined;
   };
 };
+
+export const longerThan = (minLength: number): FieldValidator => {
+  return (value): ValidationError => {
+    if (value && value.length < minLength) {
+      return `Must be longer than ${minLength} characters`;
+    }
+
+    return undefined;
+  };
+};
+
+export const numberOfWords = (numWords: number): FieldValidator => {
+  return (value): ValidationError => {
+    if (value && value.split(' ').length !== numWords) {
+      return `Should contain ${numWords} words only`;
+    }
+
+    return undefined;
+  };
+};

--- a/packages/sanes-chrome-extension/src/routes/account/index.e2e.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/account/index.e2e.spec.ts
@@ -1,9 +1,10 @@
 import { Browser, Page } from 'puppeteer';
 import { closeBrowser, createPage, launchBrowser } from '../../utils/test/e2e';
+import { randomString } from '../../utils/test/random';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
+import { sleep } from '../../utils/timer';
 import { submitRecoveryPhraseE2E } from '../restore-account/test/fillRecoveryPhrase';
 import { travelToRestoreAccountStep } from '../restore-account/test/travelToRestoreAccount';
-import { sleep } from '../../utils/timer';
 
 withChainsDescribe('E2E > Account route', () => {
   let browser: Browser;
@@ -14,8 +15,9 @@ withChainsDescribe('E2E > Account route', () => {
     page = await createPage(browser);
 
     await travelToRestoreAccountStep(page);
+    const password = randomString(10);
     const mnemonic = 'degree tackle suggest window test behind mesh extra cover prepare oak script';
-    await submitRecoveryPhraseE2E(page, mnemonic);
+    await submitRecoveryPhraseE2E(page, mnemonic, password);
   }, 10000);
 
   afterEach(async () => {

--- a/packages/sanes-chrome-extension/src/routes/restore-account/components/SetMnemonicForm.tsx
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/components/SetMnemonicForm.tsx
@@ -1,45 +1,35 @@
-import * as React from 'react';
-import Button from 'medulas-react-components/lib/components/Button';
 import Block from 'medulas-react-components/lib/components/Block';
+import Button from 'medulas-react-components/lib/components/Button';
 import Back from 'medulas-react-components/lib/components/Button/Back';
-import Typography from 'medulas-react-components/lib/components/Typography';
-import Form, {
-  useForm,
-  FormValues,
-  ValidationError,
-} from 'medulas-react-components/lib/components/forms/Form';
+import Form, { FormValues, useForm } from 'medulas-react-components/lib/components/forms/Form';
 import TextFieldForm from 'medulas-react-components/lib/components/forms/TextFieldForm';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import { numberOfWords } from 'medulas-react-components/lib/utils/forms/validators';
+import * as React from 'react';
+import { useMemo } from 'react';
 import { RESTORE_ACCOUNT } from '../../paths';
 
-export const RECOVERY_PHRASE = 'recoveryPhraseField';
-
-const validate = (values: object): object => {
-  const formValues = values as FormValues;
-  let errors: ValidationError = {};
-
-  if (formValues[RECOVERY_PHRASE] && formValues[RECOVERY_PHRASE].split(' ').length !== 12) {
-    errors[RECOVERY_PHRASE] = 'Recovery phrase should contain 12 words only.';
-  }
-
-  return errors;
-};
+export const MNEMONIC_FIELD = 'mnemonicField';
+export const MNEMONIC_NUM_WORDS = 12;
 
 interface Props {
-  readonly onRestoreAccount: (values: FormValues) => void;
+  readonly onSetMnemonic: (values: FormValues) => void;
   readonly onBack: () => void;
 }
 
-const RestoreAccountForm = ({ onRestoreAccount, onBack }: Props): JSX.Element => {
+const SetMnemonicForm = ({ onSetMnemonic, onBack }: Props): JSX.Element => {
   const onSubmit = async (values: object): Promise<void> => {
     const formValues = values as FormValues;
-    onRestoreAccount(formValues);
+    onSetMnemonic(formValues);
   };
 
-  const { form, handleSubmit, submitting, invalid } = useForm({
-    onSubmit,
-    validate,
-  });
+  const { form, handleSubmit, submitting, invalid } = useForm({ onSubmit });
+
+  //TODO optimize update of validators with array of dependencies
+  const validator = useMemo(() => {
+    return numberOfWords(MNEMONIC_NUM_WORDS);
+  }, []);
 
   return (
     <PageLayout id={RESTORE_ACCOUNT} primaryTitle="Restore" title="Account">
@@ -54,7 +44,8 @@ const RestoreAccountForm = ({ onRestoreAccount, onBack }: Props): JSX.Element =>
             placeholder="Recovery phrase"
             form={form}
             fullWidth
-            name={RECOVERY_PHRASE}
+            name={MNEMONIC_FIELD}
+            validate={validator}
           />
         </Block>
         <Block display="flex" justifyContent="space-between">
@@ -65,7 +56,7 @@ const RestoreAccountForm = ({ onRestoreAccount, onBack }: Props): JSX.Element =>
           </Block>
           <Block width={120}>
             <Button fullWidth type="submit" disabled={invalid || submitting}>
-              Restore
+              Continue
             </Button>
           </Block>
         </Block>
@@ -74,4 +65,4 @@ const RestoreAccountForm = ({ onRestoreAccount, onBack }: Props): JSX.Element =>
   );
 };
 
-export default RestoreAccountForm;
+export default SetMnemonicForm;

--- a/packages/sanes-chrome-extension/src/routes/restore-account/components/SetPasswordForm.tsx
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/components/SetPasswordForm.tsx
@@ -1,0 +1,106 @@
+import Block from 'medulas-react-components/lib/components/Block';
+import Button from 'medulas-react-components/lib/components/Button';
+import Back from 'medulas-react-components/lib/components/Button/Back';
+import Form, {
+  FormValues,
+  useForm,
+  ValidationError,
+} from 'medulas-react-components/lib/components/forms/Form';
+import TextFieldForm from 'medulas-react-components/lib/components/forms/TextFieldForm';
+import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import { composeValidators, longerThan, required } from 'medulas-react-components/lib/utils/forms/validators';
+import * as React from 'react';
+import { useMemo } from 'react';
+import { RESTORE_ACCOUNT } from '../../paths';
+
+export const SET_PASSWORD_STEP_RESTORE_ACCOUNT_ROUTE = `${RESTORE_ACCOUNT}2`;
+
+export const PASSWORD_FIELD = 'passwordField';
+const PASSWORD_MIN_LENGTH = 8;
+export const PASSWORD_CONFIRM_FIELD = 'passwordConfirmField';
+
+const validate = (values: object): object => {
+  const formValues = values as FormValues;
+  let errors: ValidationError = {};
+
+  if (formValues[PASSWORD_FIELD] !== formValues[PASSWORD_CONFIRM_FIELD]) {
+    errors[PASSWORD_CONFIRM_FIELD] = 'Passwords mismatch';
+  }
+
+  return errors;
+};
+
+interface Props {
+  readonly onSetPassword: (values: FormValues) => void;
+  readonly onBack: () => void;
+}
+
+const SetPasswordForm = ({ onSetPassword, onBack }: Props): JSX.Element => {
+  const onSubmit = async (values: object): Promise<void> => {
+    const formValues = values as FormValues;
+    onSetPassword(formValues);
+  };
+
+  const { form, handleSubmit, submitting, invalid } = useForm({
+    onSubmit,
+    validate,
+  });
+
+  //TODO optimize update of validators with array of dependencies
+  const validatorPassword = useMemo(() => {
+    return composeValidators(required, longerThan(PASSWORD_MIN_LENGTH));
+  }, []);
+
+  const validatorPasswordConfirm = useMemo(() => {
+    return required;
+  }, []);
+
+  return (
+    <PageLayout id={SET_PASSWORD_STEP_RESTORE_ACCOUNT_ROUTE} primaryTitle="Restore" title="Account">
+      <Typography variant="subtitle1" inline>
+        Enter the new password that will be used to encrypt your profile.
+      </Typography>
+      <Form onSubmit={handleSubmit}>
+        <Block marginTop={2} marginBottom={1}>
+          <TextFieldForm
+            label="Password"
+            placeholder="Password"
+            type="password"
+            form={form}
+            required
+            fullWidth
+            name={PASSWORD_FIELD}
+            validate={validatorPassword}
+          />
+        </Block>
+        <Block marginBottom={4}>
+          <TextFieldForm
+            label="Confirm Password"
+            placeholder="Confirm Password"
+            type="password"
+            form={form}
+            required
+            fullWidth
+            name={PASSWORD_CONFIRM_FIELD}
+            validate={validatorPasswordConfirm}
+          />
+        </Block>
+        <Block display="flex" justifyContent="space-between">
+          <Block width={120}>
+            <Back fullWidth onClick={onBack}>
+              Back
+            </Back>
+          </Block>
+          <Block width={120}>
+            <Button fullWidth type="submit" disabled={invalid || submitting}>
+              Restore
+            </Button>
+          </Block>
+        </Block>
+      </Form>
+    </PageLayout>
+  );
+};
+
+export default SetPasswordForm;

--- a/packages/sanes-chrome-extension/src/routes/restore-account/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/index.dom.spec.ts
@@ -3,31 +3,35 @@ import { PersonaData } from '../../extension/background/model/backgroundscript';
 import { aNewStore } from '../../store';
 import { RootState } from '../../store/reducers';
 import * as chromeInternalMsgs from '../../utils/chrome';
+import { whenOnNavigatedToRoute } from '../../utils/test/navigation';
+import { randomString } from '../../utils/test/random';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
+import { ACCOUNT_STATUS_ROUTE } from '../paths';
 import { submitRecoveryPhrase } from './test/fillRecoveryPhrase';
 import { travelToRestoreAccount } from './test/travelToRestoreAccount';
 
-withChainsDescribe(
-  'DOM > Feature > Restore Account',
-  (): void => {
-    let store: Store<RootState>;
+withChainsDescribe('DOM > Feature > Restore Account', () => {
+  const password = randomString(10);
+  const mnemonic = 'badge cattle stool execute involve main mirror envelope brave scrap involve simple';
 
-    beforeEach(() => {
-      store = aNewStore();
+  const response: PersonaData = {
+    accounts: [],
+    mnemonic,
+    txs: [],
+  };
 
-      const response: PersonaData = {
-        accounts: [],
-        mnemonic: 'badge cattle stool execute involve main mirror envelope brave scrap involve simple',
-        txs: [],
-      };
-      jest.spyOn(chromeInternalMsgs, 'createPersona').mockResolvedValueOnce(response);
-    });
+  let store: Store<RootState>;
+  let restoreAccountDom: React.Component;
 
-    it(`should restore profile from mnemonic`, async (): Promise<void> => {
-      const RestoreDOM = await travelToRestoreAccount(store);
+  beforeEach(async () => {
+    jest.spyOn(chromeInternalMsgs, 'createPersona').mockResolvedValueOnce(response);
 
-      const mnemonic = 'badge cattle stool execute involve main mirror envelope brave scrap involve simple';
-      await submitRecoveryPhrase(RestoreDOM, mnemonic);
-    }, 55000);
-  },
-);
+    store = aNewStore();
+    restoreAccountDom = await travelToRestoreAccount(store);
+  });
+
+  it('should restore profile from mnemonic', async () => {
+    await submitRecoveryPhrase(restoreAccountDom, mnemonic, password);
+    await whenOnNavigatedToRoute(store, ACCOUNT_STATUS_ROUTE);
+  }, 55000);
+});

--- a/packages/sanes-chrome-extension/src/routes/restore-account/index.e2e.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/index.e2e.spec.ts
@@ -1,33 +1,28 @@
 import { Browser, Page } from 'puppeteer';
+import { closeBrowser, createPage, launchBrowser } from '../../utils/test/e2e';
+import { randomString } from '../../utils/test/random';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
-import { launchBrowser, createPage, closeBrowser } from '../../utils/test/e2e';
-import { travelToRestoreAccountStep } from './test/travelToRestoreAccount';
 import { submitRecoveryPhraseE2E } from './test/fillRecoveryPhrase';
+import { travelToRestoreAccountStep } from './test/travelToRestoreAccount';
 
-withChainsDescribe(
-  'E2E > Restore Account route',
-  (): void => {
-    let browser: Browser;
-    let page: Page;
+withChainsDescribe('E2E > Restore Account route', () => {
+  const password = randomString(10);
+  const mnemonic = 'degree tackle suggest window test behind mesh extra cover prepare oak script';
 
-    beforeEach(async (): Promise<void> => {
-      browser = await launchBrowser();
-      page = await createPage(browser);
-    }, 45000);
+  let browser: Browser;
+  let page: Page;
 
-    afterEach(
-      async (): Promise<void> => {
-        await closeBrowser(browser);
-      },
-    );
+  beforeEach(async () => {
+    browser = await launchBrowser();
+    page = await createPage(browser);
+  }, 45000);
 
-    it('should redirect to restore account route, fill recovery phrase and redirect to account route', async (): Promise<
-      void
-    > => {
-      await travelToRestoreAccountStep(page);
+  afterEach(async () => {
+    await closeBrowser(browser);
+  });
 
-      const mnemonic = 'degree tackle suggest window test behind mesh extra cover prepare oak script';
-      await submitRecoveryPhraseE2E(page, mnemonic);
-    }, 60000);
-  },
-);
+  it('should redirect to restore account route, fill recovery phrase and redirect to account route', async () => {
+    await travelToRestoreAccountStep(page);
+    await submitRecoveryPhraseE2E(page, mnemonic, password);
+  }, 60000);
+});

--- a/packages/sanes-chrome-extension/src/routes/restore-account/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/index.stories.tsx
@@ -1,15 +1,25 @@
-import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
-import RestoreAccountForm from './components';
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
+import SetMnemonicForm from './components/SetMnemonicForm';
+import SetPasswordForm from './components/SetPasswordForm';
 
-storiesOf(CHROME_EXTENSION_ROOT, module).add(
-  'Restore Account page',
-  (): JSX.Element => (
-    <Storybook>
-      <RestoreAccountForm onBack={action('back in history')} onRestoreAccount={action('restore account')} />
-    </Storybook>
-  ),
-);
+storiesOf(`${CHROME_EXTENSION_ROOT}/Restore Account`, module)
+  .add(
+    'Set Mnemonic page',
+    (): JSX.Element => (
+      <Storybook>
+        <SetMnemonicForm onBack={action('back in history')} onSetMnemonic={action('password step')} />
+      </Storybook>
+    ),
+  )
+  .add(
+    'Set Password page',
+    (): JSX.Element => (
+      <Storybook>
+        <SetPasswordForm onBack={action('back in history')} onSetPassword={action('restore account')} />
+      </Storybook>
+    ),
+  );

--- a/packages/sanes-chrome-extension/src/routes/restore-account/test/fillRecoveryPhrase.ts
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/test/fillRecoveryPhrase.ts
@@ -1,45 +1,82 @@
+import { Page } from 'puppeteer';
 import TestUtils from 'react-dom/test-utils';
 import {
   findRenderedDOMComponentWithId,
   findRenderedE2EComponentWithId,
 } from '../../../utils/test/reactElemFinder';
 import { ACCOUNT_STATUS_ROUTE } from '../../paths';
-import { RECOVERY_PHRASE } from '../components';
-import { Page } from 'puppeteer';
+import { MNEMONIC_FIELD } from '../components/SetMnemonicForm';
+import {
+  PASSWORD_CONFIRM_FIELD,
+  PASSWORD_FIELD,
+  SET_PASSWORD_STEP_RESTORE_ACCOUNT_ROUTE,
+} from '../components/SetPasswordForm';
 
 export const submitRecoveryPhrase = async (
-  AccountSubmitDom: React.Component,
+  restoreAccountDom: React.Component,
   mnemonic: string,
+  password: string,
 ): Promise<void> => {
-  const textarea = TestUtils.scryRenderedDOMComponentsWithTag(AccountSubmitDom, 'textarea');
+  const mnemonicTextarea = TestUtils.findRenderedDOMComponentWithTag(restoreAccountDom, 'textarea');
 
-  expect(textarea.length).toBe(1);
+  TestUtils.act(() => {
+    TestUtils.Simulate.change(mnemonicTextarea, {
+      target: {
+        value: mnemonic,
+      },
+    } as any); //eslint-disable-line @typescript-eslint/no-explicit-any
+  });
 
-  const recoveryPhraseField = textarea[0];
+  const mnemonicForm = TestUtils.findRenderedDOMComponentWithTag(restoreAccountDom, 'form');
 
-  TestUtils.act(
-    (): void => {
-      TestUtils.Simulate.change(recoveryPhraseField, {
-        target: {
-          value: mnemonic,
-        },
-      } as any); //eslint-disable-line @typescript-eslint/no-explicit-any
-    },
-  );
-
-  const form = TestUtils.findRenderedDOMComponentWithTag(AccountSubmitDom, 'form');
-
-  const submitForm = async (): Promise<void> => {
-    TestUtils.Simulate.submit(form);
-    await findRenderedDOMComponentWithId(AccountSubmitDom, ACCOUNT_STATUS_ROUTE);
+  const submitMnemonicForm = async (): Promise<void> => {
+    TestUtils.Simulate.submit(mnemonicForm);
+    await findRenderedDOMComponentWithId(restoreAccountDom, SET_PASSWORD_STEP_RESTORE_ACCOUNT_ROUTE);
   };
   // FIXME  Once this is updated https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-dom/test-utils/index.d.ts#L296
-  await TestUtils.act(submitForm as any); //eslint-disable-line @typescript-eslint/no-explicit-any
+  await TestUtils.act(submitMnemonicForm as any); //eslint-disable-line @typescript-eslint/no-explicit-any
+
+  const [passwordInput, passwordConfirmInput] = TestUtils.scryRenderedDOMComponentsWithTag(
+    restoreAccountDom,
+    'input',
+  );
+
+  TestUtils.act(() => {
+    TestUtils.Simulate.change(passwordInput, {
+      target: {
+        value: password,
+      },
+    } as any); //eslint-disable-line @typescript-eslint/no-explicit-any
+  });
+
+  TestUtils.act(() => {
+    TestUtils.Simulate.change(passwordConfirmInput, {
+      target: {
+        value: password,
+      },
+    } as any); //eslint-disable-line @typescript-eslint/no-explicit-any
+  });
+
+  const passwordForm = TestUtils.findRenderedDOMComponentWithTag(restoreAccountDom, 'form');
+
+  const submitPasswordForm = async (): Promise<void> => {
+    TestUtils.Simulate.submit(passwordForm);
+  };
+  // FIXME  Once this is updated https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-dom/test-utils/index.d.ts#L296
+  await TestUtils.act(submitPasswordForm as any); //eslint-disable-line @typescript-eslint/no-explicit-any
 };
 
-export const submitRecoveryPhraseE2E = async (page: Page, mnemonic: string): Promise<void> => {
-  await page.type(`textarea[name="${RECOVERY_PHRASE}"]`, mnemonic);
+export const submitRecoveryPhraseE2E = async (
+  page: Page,
+  mnemonic: string,
+  password: string,
+): Promise<void> => {
+  await page.type(`textarea[name="${MNEMONIC_FIELD}"]`, mnemonic);
+  await page.click('button[type="submit"]');
+  await findRenderedE2EComponentWithId(page, SET_PASSWORD_STEP_RESTORE_ACCOUNT_ROUTE);
 
+  await page.type(`input[name="${PASSWORD_FIELD}"]`, password);
+  await page.type(`input[name="${PASSWORD_CONFIRM_FIELD}"]`, password);
   await page.click('button[type="submit"]');
   await findRenderedE2EComponentWithId(page, ACCOUNT_STATUS_ROUTE);
 };

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2929,10 +2929,10 @@ exports[`Storyshots Extension Request queue page 1`] = `
 </div>
 `;
 
-exports[`Storyshots Extension Restore Account page 1`] = `
+exports[`Storyshots Extension Welcome page 1`] = `
 <div
   className="MuiBox-root MuiBox-root-1782 makeStyles-root-1779 makeStyles-root-1780"
-  id="/restore-account"
+  id="/welcome"
 >
   <div
     className="MuiBox-root MuiBox-root-1783"
@@ -2940,20 +2940,144 @@ exports[`Storyshots Extension Restore Account page 1`] = `
     <h4
       className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1786 makeStyles-weight-1787 makeStyles-inline-1784"
     >
-      Restore
+      Welcome
     </h4>
     <h4
       className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1786 makeStyles-weight-1818 makeStyles-inline-1784"
+    >
+       
+      to your IOV manager
+    </h4>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-1819"
+  >
+    <p
+      className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1786 makeStyles-weight-1820 makeStyles-inline-1784"
+    >
+      This plugin lets you manage all your accounts in one place.
+    </p>
+    <div
+      className="MuiBox-root MuiBox-root-1821"
+    />
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Log in
+      </span>
+    </button>
+    <div
+      className="MuiBox-root MuiBox-root-1842"
+    />
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        New account
+      </span>
+    </button>
+    <div
+      className="MuiBox-root MuiBox-root-1843"
+    />
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Import account
+      </span>
+    </button>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-1844"
+  />
+  <div
+    className="MuiBox-root MuiBox-root-1845"
+  >
+    <img
+      alt="IOV logo"
+      className="makeStyles-root-1846"
+      height={39}
+      src="iov-logo.png"
+      width={84}
+    />
+  </div>
+</div>
+`;
+
+exports[`Storyshots Extension/Restore Account Set Mnemonic page 1`] = `
+<div
+  className="MuiBox-root MuiBox-root-1854 makeStyles-root-1851 makeStyles-root-1852"
+  id="/restore-account"
+>
+  <div
+    className="MuiBox-root MuiBox-root-1855"
+  >
+    <h4
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1858 makeStyles-weight-1859 makeStyles-inline-1856"
+    >
+      Restore
+    </h4>
+    <h4
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1858 makeStyles-weight-1890 makeStyles-inline-1856"
     >
        
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1819"
+    className="MuiBox-root MuiBox-root-1891"
   >
     <h6
-      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-1786 makeStyles-weight-1820 makeStyles-inline-1784"
+      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-1858 makeStyles-weight-1892 makeStyles-inline-1856"
     >
       Restore your account with your recovery words. Enter your recovery words here.
     </h6>
@@ -2961,7 +3085,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-1821"
+        className="MuiBox-root MuiBox-root-1893"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3000,7 +3124,7 @@ exports[`Storyshots Extension Restore Account page 1`] = `
               aria-invalid={false}
               className="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline"
               disabled={false}
-              name="recoveryPhraseField"
+              name="mnemonicField"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -3012,10 +3136,10 @@ exports[`Storyshots Extension Restore Account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-1859"
+        className="MuiBox-root MuiBox-root-1931"
       >
         <div
-          className="MuiBox-root MuiBox-root-1860"
+          className="MuiBox-root MuiBox-root-1932"
         >
           <button
             aria-label="Go back"
@@ -3043,7 +3167,239 @@ exports[`Storyshots Extension Restore Account page 1`] = `
           </button>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-1881"
+          className="MuiBox-root MuiBox-root-1953"
+        >
+          <button
+            className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
+            disabled={false}
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex="0"
+            type="submit"
+          >
+            <span
+              className="MuiButton-label"
+            >
+              Continue
+            </span>
+          </button>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-1954"
+  />
+  <div
+    className="MuiBox-root MuiBox-root-1955"
+  >
+    <img
+      alt="IOV logo"
+      className="makeStyles-root-1956"
+      height={39}
+      src="iov-logo.png"
+      width={84}
+    />
+  </div>
+</div>
+`;
+
+exports[`Storyshots Extension/Restore Account Set Password page 1`] = `
+<div
+  className="MuiBox-root MuiBox-root-1964 makeStyles-root-1961 makeStyles-root-1962"
+  id="/restore-account2"
+>
+  <div
+    className="MuiBox-root MuiBox-root-1965"
+  >
+    <h4
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1968 makeStyles-weight-1969 makeStyles-inline-1966"
+    >
+      Restore
+    </h4>
+    <h4
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1968 makeStyles-weight-2000 makeStyles-inline-1966"
+    >
+       
+      Account
+    </h4>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-2001"
+  >
+    <h6
+      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-1968 makeStyles-weight-2002 makeStyles-inline-1966"
+    >
+      Enter the new password that will be used to encrypt your profile.
+    </h6>
+    <form
+      onSubmit={[Function]}
+    >
+      <div
+        className="MuiBox-root MuiBox-root-2003"
+      >
+        <div
+          className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
+        >
+          <label
+            className="MuiFormLabel-root Mui-required Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+            data-shrink={true}
+          >
+            Password
+            <span
+              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+            >
+               *
+            </span>
+          </label>
+          <div
+            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+            onClick={[Function]}
+          >
+            <fieldset
+              aria-hidden={true}
+              className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+              style={
+                Object {
+                  "paddingLeft": 8,
+                }
+              }
+            >
+              <legend
+                className="MuiPrivateNotchedOutline-legend"
+                style={
+                  Object {
+                    "width": 0.01,
+                  }
+                }
+              >
+                <span
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "&#8203;",
+                    }
+                  }
+                />
+              </legend>
+            </fieldset>
+            <input
+              aria-invalid={false}
+              className="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputType"
+              disabled={false}
+              name="passwordField"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="Password"
+              required={true}
+              type="password"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        className="MuiBox-root MuiBox-root-2060"
+      >
+        <div
+          className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
+        >
+          <label
+            className="MuiFormLabel-root Mui-required Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+            data-shrink={true}
+          >
+            Confirm Password
+            <span
+              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+            >
+               *
+            </span>
+          </label>
+          <div
+            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl"
+            onClick={[Function]}
+          >
+            <fieldset
+              aria-hidden={true}
+              className="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+              style={
+                Object {
+                  "paddingLeft": 8,
+                }
+              }
+            >
+              <legend
+                className="MuiPrivateNotchedOutline-legend"
+                style={
+                  Object {
+                    "width": 0.01,
+                  }
+                }
+              >
+                <span
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "&#8203;",
+                    }
+                  }
+                />
+              </legend>
+            </fieldset>
+            <input
+              aria-invalid={false}
+              className="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputType"
+              disabled={false}
+              name="passwordConfirmField"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="Confirm Password"
+              required={true}
+              type="password"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        className="MuiBox-root MuiBox-root-2061"
+      >
+        <div
+          className="MuiBox-root MuiBox-root-2062"
+        >
+          <button
+            aria-label="Go back"
+            className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex="0"
+            type="button"
+          >
+            <span
+              className="MuiButton-label"
+            >
+              Back
+            </span>
+          </button>
+        </div>
+        <div
+          className="MuiBox-root MuiBox-root-2083"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -3072,138 +3428,14 @@ exports[`Storyshots Extension Restore Account page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-1882"
+    className="MuiBox-root MuiBox-root-2084"
   />
   <div
-    className="MuiBox-root MuiBox-root-1883"
+    className="MuiBox-root MuiBox-root-2085"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-1884"
-      height={39}
-      src="iov-logo.png"
-      width={84}
-    />
-  </div>
-</div>
-`;
-
-exports[`Storyshots Extension Welcome page 1`] = `
-<div
-  className="MuiBox-root MuiBox-root-1892 makeStyles-root-1889 makeStyles-root-1890"
-  id="/welcome"
->
-  <div
-    className="MuiBox-root MuiBox-root-1893"
-  >
-    <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1896 makeStyles-weight-1897 makeStyles-inline-1894"
-    >
-      Welcome
-    </h4>
-    <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1896 makeStyles-weight-1928 makeStyles-inline-1894"
-    >
-       
-      to your IOV manager
-    </h4>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-1929"
-  >
-    <p
-      className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1896 makeStyles-weight-1930 makeStyles-inline-1894"
-    >
-      This plugin lets you manage all your accounts in one place.
-    </p>
-    <div
-      className="MuiBox-root MuiBox-root-1931"
-    />
-    <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex="0"
-      type="button"
-    >
-      <span
-        className="MuiButton-label"
-      >
-        Log in
-      </span>
-    </button>
-    <div
-      className="MuiBox-root MuiBox-root-1952"
-    />
-    <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex="0"
-      type="button"
-    >
-      <span
-        className="MuiButton-label"
-      >
-        New account
-      </span>
-    </button>
-    <div
-      className="MuiBox-root MuiBox-root-1953"
-    />
-    <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
-      disabled={false}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex="0"
-      type="button"
-    >
-      <span
-        className="MuiButton-label"
-      >
-        Import account
-      </span>
-    </button>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-1954"
-  />
-  <div
-    className="MuiBox-root MuiBox-root-1955"
-  >
-    <img
-      alt="IOV logo"
-      className="makeStyles-root-1956"
+      className="makeStyles-root-2086"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3214,56 +3446,56 @@ exports[`Storyshots Extension Welcome page 1`] = `
 
 exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2064 makeStyles-root-2061 makeStyles-root-2062"
+  className="MuiBox-root MuiBox-root-2194 makeStyles-root-2191 makeStyles-root-2192"
   id="/share-identity_reject"
 >
   <div
-    className="MuiBox-root MuiBox-root-2065"
+    className="MuiBox-root MuiBox-root-2195"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2068 makeStyles-weight-2069 makeStyles-inline-2066"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2198 makeStyles-weight-2199 makeStyles-inline-2196"
     >
       Share
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2068 makeStyles-weight-2100 makeStyles-inline-2066"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2198 makeStyles-weight-2230 makeStyles-inline-2196"
     >
        
       Identity
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2101"
+    className="MuiBox-root MuiBox-root-2231"
   >
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-2102"
+        className="MuiBox-root MuiBox-root-2232"
       >
         <p
-          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2068 makeStyles-weight-2103"
+          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2198 makeStyles-weight-2233"
         >
           The following site:
         </p>
         <p
-          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2068 makeStyles-weight-2104"
+          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2198 makeStyles-weight-2234"
         >
           http://finnex.com
         </p>
         <p
-          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorError makeStyles-weight-2068 makeStyles-weight-2105 makeStyles-inline-2066"
+          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorError makeStyles-weight-2198 makeStyles-weight-2235 makeStyles-inline-2196"
         >
           would not be able to request
         </p>
         <p
-          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2068 makeStyles-weight-2106 makeStyles-inline-2066"
+          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2198 makeStyles-weight-2236 makeStyles-inline-2196"
         >
            
           your identity on blockchains.
         </p>
         <div
-          className="MuiBox-root MuiBox-root-2107"
+          className="MuiBox-root MuiBox-root-2237"
         />
         <label
           className="MuiFormControlLabel-root"
@@ -3321,7 +3553,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
         </label>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2145"
+        className="MuiBox-root MuiBox-root-2275"
       />
       <button
         className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
@@ -3346,7 +3578,7 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
         </span>
       </button>
       <div
-        className="MuiBox-root MuiBox-root-2163"
+        className="MuiBox-root MuiBox-root-2293"
       />
       <button
         aria-label="Go back"
@@ -3375,14 +3607,14 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2164"
+    className="MuiBox-root MuiBox-root-2294"
   />
   <div
-    className="MuiBox-root MuiBox-root-2165"
+    className="MuiBox-root MuiBox-root-2295"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2166"
+      className="makeStyles-root-2296"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3393,42 +3625,42 @@ exports[`Storyshots Extension/Share Identity Reject Request page 1`] = `
 
 exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-1964 makeStyles-root-1961 makeStyles-root-1962"
+  className="MuiBox-root MuiBox-root-2094 makeStyles-root-2091 makeStyles-root-2092"
   id="/share-identity_show"
 >
   <div
-    className="MuiBox-root MuiBox-root-1965"
+    className="MuiBox-root MuiBox-root-2095"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-1968 makeStyles-weight-1969 makeStyles-inline-1966"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2098 makeStyles-weight-2099 makeStyles-inline-2096"
     >
       Share
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-1968 makeStyles-weight-2000 makeStyles-inline-1966"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2098 makeStyles-weight-2130 makeStyles-inline-2096"
     >
        
       Identity
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2001"
+    className="MuiBox-root MuiBox-root-2131"
   >
     <div
-      className="MuiBox-root MuiBox-root-2002"
+      className="MuiBox-root MuiBox-root-2132"
     >
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1968 makeStyles-weight-2003"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2098 makeStyles-weight-2133"
       >
         The following site:
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-1968 makeStyles-weight-2004"
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2098 makeStyles-weight-2134"
       >
         http://finnex.com
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-1968 makeStyles-weight-2005 makeStyles-inline-1966"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2098 makeStyles-weight-2135 makeStyles-inline-2096"
       >
         wants to have access to:
       </p>
@@ -3456,7 +3688,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
         </div>
       </li>
       <div
-        className="MuiBox-root MuiBox-root-2028"
+        className="MuiBox-root MuiBox-root-2158"
       />
       <li
         className="MuiListItem-root MuiListItem-default MuiListItem-gutters"
@@ -3478,7 +3710,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
         </div>
       </li>
       <div
-        className="MuiBox-root MuiBox-root-2029"
+        className="MuiBox-root MuiBox-root-2159"
       />
       <li
         className="MuiListItem-root MuiListItem-default MuiListItem-gutters"
@@ -3500,7 +3732,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
         </div>
       </li>
       <div
-        className="MuiBox-root MuiBox-root-2030"
+        className="MuiBox-root MuiBox-root-2160"
       />
       <li
         className="MuiListItem-root MuiListItem-default MuiListItem-gutters"
@@ -3522,11 +3754,11 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
         </div>
       </li>
       <div
-        className="MuiBox-root MuiBox-root-2031"
+        className="MuiBox-root MuiBox-root-2161"
       />
     </ul>
     <div
-      className="MuiBox-root MuiBox-root-2032"
+      className="MuiBox-root MuiBox-root-2162"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -3552,7 +3784,7 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
       </span>
     </button>
     <div
-      className="MuiBox-root MuiBox-root-2053"
+      className="MuiBox-root MuiBox-root-2183"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-fullWidth"
@@ -3579,14 +3811,14 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
     </button>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2054"
+    className="MuiBox-root MuiBox-root-2184"
   />
   <div
-    className="MuiBox-root MuiBox-root-2055"
+    className="MuiBox-root MuiBox-root-2185"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2056"
+      className="makeStyles-root-2186"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3597,32 +3829,32 @@ exports[`Storyshots Extension/Share Identity Show Request page 1`] = `
 
 exports[`Storyshots Extension/Signup New Account page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2174 makeStyles-root-2171 makeStyles-root-2172"
+  className="MuiBox-root MuiBox-root-2304 makeStyles-root-2301 makeStyles-root-2302"
   id="/signup1"
 >
   <div
-    className="MuiBox-root MuiBox-root-2175"
+    className="MuiBox-root MuiBox-root-2305"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2178 makeStyles-weight-2179 makeStyles-inline-2176"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2308 makeStyles-weight-2309 makeStyles-inline-2306"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2178 makeStyles-weight-2210 makeStyles-inline-2176"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2308 makeStyles-weight-2340 makeStyles-inline-2306"
     >
        
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2211"
+    className="MuiBox-root MuiBox-root-2341"
   >
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-2212"
+        className="MuiBox-root MuiBox-root-2342"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3684,7 +3916,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2269"
+        className="MuiBox-root MuiBox-root-2399"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3746,7 +3978,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2270"
+        className="MuiBox-root MuiBox-root-2400"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -3808,10 +4040,10 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2271"
+        className="MuiBox-root MuiBox-root-2401"
       >
         <div
-          className="MuiBox-root MuiBox-root-2272"
+          className="MuiBox-root MuiBox-root-2402"
         >
           <button
             aria-label="Go back"
@@ -3839,7 +4071,7 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
           </button>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-2293"
+          className="MuiBox-root MuiBox-root-2423"
         >
           <button
             className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
@@ -3868,14 +4100,14 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2294"
+    className="MuiBox-root MuiBox-root-2424"
   />
   <div
-    className="MuiBox-root MuiBox-root-2295"
+    className="MuiBox-root MuiBox-root-2425"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2296"
+      className="makeStyles-root-2426"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -3886,49 +4118,49 @@ exports[`Storyshots Extension/Signup New Account page 1`] = `
 
 exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2304 makeStyles-root-2301 makeStyles-root-2302"
+  className="MuiBox-root MuiBox-root-2434 makeStyles-root-2431 makeStyles-root-2432"
   id="/signup2"
 >
   <div
-    className="MuiBox-root MuiBox-root-2305"
+    className="MuiBox-root MuiBox-root-2435"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2308 makeStyles-weight-2309 makeStyles-inline-2306"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2438 makeStyles-weight-2439 makeStyles-inline-2436"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2308 makeStyles-weight-2340 makeStyles-inline-2306"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2438 makeStyles-weight-2470 makeStyles-inline-2436"
     >
        
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2341"
+    className="MuiBox-root MuiBox-root-2471"
   >
     <div
-      className="MuiBox-root MuiBox-root-2342"
+      className="MuiBox-root MuiBox-root-2472"
     >
       <div
-        className="MuiBox-root MuiBox-root-2343"
+        className="MuiBox-root MuiBox-root-2473"
       >
         <div
-          className="MuiBox-root MuiBox-root-2344"
+          className="MuiBox-root MuiBox-root-2474"
         >
           <h6
-            className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-2308 makeStyles-weight-2345 makeStyles-inline-2306"
+            className="MuiTypography-root MuiTypography-subtitle2 makeStyles-weight-2438 makeStyles-weight-2475 makeStyles-inline-2436"
           >
             Activate Recovery Phrase?
           </h6>
         </div>
         <div
-          className="makeStyles-container-2347"
+          className="makeStyles-container-2477"
           onClick={[Function]}
         >
           <img
             alt="Info"
-            className="makeStyles-root-2350"
+            className="makeStyles-root-2480"
             height={16}
             src="info_normal.svg"
             width={16}
@@ -3979,19 +4211,19 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
       </label>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-2386"
+      className="MuiBox-root MuiBox-root-2516"
     >
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2308 makeStyles-weight-2387 makeStyles-inline-2306"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2438 makeStyles-weight-2517 makeStyles-inline-2436"
       >
         
       </p>
     </div>
     <div
-      className="MuiBox-root MuiBox-root-2388"
+      className="MuiBox-root MuiBox-root-2518"
     >
       <div
-        className="MuiBox-root MuiBox-root-2389"
+        className="MuiBox-root MuiBox-root-2519"
       >
         <button
           aria-label="Go back"
@@ -4019,7 +4251,7 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
         </button>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2407"
+        className="MuiBox-root MuiBox-root-2537"
       >
         <button
           className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -4048,14 +4280,14 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2408"
+    className="MuiBox-root MuiBox-root-2538"
   />
   <div
-    className="MuiBox-root MuiBox-root-2409"
+    className="MuiBox-root MuiBox-root-2539"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2350"
+      className="makeStyles-root-2480"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -4066,29 +4298,29 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
 
 exports[`Storyshots Extension/Signup Security Hint page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2413 makeStyles-root-2410 makeStyles-root-2411"
+  className="MuiBox-root MuiBox-root-2543 makeStyles-root-2540 makeStyles-root-2541"
   id="/signup3"
 >
   <div
-    className="MuiBox-root MuiBox-root-2414"
+    className="MuiBox-root MuiBox-root-2544"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2417 makeStyles-weight-2418 makeStyles-inline-2415"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2547 makeStyles-weight-2548 makeStyles-inline-2545"
     >
       New
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2417 makeStyles-weight-2449 makeStyles-inline-2415"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2547 makeStyles-weight-2579 makeStyles-inline-2545"
     >
        
       Account
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2450"
+    className="MuiBox-root MuiBox-root-2580"
   >
     <h6
-      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-2417 makeStyles-weight-2451 makeStyles-inline-2415"
+      className="MuiTypography-root MuiTypography-subtitle1 makeStyles-weight-2547 makeStyles-weight-2581 makeStyles-inline-2545"
     >
       To help you remember your details in the future please provide a security hint:
     </h6>
@@ -4096,7 +4328,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-2452"
+        className="MuiBox-root MuiBox-root-2582"
       >
         <div
           className="MuiFormControl-root MuiFormControl-marginNormal MuiFormControl-fullWidth MuiTextField-root"
@@ -4147,10 +4379,10 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
         </div>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2490"
+        className="MuiBox-root MuiBox-root-2620"
       >
         <div
-          className="MuiBox-root MuiBox-root-2491"
+          className="MuiBox-root MuiBox-root-2621"
         >
           <button
             aria-label="Go back"
@@ -4178,7 +4410,7 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
           </button>
         </div>
         <div
-          className="MuiBox-root MuiBox-root-2512"
+          className="MuiBox-root MuiBox-root-2642"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -4207,14 +4439,14 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2513"
+    className="MuiBox-root MuiBox-root-2643"
   />
   <div
-    className="MuiBox-root MuiBox-root-2514"
+    className="MuiBox-root MuiBox-root-2644"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2515"
+      className="makeStyles-root-2645"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -4225,53 +4457,53 @@ exports[`Storyshots Extension/Signup Security Hint page 1`] = `
 
 exports[`Storyshots Extension/Transaction Request Reject Request page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2620 makeStyles-root-2617 makeStyles-root-2618"
+  className="MuiBox-root MuiBox-root-2750 makeStyles-root-2747 makeStyles-root-2748"
   id="/tx-request_reject"
 >
   <div
-    className="MuiBox-root MuiBox-root-2621"
+    className="MuiBox-root MuiBox-root-2751"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2624 makeStyles-weight-2625 makeStyles-inline-2622"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2754 makeStyles-weight-2755 makeStyles-inline-2752"
     >
       Tx
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2624 makeStyles-weight-2656 makeStyles-inline-2622"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2754 makeStyles-weight-2786 makeStyles-inline-2752"
     >
        
       Request
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2657"
+    className="MuiBox-root MuiBox-root-2787"
   >
     <div
-      className="MuiBox-root MuiBox-root-2658"
+      className="MuiBox-root MuiBox-root-2788"
     />
     <form
       onSubmit={[Function]}
     >
       <div
-        className="MuiBox-root MuiBox-root-2659"
+        className="MuiBox-root MuiBox-root-2789"
       >
         <p
-          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2624 makeStyles-weight-2660 makeStyles-inline-2622"
+          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2754 makeStyles-weight-2790 makeStyles-inline-2752"
         >
           You are rejecting the tx sent from 
         </p>
         <p
-          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2624 makeStyles-weight-2661 makeStyles-inline-2622"
+          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2754 makeStyles-weight-2791 makeStyles-inline-2752"
         >
           http://localhost/
         </p>
         <p
-          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2624 makeStyles-weight-2662"
+          className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2754 makeStyles-weight-2792"
         >
            from being signed and posted.
         </p>
         <div
-          className="MuiBox-root MuiBox-root-2663"
+          className="MuiBox-root MuiBox-root-2793"
         />
         <label
           className="MuiFormControlLabel-root"
@@ -4329,7 +4561,7 @@ exports[`Storyshots Extension/Transaction Request Reject Request page 1`] = `
         </label>
       </div>
       <div
-        className="MuiBox-root MuiBox-root-2701"
+        className="MuiBox-root MuiBox-root-2831"
       />
       <button
         className="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled MuiButton-fullWidth"
@@ -4354,7 +4586,7 @@ exports[`Storyshots Extension/Transaction Request Reject Request page 1`] = `
         </span>
       </button>
       <div
-        className="MuiBox-root MuiBox-root-2719"
+        className="MuiBox-root MuiBox-root-2849"
       />
       <button
         aria-label="Go back"
@@ -4383,14 +4615,14 @@ exports[`Storyshots Extension/Transaction Request Reject Request page 1`] = `
     </form>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2720"
+    className="MuiBox-root MuiBox-root-2850"
   />
   <div
-    className="MuiBox-root MuiBox-root-2721"
+    className="MuiBox-root MuiBox-root-2851"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2722"
+      className="makeStyles-root-2852"
       height={39}
       src="iov-logo.png"
       width={84}
@@ -4401,42 +4633,42 @@ exports[`Storyshots Extension/Transaction Request Reject Request page 1`] = `
 
 exports[`Storyshots Extension/Transaction Request Show Request page 1`] = `
 <div
-  className="MuiBox-root MuiBox-root-2523 makeStyles-root-2520 makeStyles-root-2521"
+  className="MuiBox-root MuiBox-root-2653 makeStyles-root-2650 makeStyles-root-2651"
   id="/tx-request_show"
 >
   <div
-    className="MuiBox-root MuiBox-root-2524"
+    className="MuiBox-root MuiBox-root-2654"
   >
     <h4
-      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2527 makeStyles-weight-2528 makeStyles-inline-2525"
+      className="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary makeStyles-weight-2657 makeStyles-weight-2658 makeStyles-inline-2655"
     >
       Tx
     </h4>
     <h4
-      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2527 makeStyles-weight-2559 makeStyles-inline-2525"
+      className="MuiTypography-root MuiTypography-h4 makeStyles-weight-2657 makeStyles-weight-2689 makeStyles-inline-2655"
     >
        
       Request
     </h4>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2560"
+    className="MuiBox-root MuiBox-root-2690"
   >
     <div
-      className="MuiBox-root MuiBox-root-2561"
+      className="MuiBox-root MuiBox-root-2691"
     >
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2527 makeStyles-weight-2562 makeStyles-inline-2525"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2657 makeStyles-weight-2692 makeStyles-inline-2655"
       >
         The following site: 
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2527 makeStyles-weight-2563 makeStyles-inline-2525"
+        className="MuiTypography-root MuiTypography-body1 MuiTypography-colorPrimary makeStyles-weight-2657 makeStyles-weight-2693 makeStyles-inline-2655"
       >
         http://localhost/
       </p>
       <p
-        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2527 makeStyles-weight-2564 makeStyles-inline-2525"
+        className="MuiTypography-root MuiTypography-body1 makeStyles-weight-2657 makeStyles-weight-2694 makeStyles-inline-2655"
       >
          wants you to sign:
       </p>
@@ -4522,7 +4754,7 @@ exports[`Storyshots Extension/Transaction Request Show Request page 1`] = `
       </li>
     </ul>
     <div
-      className="MuiBox-root MuiBox-root-2587"
+      className="MuiBox-root MuiBox-root-2717"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
@@ -4548,7 +4780,7 @@ exports[`Storyshots Extension/Transaction Request Show Request page 1`] = `
       </span>
     </button>
     <div
-      className="MuiBox-root MuiBox-root-2608"
+      className="MuiBox-root MuiBox-root-2738"
     />
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-fullWidth"
@@ -4574,18 +4806,18 @@ exports[`Storyshots Extension/Transaction Request Show Request page 1`] = `
       </span>
     </button>
     <div
-      className="MuiBox-root MuiBox-root-2609"
+      className="MuiBox-root MuiBox-root-2739"
     />
   </div>
   <div
-    className="MuiBox-root MuiBox-root-2610"
+    className="MuiBox-root MuiBox-root-2740"
   />
   <div
-    className="MuiBox-root MuiBox-root-2611"
+    className="MuiBox-root MuiBox-root-2741"
   >
     <img
       alt="IOV logo"
-      className="makeStyles-root-2612"
+      className="makeStyles-root-2742"
       height={39}
       src="iov-logo.png"
       width={84}


### PR DESCRIPTION
**Description**
The goal of this PR is to add a password field to the Restore Account view so that when a new Persona is created from an imported mnemonic, the user has the opportunity to set a new password.

The *Password* and *Confirm password* fields have been placed on a different view on the same route, making it so that Restore Account has now two steps. It has been made this way because of space limitations and aesthetic reasons, as can be seen on the screenshots below.

Closes #217.

**Screenshots**
![imagen](https://user-images.githubusercontent.com/44572727/58650950-4f05b400-8310-11e9-894d-18adac488f95.png)
![imagen](https://user-images.githubusercontent.com/44572727/58650957-52993b00-8310-11e9-99b5-a2fc528dd2bf.png)