### PR TITLE
Fix - Makes the Mnemonic field "Required" in Restore Account view

### DIFF
--- a/packages/sanes-chrome-extension/src/routes/restore-account/components/SetMnemonicForm.tsx
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/components/SetMnemonicForm.tsx
@@ -5,7 +5,11 @@ import Form, { FormValues, useForm } from 'medulas-react-components/lib/componen
 import TextFieldForm from 'medulas-react-components/lib/components/forms/TextFieldForm';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import Typography from 'medulas-react-components/lib/components/Typography';
-import { numberOfWords } from 'medulas-react-components/lib/utils/forms/validators';
+import {
+  composeValidators,
+  numberOfWords,
+  required,
+} from 'medulas-react-components/lib/utils/forms/validators';
 import * as React from 'react';
 import { useMemo } from 'react';
 import { RESTORE_ACCOUNT } from '../../paths';
@@ -28,7 +32,7 @@ const SetMnemonicForm = ({ onSetMnemonic, onBack }: Props): JSX.Element => {
 
   //TODO optimize update of validators with array of dependencies
   const validator = useMemo(() => {
-    return numberOfWords(MNEMONIC_NUM_WORDS);
+    return composeValidators(required, numberOfWords(MNEMONIC_NUM_WORDS));
   }, []);
 
   return (

--- a/packages/sanes-chrome-extension/src/routes/restore-account/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/index.dom.spec.ts
@@ -1,3 +1,4 @@
+import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
 import { PersonaData } from '../../extension/background/model/backgroundscript';
 import { aNewStore } from '../../store';
@@ -33,5 +34,16 @@ withChainsDescribe('DOM > Feature > Restore Account', () => {
   it('should restore profile from mnemonic', async () => {
     await submitRecoveryPhrase(restoreAccountDom, mnemonic, password);
     await whenOnNavigatedToRoute(store, ACCOUNT_STATUS_ROUTE);
+  }, 55000);
+
+  it('should warn required mnemonic if empty', async () => {
+    const mnemonicForm = TestUtils.findRenderedDOMComponentWithTag(restoreAccountDom, 'form');
+
+    TestUtils.act(() => {
+      TestUtils.Simulate.submit(mnemonicForm);
+    });
+
+    const validityLabel = TestUtils.findRenderedDOMComponentWithTag(restoreAccountDom, 'p');
+    expect(validityLabel.textContent).toBe('Required');
   }, 55000);
 });


### PR DESCRIPTION
**Description**
The Restore Account process is comprised of two forms: a Set Mnemonic Form and a Set Password Form. The mnemonic one has a bug that lets a user continue the account restoration process without providing a mnemonic.

This PR makes use of Medulas' form validators to ensure that the mnemonic field is required, so it has to be correctly filled before submitting the form.