### PR TITLE
Feature - Remove test check when pushing a PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "yarn lint && yarn test"
+      "pre-push": "yarn lint"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
**Description**
As long as the project is growing it is a time-consuming wait to pass all tests in the project. We are using --no-verify flag each day more times, so developers should run tests locally before pushing and then, let Travis test again. 