### PR TITLE
Fix – Remove unused content script

### DIFF
--- a/packages/sanes-chrome-extension/public/manifest.json
+++ b/packages/sanes-chrome-extension/public/manifest.json
@@ -17,12 +17,7 @@
     "48": "assets/icons/icon48.png",
     "128": "assets/icons/icon128.png"
   },
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": ["js/contentScript.js"]
-    }
-  ],
+  "content_scripts": [],
   "externally_connectable": {
     "matches": ["http://localhost/*", "https://*.iov.one/*"]
   },


### PR DESCRIPTION
With this change, the “Broad host permissions” warning is gone. See also https://stackoverflow.com/questions/52929477/broad-host-permissions-webstore-warning-despite-only-one-host-in-permissions