### PR TITLE
Feature #235 - Fix height issues with PageLayout

### DIFF
--- a/packages/medulas-react-components/src/components/PageLayout/index.tsx
+++ b/packages/medulas-react-components/src/components/PageLayout/index.tsx
@@ -7,6 +7,8 @@ import Block from '../Block';
 import Image from '../Image';
 import Typography from '../Typography';
 
+const PAGE_HEIGHT = 500;
+
 interface Props extends StyleProps {
   readonly id?: string;
   readonly children: React.ReactNode;
@@ -17,7 +19,7 @@ interface Props extends StyleProps {
 
 interface StyleProps {
   readonly color?: 'white' | 'transparent';
-  readonly minHeight?: string;
+  readonly minHeight?: string | number;
 }
 
 const useStyles = makeStyles<Theme, StyleProps>({
@@ -34,7 +36,7 @@ const PageLayout = ({
   primaryTitle,
   onBack,
   color = 'transparent',
-  minHeight = '500px',
+  minHeight = PAGE_HEIGHT,
 }: Props): JSX.Element => {
   const showBackArrow = !!onBack;
   const classes = useStyles({ color, minHeight });

--- a/packages/medulas-react-components/src/components/PageLayout/index.tsx
+++ b/packages/medulas-react-components/src/components/PageLayout/index.tsx
@@ -17,24 +17,27 @@ interface Props extends StyleProps {
 
 interface StyleProps {
   readonly color?: 'white' | 'transparent';
+  readonly minHeight?: string;
 }
 
 const useStyles = makeStyles<Theme, StyleProps>({
   root: props => ({
     backgroundColor: props.color,
+    minHeight: props.minHeight,
   }),
 });
 
 const PageLayout = ({
   id,
   children,
-  color = 'transparent',
   title,
   primaryTitle,
   onBack,
+  color = 'transparent',
+  minHeight = '500px',
 }: Props): JSX.Element => {
   const showBackArrow = !!onBack;
-  const classes = useStyles({ color });
+  const classes = useStyles({ color, minHeight });
 
   return (
     <Block
@@ -44,7 +47,7 @@ const PageLayout = ({
       paddingRight={4}
       paddingLeft={4}
       paddingTop={2}
-      height="100%"
+      height="auto"
       className={classes.root}
     >
       {showBackArrow && (

--- a/packages/sanes-chrome-extension/public/index.html
+++ b/packages/sanes-chrome-extension/public/index.html
@@ -31,9 +31,6 @@
         -ms-overflow-style: '-ms-autohiding-scrollbar';
         font-size: 10px;
       }
-      #root {
-        height: calc(100% - 16px);
-      }
     </style>
   </head>
   <body>

--- a/packages/sanes-chrome-extension/src/routes/account/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/index.tsx
@@ -9,13 +9,17 @@ import * as React from 'react';
 import { useForm } from 'react-final-form-hooks';
 import { PersonaContext } from '../../context/PersonaProvider';
 import { history } from '../../store/reducers';
+import { EXTENSION_HEIGHT } from '../../theme/constants';
 import { createAccount } from '../../utils/chrome';
 import { ACCOUNT_STATUS_ROUTE, RECOVERY_PHRASE_ROUTE, REQUEST_ROUTE } from '../paths';
-import ListTxs from './components/ListTxs';
 import recoveryPhrase from './assets/recoveryPhrase.svg';
 import requests from './assets/requests.svg';
+import ListTxs from './components/ListTxs';
 
 const CREATE_NEW_ONE = 'Create a new one';
+
+const DRAWER_HEIGHT = 56;
+const CONTENT_HEIGHT = EXTENSION_HEIGHT - DRAWER_HEIGHT;
 
 const AccountView = (): JSX.Element => {
   const [accounts, setAccounts] = React.useState<Item[]>([]);
@@ -59,7 +63,7 @@ const AccountView = (): JSX.Element => {
 
   return (
     <Drawer items={items}>
-      <PageLayout id={ACCOUNT_STATUS_ROUTE} primaryTitle="Account" title="Status" minHeight="444px">
+      <PageLayout id={ACCOUNT_STATUS_ROUTE} primaryTitle="Account" title="Status" minHeight={CONTENT_HEIGHT}>
         {accountLoaded && (
           <Form onSubmit={handleSubmit}>
             <Block marginBottom={1}>

--- a/packages/sanes-chrome-extension/src/routes/account/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/index.tsx
@@ -59,7 +59,7 @@ const AccountView = (): JSX.Element => {
 
   return (
     <Drawer items={items}>
-      <PageLayout id={ACCOUNT_STATUS_ROUTE} primaryTitle="Account" title="Status">
+      <PageLayout id={ACCOUNT_STATUS_ROUTE} primaryTitle="Account" title="Status" minHeight="444px">
         {accountLoaded && (
           <Form onSubmit={handleSubmit}>
             <Block marginBottom={1}>
@@ -75,7 +75,7 @@ const AccountView = (): JSX.Element => {
           </Form>
         )}
         <Hairline space={2} />
-        <Block marginBottom={4}>
+        <Block>
           <ListTxs title="Transactions" txs={personaProvider.txs} />
         </Block>
       </PageLayout>

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
@@ -30,7 +30,7 @@ const Layout = ({ sender, onBack, onRejectRequest }: Props): JSX.Element => {
   });
 
   return (
-    <PageLayout id={SHARE_IDENTITY_REJECT} primaryTitle="Share" title="Identity">
+    <PageLayout id={SHARE_IDENTITY_REJECT} color="white" primaryTitle="Share" title="Identity">
       <Form onSubmit={handleSubmit}>
         <Block textAlign="center">
           <Typography variant="body1">The following site:</Typography>

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 const Layout = ({ sender, data, onAcceptRequest, showRejectView }: Props): JSX.Element => (
-  <PageLayout id={SHARE_IDENTITY_SHOW} primaryTitle="Share" title="Identity">
+  <PageLayout id={SHARE_IDENTITY_SHOW} color="white" primaryTitle="Share" title="Identity">
     <Block textAlign="center" marginBottom={2}>
       <Typography variant="body1">The following site:</Typography>
       <Typography variant="body1" color="primary">

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest.tsx
@@ -22,7 +22,7 @@ const secondaryProps = {
 };
 
 const Layout = ({ sender, tx, onAcceptRequest, showRejectView }: Props): JSX.Element => (
-  <PageLayout id={TX_REQUEST_SHOW} primaryTitle="Tx" title="Request">
+  <PageLayout id={TX_REQUEST_SHOW} color="white" primaryTitle="Tx" title="Request">
     <Block textAlign="center" marginBottom={2}>
       <Typography variant="body1" inline>
         {'The following site: '}


### PR DESCRIPTION
**Description**
The hardcoded CSS rule in the `body` element `"height: 500px"` means that every view in the extension will have a viewport height of 500px. However, the `height` properties of some of its children are not properly implemented, resulting in the following issues: 

- When a container dynamically grows, its parent container does not adjust its own height, resulting in visual issues.
- The IOV logo at the bottom is not vertically aligned to the end of the view.

There is a color inconsistency addressed in this [#235 comment](https://github.com/iov-one/ponferrada/issues/235#issuecomment-497680085).

Closes #235.

**Screenshots**
The following screenshots are presented as a counterpart of the ones present in issue #235:
![imagen](https://user-images.githubusercontent.com/44572727/58703519-3dbcb600-83a9-11e9-8b43-c934d40550ba.png)
![imagen](https://user-images.githubusercontent.com/44572727/58703527-42816a00-83a9-11e9-8105-fb5ca4020a48.png)