### PR TITLE
Feature – Import sorting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,10 +11,12 @@ module.exports = {
   rules: {
     "no-empty": "off",
     "no-console": "warn",
+    "sort-imports": "off", // we use the simple-import-sort plugin instead
+    "simple-import-sort/sort": "warn",
     "@typescript-eslint/explicit-function-return-type": [ "error", {
       allowExpressions: true,
     }],
     "@typescript-eslint/no-explicit-any": "off",
   },
-  plugins: ['@typescript-eslint', 'react'],
+  plugins: ["@typescript-eslint", "react", "simple-import-sort"],
 };

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint-config-prettier": "^4.1.0",
     "eslint-config-react-app": "4.0.0",
     "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-simple-import-sort": "^4.0.0",
     "history": "^4.7.2",
     "husky": "^1.3.1",
     "lerna": "^3.13.0",

--- a/packages/bierzo-wallet/src/communication/identities/index.ts
+++ b/packages/bierzo-wallet/src/communication/identities/index.ts
@@ -3,6 +3,7 @@ import { isPublicIdentity, PublicIdentity } from '@iov/bcp';
 import { TransactionEncoder } from '@iov/core';
 import { ethereumCodec } from '@iov/ethereum';
 import { isJsonRpcErrorResponse, JsonRpcRequest, makeJsonRpcId, parseJsonRpcResponse2 } from '@iov/jsonrpc';
+
 import { extensionId } from '..';
 
 export const generateGetIdentitiesRequest = (): JsonRpcRequest => ({

--- a/packages/bierzo-wallet/src/communication/signAndPost/index.ts
+++ b/packages/bierzo-wallet/src/communication/signAndPost/index.ts
@@ -1,8 +1,9 @@
 /*global chrome*/
-import { JsonRpcRequest, parseJsonRpcResponse2, isJsonRpcErrorResponse, makeJsonRpcId } from '@iov/jsonrpc';
+import { Address, PublicIdentity, SendTransaction, TokenTicker, TransactionId } from '@iov/bcp';
 import { TransactionEncoder } from '@iov/core';
-import { PublicIdentity, SendTransaction, Address, TokenTicker, TransactionId } from '@iov/bcp';
 import { EthereumConnection } from '@iov/ethereum';
+import { isJsonRpcErrorResponse, JsonRpcRequest, makeJsonRpcId, parseJsonRpcResponse2 } from '@iov/jsonrpc';
+
 import { extensionId } from '..';
 
 async function withEthereumFee(transaction: SendTransaction): Promise<SendTransaction> {

--- a/packages/bierzo-wallet/src/components/Header/components/BellMenu/TxItem/MsgError.tsx
+++ b/packages/bierzo-wallet/src/components/Header/components/BellMenu/TxItem/MsgError.tsx
@@ -1,5 +1,6 @@
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+
 import { elipsify } from '../../../../../utils/strings';
 
 interface MsgErrorProps {

--- a/packages/bierzo-wallet/src/components/Header/components/BellMenu/TxItem/MsgSuccess.tsx
+++ b/packages/bierzo-wallet/src/components/Header/components/BellMenu/TxItem/MsgSuccess.tsx
@@ -1,5 +1,6 @@
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+
 import { elipsify } from '../../../../../utils/strings';
 
 interface MsgProps {

--- a/packages/bierzo-wallet/src/components/Header/components/BellMenu/TxItem/index.tsx
+++ b/packages/bierzo-wallet/src/components/Header/components/BellMenu/TxItem/index.tsx
@@ -5,6 +5,7 @@ import Block from 'medulas-react-components/lib/components/Block';
 import Hairline from 'medulas-react-components/lib/components/Hairline';
 import Image from 'medulas-react-components/lib/components/Image';
 import * as React from 'react';
+
 import { history } from '../../../../../routes';
 import { PAYMENT_ROUTE } from '../../../../../routes/paths';
 import { ProcessedTx } from '../../../../../store/notifications';

--- a/packages/bierzo-wallet/src/components/Header/components/BellMenu/index.tsx
+++ b/packages/bierzo-wallet/src/components/Header/components/BellMenu/index.tsx
@@ -8,6 +8,7 @@ import Typography from 'medulas-react-components/lib/components/Typography';
 import EmptyListIcon from 'medulas-react-components/lib/templates/menu/EmptyListIcon';
 import ListMenu from 'medulas-react-components/lib/templates/menu/ListMenu';
 import * as React from 'react';
+
 import { ProcessedTx } from '../../../../store/notifications';
 import { getLastTx, storeLastTx } from '../../../../utils/localstorage/transactions';
 import bell from '../../assets/bell.svg';

--- a/packages/bierzo-wallet/src/components/Header/components/HiMenu/index.tsx
+++ b/packages/bierzo-wallet/src/components/Header/components/HiMenu/index.tsx
@@ -9,6 +9,7 @@ import Image from 'medulas-react-components/lib/components/Image';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import ListMenu from 'medulas-react-components/lib/templates/menu/ListMenu';
 import * as React from 'react';
+
 import { getBorderColor } from '../../../../theme/css';
 import chevronDown from '../../assets/chevronDown.svg';
 import chevronUp from '../../assets/chevronUp.svg';

--- a/packages/bierzo-wallet/src/components/Header/components/LinksMenu/index.tsx
+++ b/packages/bierzo-wallet/src/components/Header/components/LinksMenu/index.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import Block from 'medulas-react-components/lib/components/Block';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+
 import { history } from '../../../../routes';
 import {
   BALANCE_ROUTE,

--- a/packages/bierzo-wallet/src/components/Header/components/TransactionsMenu/TransactionsList.tsx
+++ b/packages/bierzo-wallet/src/components/Header/components/TransactionsMenu/TransactionsList.tsx
@@ -5,6 +5,7 @@ import Block from 'medulas-react-components/lib/components/Block';
 import Hairline from 'medulas-react-components/lib/components/Hairline';
 import EmptyListIcon from 'medulas-react-components/lib/templates/menu/EmptyListIcon';
 import * as React from 'react';
+
 import { Tx } from '../../../../store/notifications';
 import { prettyAmount } from '../../../../utils/balances';
 import { elipsify } from '../../../../utils/strings';

--- a/packages/bierzo-wallet/src/components/Header/components/TransactionsMenu/index.tsx
+++ b/packages/bierzo-wallet/src/components/Header/components/TransactionsMenu/index.tsx
@@ -3,6 +3,7 @@ import Badge from 'medulas-react-components/lib/components/Badge';
 import Image from 'medulas-react-components/lib/components/Image';
 import ListMenu from 'medulas-react-components/lib/templates/menu/ListMenu';
 import * as React from 'react';
+
 import { Tx } from '../../../../store/notifications';
 import loading from '../../assets/loading.svg';
 import loadingSpin from '../../assets/loadingSpin.svg';

--- a/packages/bierzo-wallet/src/components/Header/index.stories.tsx
+++ b/packages/bierzo-wallet/src/components/Header/index.stories.tsx
@@ -6,6 +6,7 @@ import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
 import { ReadonlyDate } from 'readonly-date';
 import { DeepPartial } from 'redux';
+
 import { ProcessedTx, Tx } from '../../store/notifications';
 import { RootState } from '../../store/reducers';
 import { stringToAmount } from '../../utils/balances';

--- a/packages/bierzo-wallet/src/components/Header/index.tsx
+++ b/packages/bierzo-wallet/src/components/Header/index.tsx
@@ -3,6 +3,7 @@ import Block from 'medulas-react-components/lib/components/Block';
 import Img from 'medulas-react-components/lib/components/Image';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
+
 import { getPendingTransactions } from '../../store/notifications/selectors';
 import logoBlack from './assets/logoBlack.svg';
 import BellMenu from './components/BellMenu';

--- a/packages/bierzo-wallet/src/components/Header/selector.ts
+++ b/packages/bierzo-wallet/src/components/Header/selector.ts
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+
 import { ProcessedTx } from '../../store/notifications';
 import { getTransactions } from '../../store/notifications/selectors';
 

--- a/packages/bierzo-wallet/src/components/RequireLogin/index.tsx
+++ b/packages/bierzo-wallet/src/components/RequireLogin/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import { Redirect } from 'react-router';
+
 import { LOGIN_ROUTE } from '../../routes/paths';
 import { RootState } from '../../store/reducers';
 

--- a/packages/bierzo-wallet/src/index.tsx
+++ b/packages/bierzo-wallet/src/index.tsx
@@ -3,6 +3,7 @@ import MedulasThemeProvider from 'medulas-react-components/lib/theme/MedulasThem
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+
 import Routes from './routes';
 import { configureStore } from './store';
 import { globalStyles } from './theme/globalStyles';

--- a/packages/bierzo-wallet/src/routes/index.tsx
+++ b/packages/bierzo-wallet/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { createBrowserHistory } from 'history';
 import React from 'react';
 import { Route, Router, Switch } from 'react-router';
+
 import RequireLogin from '../components/RequireLogin';
 import Login from './login';
 import { LOGIN_ROUTE, PAYMENT_ROUTE, WELCOME_ROUTE } from './paths';

--- a/packages/bierzo-wallet/src/routes/login/index.e2e.spec.ts
+++ b/packages/bierzo-wallet/src/routes/login/index.e2e.spec.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response } from 'express';
 import { Server } from 'http';
 import { Browser, Page } from 'puppeteer';
-import { INSTALL_EXTENSION_MSG, LOGIN_EXTENSION_MSG } from '.';
+
 import {
   closeBrowser,
   closeToast,
@@ -20,6 +20,7 @@ import { withChainsDescribe } from '../../utils/test/testExecutor';
 import { sleep } from '../../utils/timer';
 import { WELCOME_ROUTE } from '../paths';
 import { travelToWelcomeE2e } from '../welcome/test/travelToWelcome';
+import { INSTALL_EXTENSION_MSG, LOGIN_EXTENSION_MSG } from '.';
 
 withChainsDescribe(
   'E2E > Login route',

--- a/packages/bierzo-wallet/src/routes/login/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/login/index.stories.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import DecoratedStorybook, { WALLET_ROOT } from '../../utils/storybook';
 import Login from './index';
 

--- a/packages/bierzo-wallet/src/routes/login/index.tsx
+++ b/packages/bierzo-wallet/src/routes/login/index.tsx
@@ -3,6 +3,7 @@ import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider
 import PageColumn from 'medulas-react-components/lib/pages/PageColumn';
 import * as React from 'react';
 import * as ReactRedux from 'react-redux';
+
 import { history } from '..';
 import { getExtensionStatus } from '../../communication/status';
 import { setExtensionStateAction } from '../../store/extension';

--- a/packages/bierzo-wallet/src/routes/payment/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/index.stories.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import DecoratedStorybook, { WALLET_ROOT } from '../../utils/storybook';
 import Payment from './index';
 

--- a/packages/bierzo-wallet/src/routes/payment/index.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/index.tsx
@@ -5,6 +5,7 @@ import Button from 'medulas-react-components/lib/components/Button';
 import Form, { useForm } from 'medulas-react-components/lib/components/forms/Form';
 import React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
+
 import Header from '../../components/Header';
 import CurrencyToSend from './components/CurrencyToSend';
 import ReceiverAddress from './components/ReceiverAddress';

--- a/packages/bierzo-wallet/src/routes/welcome/index.dom.spec.ts
+++ b/packages/bierzo-wallet/src/routes/welcome/index.dom.spec.ts
@@ -1,5 +1,6 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import { aNewStore } from '../../store';
 import { RootState } from '../../store/reducers';
 import { expectRoute } from '../../utils/test/dom';

--- a/packages/bierzo-wallet/src/routes/welcome/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/welcome/index.stories.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import DecoratedStorybook, { WALLET_ROOT } from '../../utils/storybook';
 import Welcome from './index';
 

--- a/packages/bierzo-wallet/src/routes/welcome/index.tsx
+++ b/packages/bierzo-wallet/src/routes/welcome/index.tsx
@@ -8,6 +8,7 @@ import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider
 import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
 import React from 'react';
 import * as ReactRedux from 'react-redux';
+
 import icon from '../../assets/iov-logo.svg';
 import { sendGetIdentitiesRequest } from '../../communication/identities';
 import { sendSignAndPostRequest } from '../../communication/signAndPost';

--- a/packages/bierzo-wallet/src/routes/welcome/test/travelToWelcome.ts
+++ b/packages/bierzo-wallet/src/routes/welcome/test/travelToWelcome.ts
@@ -1,6 +1,7 @@
 import { Page } from 'puppeteer';
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import { history } from '../../../routes';
 import { createDom } from '../../../utils/test/dom';
 import { whenOnNavigatedToRoute } from '../../../utils/test/navigation';

--- a/packages/bierzo-wallet/src/store/extension/reducer.ts
+++ b/packages/bierzo-wallet/src/store/extension/reducer.ts
@@ -1,5 +1,6 @@
 import { Action } from 'redux';
 import { ActionType } from 'typesafe-actions';
+
 import * as actions from './actions';
 
 export interface ExtensionState {

--- a/packages/bierzo-wallet/src/store/index.ts
+++ b/packages/bierzo-wallet/src/store/index.ts
@@ -1,4 +1,5 @@
 import { applyMiddleware, compose, createStore, DeepPartial, Middleware, Store } from 'redux';
+
 import reducers, { RootReducer, RootState } from './reducers';
 
 const composeEnhancers =

--- a/packages/bierzo-wallet/src/store/notifications/actions.ts
+++ b/packages/bierzo-wallet/src/store/notifications/actions.ts
@@ -1,5 +1,6 @@
 import { Action } from 'redux';
 import { ActionType } from 'typesafe-actions';
+
 import { ProcessedTx } from './reducer';
 
 export interface AddPendingTransactionActionType extends Action {

--- a/packages/bierzo-wallet/src/store/notifications/reducer.ts
+++ b/packages/bierzo-wallet/src/store/notifications/reducer.ts
@@ -1,5 +1,6 @@
 import { Amount } from '@iov/bcp';
 import { ReadonlyDate } from 'readonly-date';
+
 import { NotificationActions } from './actions';
 
 export interface Tx {

--- a/packages/bierzo-wallet/src/store/reducers.ts
+++ b/packages/bierzo-wallet/src/store/reducers.ts
@@ -1,5 +1,6 @@
 import { combineReducers, Reducer } from 'redux';
 import { StateType } from 'typesafe-actions';
+
 import { extensionReducer, ExtensionState } from './extension';
 import { notificationReducer, NotificationState } from './notifications';
 import { tokensReducer, TokenState } from './tokens';

--- a/packages/bierzo-wallet/src/store/tokens/actions.ts
+++ b/packages/bierzo-wallet/src/store/tokens/actions.ts
@@ -1,4 +1,5 @@
 import { EthereumConnection } from '@iov/ethereum';
+
 import { AddTickerActionType, BwToken } from './reducer';
 
 export async function getTokens(): Promise<{ [key: string]: BwToken }> {

--- a/packages/bierzo-wallet/src/store/tokens/reducer.ts
+++ b/packages/bierzo-wallet/src/store/tokens/reducer.ts
@@ -1,6 +1,7 @@
 import { ChainId, Token } from '@iov/bcp';
 import { Action } from 'redux';
 import { ActionType } from 'typesafe-actions';
+
 import * as actions from './actions';
 
 export interface BwToken {

--- a/packages/bierzo-wallet/src/theme/globalStyles.ts
+++ b/packages/bierzo-wallet/src/theme/globalStyles.ts
@@ -1,5 +1,6 @@
-import makeStyles from 'medulas-react-components/lib/theme/utils/styles';
 import 'normalize.css';
+
+import makeStyles from 'medulas-react-components/lib/theme/utils/styles';
 
 export const globalStyles = makeStyles({
   '@global': {

--- a/packages/bierzo-wallet/src/utils/balances.spec.ts
+++ b/packages/bierzo-wallet/src/utils/balances.spec.ts
@@ -1,4 +1,5 @@
 import { Amount, TokenTicker } from '@iov/bcp';
+
 import {
   amountToString,
   makeAmount as makeInfo,

--- a/packages/bierzo-wallet/src/utils/storybook/index.tsx
+++ b/packages/bierzo-wallet/src/utils/storybook/index.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
 import { DeepPartial } from 'redux';
+
 import { aNewStore } from '../../store';
 import { RootState } from '../../store/reducers';
 import { globalStyles } from '../../theme/globalStyles';

--- a/packages/bierzo-wallet/src/utils/test/dom.tsx
+++ b/packages/bierzo-wallet/src/utils/test/dom.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { Store } from 'redux';
+
 import Routes from '../../routes';
 
 export const createDom = (store: Store): React.Component =>

--- a/packages/bierzo-wallet/src/utils/test/e2e.ts
+++ b/packages/bierzo-wallet/src/utils/test/e2e.ts
@@ -1,4 +1,5 @@
 import puppeteer, { Browser, Page } from 'puppeteer';
+
 import { extensionId } from '../../communication';
 
 export function launchBrowser(slowMo: number = 0, install: boolean = true): Promise<Browser> {

--- a/packages/bierzo-wallet/src/utils/test/persona.ts
+++ b/packages/bierzo-wallet/src/utils/test/persona.ts
@@ -1,4 +1,5 @@
 import { Page } from 'puppeteer';
+
 import { sleep } from '../timer';
 import { whenOnNavigatedToE2eRoute } from './navigation';
 

--- a/packages/medulas-react-components/src/components/Avatar/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Avatar/index.stories.tsx
@@ -6,6 +6,7 @@ import FolderIcon from '@material-ui/icons/Folder';
 import PageviewIcon from '@material-ui/icons/Pageview';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
+
 import { Storybook } from '../../utils/storybook';
 import Avatar from '../Avatar';
 import Block from '../Block';

--- a/packages/medulas-react-components/src/components/Badge/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Badge/index.stories.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import RecoveryPhraseIcon from '../../theme/assets/badgeIcon/recoveryPhrase.svg';
 import { Storybook } from '../../utils/storybook';
 import Block from '../Block';

--- a/packages/medulas-react-components/src/components/Badge/index.tsx
+++ b/packages/medulas-react-components/src/components/Badge/index.tsx
@@ -1,5 +1,6 @@
 import { Badge, makeStyles, PropTypes, Theme } from '@material-ui/core';
 import React from 'react';
+
 import CheckIcon from '../../theme/assets/badgeIcon/check.svg';
 import Img from '../Image';
 

--- a/packages/medulas-react-components/src/components/BoxScroll/index.tsx
+++ b/packages/medulas-react-components/src/components/BoxScroll/index.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import { makeStyles, Theme } from '@material-ui/core';
 import Box, { BoxProps } from '@material-ui/core/Box';
 import classNames from 'classnames';
-import { Theme, makeStyles } from '@material-ui/core';
+import * as React from 'react';
 
 const useStyles = makeStyles((theme: Theme) => ({
   scroll: {

--- a/packages/medulas-react-components/src/components/Button/Back.tsx
+++ b/packages/medulas-react-components/src/components/Button/Back.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import MuiButton, { ButtonProps } from '@material-ui/core/Button';
+import * as React from 'react';
 
 const Back = ({ children, ...restProps }: ButtonProps): JSX.Element => (
   <MuiButton {...restProps} variant="text" aria-label="Go back">

--- a/packages/medulas-react-components/src/components/Button/Download.tsx
+++ b/packages/medulas-react-components/src/components/Button/Download.tsx
@@ -2,10 +2,11 @@ import { Fab, makeStyles } from '@material-ui/core';
 import { Theme } from '@material-ui/core/styles';
 import { useTheme } from '@material-ui/styles';
 import * as React from 'react';
+
+import download from '../../theme/assets/download.svg';
 import Block from '../Block';
 import CircleImage from '../Image/CircleImage';
 import Typography from '../Typography';
-import download from '../../theme/assets/download.svg';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {

--- a/packages/medulas-react-components/src/components/Button/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Button/index.stories.tsx
@@ -1,12 +1,13 @@
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
-import Button from './index';
-import Download from './Download';
-import Back from './Back';
+
 import { Storybook } from '../../utils/storybook';
 import Grid from '../Grid';
 import GridItem from '../GridItem';
+import Back from './Back';
+import Download from './Download';
+import Button from './index';
 
 storiesOf('Components', module).add(
   'Buttons',

--- a/packages/medulas-react-components/src/components/Button/index.tsx
+++ b/packages/medulas-react-components/src/components/Button/index.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import { Omit } from '@material-ui/core';
 import MuiButton, { ButtonProps } from '@material-ui/core/Button';
-import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
+import React from 'react';
+
 import Block from '../Block';
 
 interface Props extends Omit<ButtonProps, 'variant'> {

--- a/packages/medulas-react-components/src/components/Drawer/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Drawer/index.stories.tsx
@@ -1,6 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import { Storybook } from '../../utils/storybook';
 import Block from '../Block';
 import Link from '../Link';

--- a/packages/medulas-react-components/src/components/Drawer/index.tsx
+++ b/packages/medulas-react-components/src/components/Drawer/index.tsx
@@ -11,6 +11,7 @@ import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import MenuIcon from '@material-ui/icons/Menu';
 import classNames from 'classnames';
 import React from 'react';
+
 import Block from '../Block';
 import Image from '../Image';
 

--- a/packages/medulas-react-components/src/components/Hairline/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Hairline/index.stories.tsx
@@ -1,9 +1,10 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
-import Typography from '../Typography';
+
 import { Storybook } from '../../utils/storybook';
-import Hairline from './index';
 import Block from '../Block';
+import Typography from '../Typography';
+import Hairline from './index';
 
 storiesOf('Components', module).add('Hairline', () => (
   <Storybook>

--- a/packages/medulas-react-components/src/components/Hairline/index.tsx
+++ b/packages/medulas-react-components/src/components/Hairline/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import Block from '../Block';
 
 interface Props {

--- a/packages/medulas-react-components/src/components/Image/CircleImage.tsx
+++ b/packages/medulas-react-components/src/components/Image/CircleImage.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import Image, { ImgProps } from '../Image';
+
 import theme from '../../theme/utils/mui';
 import Block from '../Block';
+import Image, { ImgProps } from '../Image';
 
 interface Props extends ImgProps {
   readonly icon: string;

--- a/packages/medulas-react-components/src/components/Image/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Image/index.stories.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import download from '../../theme/assets/download.svg';
 import iovLogo from '../../theme/assets/iov-logo2x.png';
 import theme from '../../theme/utils/mui';

--- a/packages/medulas-react-components/src/components/Image/index.tsx
+++ b/packages/medulas-react-components/src/components/Image/index.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
-import classNames from 'classnames';
 import { makeStyles } from '@material-ui/styles';
+import classNames from 'classnames';
+import * as React from 'react';
 
 const useStyles = makeStyles({
   root: {

--- a/packages/medulas-react-components/src/components/List/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/List/index.stories.tsx
@@ -4,6 +4,7 @@ import ImageIcon from '@material-ui/icons/Image';
 import WorkIcon from '@material-ui/icons/Work';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
+
 import { Storybook } from '../../utils/storybook';
 import Avatar from '../Avatar';
 import { List, ListItem, ListItemAvatar, ListItemText } from './index';

--- a/packages/medulas-react-components/src/components/List/index.tsx
+++ b/packages/medulas-react-components/src/components/List/index.tsx
@@ -1,7 +1,7 @@
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemAvatar from '@material-ui/core/ListItemAvatar';
-import ListItemText from '@material-ui/core/ListItemText';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
 
 export { List, ListItem, ListItemText, ListItemAvatar, ListItemIcon };

--- a/packages/medulas-react-components/src/components/PageLayout/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/PageLayout/index.stories.tsx
@@ -1,9 +1,10 @@
+import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
+import { Storybook } from '../../utils/storybook';
 import Typography from '../Typography';
 import PageLayout from './index';
-import { Storybook } from '../../utils/storybook';
-import { action } from '@storybook/addon-actions';
 
 storiesOf('Components', module).add(
   'Layout',

--- a/packages/medulas-react-components/src/components/PageLayout/index.tsx
+++ b/packages/medulas-react-components/src/components/PageLayout/index.tsx
@@ -2,6 +2,7 @@ import { makeStyles, Theme } from '@material-ui/core';
 import IconButton from '@material-ui/core/IconButton';
 import ArrowBackIcon from '@material-ui/icons/ArrowBackIos';
 import * as React from 'react';
+
 import iovLogo from '../../theme/assets/iov-logo.png';
 import Block from '../Block';
 import Image from '../Image';

--- a/packages/medulas-react-components/src/components/Switch/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Switch/index.stories.tsx
@@ -1,8 +1,9 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
-import Switch from './index';
-import Block from '../Block';
+
 import { Storybook } from '../../utils/storybook';
+import Block from '../Block';
+import Switch from './index';
 
 storiesOf('Components', module).add(
   'Switch',

--- a/packages/medulas-react-components/src/components/Switch/index.tsx
+++ b/packages/medulas-react-components/src/components/Switch/index.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
-import MuiSwitch, { SwitchProps } from '@material-ui/core/Switch';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import MuiSwitch, { SwitchProps } from '@material-ui/core/Switch';
+import * as React from 'react';
 
 interface Props extends SwitchProps {
   readonly label?: string;

--- a/packages/medulas-react-components/src/components/Tooltip/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Tooltip/index.stories.tsx
@@ -1,9 +1,10 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
-import Tooltip from './index';
+
+import { Storybook } from '../../utils/storybook';
 import Block from '../Block';
 import Typography from '../Typography';
-import { Storybook } from '../../utils/storybook';
+import Tooltip from './index';
 
 storiesOf('Components', module).add(
   'Tooltip',

--- a/packages/medulas-react-components/src/components/Tooltip/index.tsx
+++ b/packages/medulas-react-components/src/components/Tooltip/index.tsx
@@ -1,6 +1,7 @@
 import { createStyles, makeStyles, Popper, Theme } from '@material-ui/core';
 import Paper from '@material-ui/core/Paper';
 import * as React from 'react';
+
 import { useOpen } from '../../hooks/open';
 import infoNormal from '../../theme/assets/info_normal.svg';
 import theme from '../../theme/utils/mui';

--- a/packages/medulas-react-components/src/components/Typography/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/Typography/index.stories.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import { Storybook } from '../../utils/storybook';
 import Link from '../Link';
 import Typography from './index';

--- a/packages/medulas-react-components/src/components/forms/CheckboxField/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/CheckboxField/index.stories.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable no-console */
-import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
 import React from 'react';
-import CheckboxField from './index';
+
 import { Storybook } from '../../../utils/storybook';
 import Form, { useForm, ValidationError } from '../Form';
+import CheckboxField from './index';
 
 const CHECKBOX_FIELD = 'CHECKBOX_FIELD';
 

--- a/packages/medulas-react-components/src/components/forms/CheckboxField/index.tsx
+++ b/packages/medulas-react-components/src/components/forms/CheckboxField/index.tsx
@@ -1,11 +1,11 @@
-import { FormApi, FieldSubscription } from 'final-form';
-import { useField } from 'react-final-form-hooks';
-import * as React from 'react';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
 import { FormControl, FormHelperText, makeStyles, Theme } from '@material-ui/core';
-import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import CheckBoxIcon from '@material-ui/icons/CheckBox';
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import { FieldSubscription, FormApi } from 'final-form';
+import * as React from 'react';
+import { useField } from 'react-final-form-hooks';
 
 const useStyles = makeStyles<Theme>({
   root: {

--- a/packages/medulas-react-components/src/components/forms/Form/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/Form/index.stories.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable no-console */
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
+
 import { Storybook } from '../../../utils/storybook';
-import Button from '../../Button';
 import Block from '../../Block';
+import Button from '../../Button';
+import CheckboxField from '../CheckboxField';
 import SelectFieldForm, { Item } from '../SelectFieldForm';
 import TextFieldForm from '../TextFieldForm';
-import CheckboxField from '../CheckboxField';
-import Form, { useForm, FormValues, ValidationError } from './index';
+import Form, { FormValues, useForm, ValidationError } from './index';
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms)); // eslint-disable-line
 

--- a/packages/medulas-react-components/src/components/forms/Form/index.tsx
+++ b/packages/medulas-react-components/src/components/forms/Form/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useForm, useField } from 'react-final-form-hooks';
+import { useField, useForm } from 'react-final-form-hooks';
 
 export { useForm, useField };
 

--- a/packages/medulas-react-components/src/components/forms/SelectFieldForm/SelectItems.tsx
+++ b/packages/medulas-react-components/src/components/forms/SelectFieldForm/SelectItems.tsx
@@ -2,6 +2,7 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import * as React from 'react';
+
 import selectedTick from '../../../theme/assets/selectField/selectedTick.svg';
 import Block from '../../Block';
 import Hairline from '../../Hairline';

--- a/packages/medulas-react-components/src/components/forms/SelectFieldForm/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/SelectFieldForm/index.stories.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable no-console */
-import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
 import React from 'react';
-import SelectField from './index';
+
 import { Storybook } from '../../../utils/storybook';
 import Form, { useForm } from '../Form';
+import SelectField from './index';
 import { Item } from './index';
 
 const SelectFieldForm = (): JSX.Element => {

--- a/packages/medulas-react-components/src/components/forms/SelectFieldForm/index.tsx
+++ b/packages/medulas-react-components/src/components/forms/SelectFieldForm/index.tsx
@@ -4,6 +4,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 import { FieldSubscription, FormApi } from 'final-form';
 import * as React from 'react';
 import { useField } from 'react-final-form-hooks';
+
 import { useOpen } from '../../../hooks/open';
 import selectChevron from '../../../theme/assets/selectField/selectChevron.svg';
 import Block from '../../Block';

--- a/packages/medulas-react-components/src/components/forms/TextFieldForm/index.stories.tsx
+++ b/packages/medulas-react-components/src/components/forms/TextFieldForm/index.stories.tsx
@@ -1,12 +1,13 @@
-import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
 import React from 'react';
-import TextFieldForm from './index';
+
 import { Storybook } from '../../../utils/storybook';
+import Block from '../../Block';
 import Grid from '../../Grid';
 import GridItem from '../../GridItem';
 import Form, { useForm } from '../Form';
-import Block from '../../Block';
+import TextFieldForm from './index';
 
 interface Props {
   readonly name: string;

--- a/packages/medulas-react-components/src/context/ToastProvider/Toast/ToastContent.tsx
+++ b/packages/medulas-react-components/src/context/ToastProvider/Toast/ToastContent.tsx
@@ -1,6 +1,7 @@
-import { IconButton, SnackbarContent, Theme, createStyles, makeStyles } from '@material-ui/core';
+import { createStyles, IconButton, makeStyles, SnackbarContent, Theme } from '@material-ui/core';
 import classNames from 'classnames';
 import * as React from 'react';
+
 import Block from '../../../components/Block';
 import Image from '../../../components/Image';
 import Typography from '../../../components/Typography';

--- a/packages/medulas-react-components/src/context/ToastProvider/Toast/index.tsx
+++ b/packages/medulas-react-components/src/context/ToastProvider/Toast/index.tsx
@@ -1,7 +1,8 @@
 import Snackbar, { SnackbarOrigin } from '@material-ui/core/Snackbar';
-import * as React from 'react';
-import ToastContent from './ToastContent';
 import SnackbarContent from '@material-ui/core/SnackbarContent';
+import * as React from 'react';
+
+import ToastContent from './ToastContent';
 
 export enum ToastVariant {
   SUCCESS = 'success',

--- a/packages/medulas-react-components/src/context/ToastProvider/Toast/toast.stories.tsx
+++ b/packages/medulas-react-components/src/context/ToastProvider/Toast/toast.stories.tsx
@@ -1,13 +1,14 @@
+import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
+
 import Block from '../../../components/Block';
 import Button from '../../../components/Button';
-import { Storybook } from '../../../utils/storybook';
-import { ToastVariant } from './index';
-import { ToastContext, ToastProvider } from '../index';
 import Typography from '../../../components/Typography';
+import { Storybook } from '../../../utils/storybook';
+import { ToastContext, ToastProvider } from '../index';
+import { ToastVariant } from './index';
 import ToastContent from './ToastContent';
-import { action } from '@storybook/addon-actions';
 
 const ToastStorybook = (): JSX.Element => {
   const { show } = React.useContext(ToastContext);

--- a/packages/medulas-react-components/src/context/ToastProvider/index.tsx
+++ b/packages/medulas-react-components/src/context/ToastProvider/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Toast, ToastVariant } from './Toast';
+
 import { singleton } from '../../utils/singleton';
+import { Toast, ToastVariant } from './Toast';
 
 export interface ToastContextInterface {
   readonly show: (message: string, variant: ToastVariant) => void;

--- a/packages/medulas-react-components/src/pages/PageColumn/EmptyHeader.tsx
+++ b/packages/medulas-react-components/src/pages/PageColumn/EmptyHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import Block from '../../components/Block';
 
 const EmptyHeader = (): JSX.Element => <Block height={109} />;

--- a/packages/medulas-react-components/src/pages/PageColumn/SubtitleSection.tsx
+++ b/packages/medulas-react-components/src/pages/PageColumn/SubtitleSection.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import Block from '../../components/Block';
 import Typography from '../../components/Typography';
 

--- a/packages/medulas-react-components/src/pages/PageColumn/TitleSection.tsx
+++ b/packages/medulas-react-components/src/pages/PageColumn/TitleSection.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import Block from '../../components/Block';
 import Typography from '../../components/Typography';
 

--- a/packages/medulas-react-components/src/pages/PageColumn/index.stories.tsx
+++ b/packages/medulas-react-components/src/pages/PageColumn/index.stories.tsx
@@ -1,6 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import { Storybook } from '../../utils/storybook';
 import PageColumn from './index';
 

--- a/packages/medulas-react-components/src/pages/PageColumn/index.tsx
+++ b/packages/medulas-react-components/src/pages/PageColumn/index.tsx
@@ -2,6 +2,7 @@ import { makeStyles, Theme } from '@material-ui/core';
 import useTheme from '@material-ui/styles/useTheme';
 import { FormApi } from 'final-form';
 import React from 'react';
+
 import Block from '../../components/Block';
 import BoxScroll from '../../components/BoxScroll';
 import Button from '../../components/Button';

--- a/packages/medulas-react-components/src/templates/menu/EmptyListIcon.tsx
+++ b/packages/medulas-react-components/src/templates/menu/EmptyListIcon.tsx
@@ -3,6 +3,7 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import * as React from 'react';
+
 import Block from '../../components/Block';
 import Img from '../../components/Image';
 

--- a/packages/medulas-react-components/src/templates/menu/ListMenu.tsx
+++ b/packages/medulas-react-components/src/templates/menu/ListMenu.tsx
@@ -4,6 +4,7 @@ import Grow from '@material-ui/core/Grow';
 import List from '@material-ui/core/List';
 import Popper from '@material-ui/core/Popper';
 import * as React from 'react';
+
 import { useOpen } from '../../hooks/open';
 
 interface Props {

--- a/packages/medulas-react-components/src/templates/menu/index.stories.tsx
+++ b/packages/medulas-react-components/src/templates/menu/index.stories.tsx
@@ -4,6 +4,7 @@ import Down from '@material-ui/icons/KeyboardArrowDown';
 import Up from '@material-ui/icons/KeyboardArrowUp';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import Block from '../../components/Block';
 import Typography from '../../components/Typography';
 import noPendingTxs from '../../theme/assets/icons/noPendingTxs.svg';

--- a/packages/medulas-react-components/src/theme/MedulasThemeProvider.tsx
+++ b/packages/medulas-react-components/src/theme/MedulasThemeProvider.tsx
@@ -1,6 +1,7 @@
-import * as React from 'react';
-import theme from './utils/mui';
 import { ThemeProvider } from '@material-ui/styles';
+import * as React from 'react';
+
+import theme from './utils/mui';
 
 interface Props {
   readonly injectFonts?: boolean;

--- a/packages/medulas-react-components/src/theme/utils/mui.ts
+++ b/packages/medulas-react-components/src/theme/utils/mui.ts
@@ -1,6 +1,7 @@
 import grey from '@material-ui/core/colors/grey';
 import { createMuiTheme } from '@material-ui/core/styles';
 import { ThemeOptions } from '@material-ui/core/styles/createMuiTheme';
+
 import { lightFont, secondaryColor, white } from './variables';
 
 const theme = createMuiTheme({

--- a/packages/medulas-react-components/src/utils/storybook/index.tsx
+++ b/packages/medulas-react-components/src/utils/storybook/index.tsx
@@ -1,5 +1,6 @@
 import { makeStyles, Theme } from '@material-ui/core';
 import * as React from 'react';
+
 import ThemeProvider from '../../theme/MedulasThemeProvider';
 
 interface Props {

--- a/packages/sanes-chrome-extension/src/context/PersonaProvider.tsx
+++ b/packages/sanes-chrome-extension/src/context/PersonaProvider.tsx
@@ -1,5 +1,6 @@
 /*global chrome*/
 import * as React from 'react';
+
 import { GetPersonaResponse } from '../extension/background/model/backgroundscript';
 import { PersonaAcccount, ProcessedTx } from '../extension/background/model/persona';
 import {

--- a/packages/sanes-chrome-extension/src/context/RequestProvider.tsx
+++ b/packages/sanes-chrome-extension/src/context/RequestProvider.tsx
@@ -1,5 +1,6 @@
 /*global chrome*/
 import * as React from 'react';
+
 import { IovWindowExtension } from '../extension/background/model/backgroundscript';
 import { Request } from '../extension/background/model/signingServer/requestQueueManager';
 import {

--- a/packages/sanes-chrome-extension/src/extension/background/model/accountManager/index.unit.spec.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/accountManager/index.unit.spec.ts
@@ -1,5 +1,6 @@
 import { Algorithm, ChainId } from '@iov/bcp';
 import { HdPaths } from '@iov/core';
+
 import { PersonaBuilder } from '../persona/personaBuider';
 import { AccountManager, AccountManagerChainConfig } from './index';
 

--- a/packages/sanes-chrome-extension/src/extension/background/model/backgroundscript/index.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/backgroundscript/index.ts
@@ -1,4 +1,5 @@
 import { JsonRpcResponse } from '@iov/jsonrpc';
+
 import { Persona, PersonaAcccount, ProcessedTx } from '../persona';
 import SigningServer from '../signingServer';
 import { Request } from '../signingServer/requestQueueManager';

--- a/packages/sanes-chrome-extension/src/extension/background/model/persona/config/codec.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/persona/config/codec.ts
@@ -1,9 +1,9 @@
 import { Algorithm, ChainConnector } from '@iov/bcp';
-import { HdPaths } from '@iov/keycontrol';
-import { Slip10RawIndex } from '@iov/crypto';
 import { bnsConnector } from '@iov/bns';
-import { liskConnector } from '@iov/lisk';
+import { Slip10RawIndex } from '@iov/crypto';
 import { ethereumConnector } from '@iov/ethereum';
+import { HdPaths } from '@iov/keycontrol';
+import { liskConnector } from '@iov/lisk';
 
 import { CodecString } from './configurationfile';
 

--- a/packages/sanes-chrome-extension/src/extension/background/model/persona/index.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/persona/index.ts
@@ -1,10 +1,11 @@
 import { isSendTransaction, SendTransaction, UnsignedTransaction } from '@iov/bcp';
-import { BnsConnection, RegisterUsernameTx, isRegisterUsernameTx } from '@iov/bns';
+import { BnsConnection, isRegisterUsernameTx, RegisterUsernameTx } from '@iov/bns';
 import { MultiChainSigner, SignedAndPosted, SigningServerCore, UserProfile } from '@iov/core';
 import { Bip39, Random } from '@iov/crypto';
 import { Encoding } from '@iov/encoding';
 import { UserProfileEncryptionKey } from '@iov/keycontrol';
 import { ReadonlyDate } from 'readonly-date';
+
 import { transactionsUpdater } from '../../updaters/appUpdater';
 import { AccountManager } from '../accountManager';
 import { StringDb } from '../backgroundscript/db';

--- a/packages/sanes-chrome-extension/src/extension/background/model/persona/index.unit.spec.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/persona/index.unit.spec.ts
@@ -2,6 +2,7 @@ import { bnsCodec, BnsConnection, RegisterUsernameTx } from '@iov/bns';
 import { Ed25519HdWallet, HdPaths, TokenTicker, UserProfile } from '@iov/core';
 import { Bip39, EnglishMnemonic, Random } from '@iov/crypto';
 import { IovFaucet } from '@iov/faucets';
+
 import { withChainsDescribe } from '../../../../utils/test/testExecutor';
 import { sleep } from '../../../../utils/timer';
 import * as txsUpdater from '../../updaters/appUpdater';

--- a/packages/sanes-chrome-extension/src/extension/background/model/persona/personaBuider.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/persona/personaBuider.ts
@@ -1,5 +1,6 @@
 import { MultiChainSigner } from '@iov/core';
 import { Ed25519HdWallet, Secp256k1HdWallet, UserProfile } from '@iov/keycontrol';
+
 import { AccountManager, AccountManagerChainConfig } from '../accountManager';
 import {
   algorithmForCodec,

--- a/packages/sanes-chrome-extension/src/extension/background/model/persona/test/persona.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/persona/test/persona.ts
@@ -1,4 +1,5 @@
 import { Store } from 'redux';
+
 import { PersonaAcccount, ProcessedTx } from '..';
 import { ACCOUNT_STATUS_ROUTE } from '../../../../../routes/paths';
 import {

--- a/packages/sanes-chrome-extension/src/extension/background/model/signingServer/index.requests.unit.spec.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/signingServer/index.requests.unit.spec.ts
@@ -1,5 +1,6 @@
 import { TransactionEncoder } from '@iov/core';
 import { jsonRpcCode, JsonRpcRequest, JsonRpcSuccessResponse, parseJsonRpcResponse2 } from '@iov/jsonrpc';
+
 import { withChainsDescribe } from '../../../../utils/test/testExecutor';
 import { sleep } from '../../../../utils/timer';
 import { generateErrorResponse } from '../../errorResponseGenerator';

--- a/packages/sanes-chrome-extension/src/extension/background/model/signingServer/index.server.unit.spec.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/signingServer/index.server.unit.spec.ts
@@ -1,4 +1,5 @@
 import { JsonRpcSigningServer, SignAndPostAuthorization, TransactionEncoder } from '@iov/core';
+
 import { withChainsDescribe } from '../../../../utils/test/testExecutor';
 import * as txsUpdater from '../../updaters/appUpdater';
 import { Db, StringDb } from '../backgroundscript/db';

--- a/packages/sanes-chrome-extension/src/extension/background/model/signingServer/index.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/signingServer/index.ts
@@ -1,6 +1,7 @@
 import { PublicIdentity, UnsignedTransaction } from '@iov/bcp';
 import { JsonRpcSigningServer, MultiChainSigner, SigningServerCore } from '@iov/core';
 import { JsonRpcResponse } from '@iov/jsonrpc';
+
 import { generateErrorResponse } from '../../errorResponseGenerator';
 import { isSupportedTransaction } from '../persona';
 import { getConfigurationFile } from '../persona/config';

--- a/packages/sanes-chrome-extension/src/extension/background/model/signingServer/requestQueueManager/index.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/signingServer/requestQueueManager/index.ts
@@ -1,5 +1,6 @@
 import { Address, isUnsignedTransaction } from '@iov/bcp';
 import { Omit } from '@material-ui/core';
+
 import { isSupportedTransaction, SupportedTransaction } from '../../persona';
 
 export interface RequestMeta {

--- a/packages/sanes-chrome-extension/src/extension/background/model/signingServer/requestQueueManager/index.unit.spec.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/signingServer/requestQueueManager/index.unit.spec.ts
@@ -1,4 +1,5 @@
 import { Omit } from '@material-ui/core';
+
 import { Request, RequestQueueManager } from './index';
 
 describe('RequestHandler', () => {

--- a/packages/sanes-chrome-extension/src/index.tsx
+++ b/packages/sanes-chrome-extension/src/index.tsx
@@ -4,6 +4,7 @@ import MedulasThemeProvider from 'medulas-react-components/lib/theme/MedulasThem
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+
 import { PersonaProvider } from './context/PersonaProvider';
 import { RequestProvider } from './context/RequestProvider';
 import { GetPersonaResponse } from './extension/background/model/backgroundscript';

--- a/packages/sanes-chrome-extension/src/routes/account/components/ListTxs.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/components/ListTxs.tsx
@@ -3,6 +3,7 @@ import Hairline from 'medulas-react-components/lib/components/Hairline';
 import { List, ListItem, ListItemText } from 'medulas-react-components/lib/components/List';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+
 import { ProcessedTx } from '../../../extension/background/model/persona';
 import upToDate from '../assets/uptodate.svg';
 import EmptyList from './Empty';

--- a/packages/sanes-chrome-extension/src/routes/account/components/Tx/MsgRegisterUsernameTx.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/components/Tx/MsgRegisterUsernameTx.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
 
 interface MsgRegisterUsernameTxProps {
   readonly id: string;

--- a/packages/sanes-chrome-extension/src/routes/account/components/Tx/MsgSendTransaction.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/components/Tx/MsgSendTransaction.tsx
@@ -8,6 +8,7 @@ import Typography from 'medulas-react-components/lib/components/Typography';
 import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider';
 import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
 import * as React from 'react';
+
 import { elipsify } from '../../../../utils/strings';
 
 interface MsgSendTransactionProps {

--- a/packages/sanes-chrome-extension/src/routes/account/components/Tx/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/components/Tx/index.tsx
@@ -7,6 +7,7 @@ import Block from 'medulas-react-components/lib/components/Block';
 import Hairline from 'medulas-react-components/lib/components/Hairline';
 import Img from 'medulas-react-components/lib/components/Image';
 import * as React from 'react';
+
 import { ProcessedTx } from '../../../../extension/background/model/persona';
 import { prettyAmount } from '../../../../utils/balances';
 import iconErrorTx from '../../assets/transactionError.svg';

--- a/packages/sanes-chrome-extension/src/routes/account/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/account/index.dom.spec.ts
@@ -1,9 +1,11 @@
 import { Address, Algorithm, ChainId, PublicKeyBytes, SendTransaction, TokenTicker } from '@iov/bcp';
+import { RegisterUsernameTx } from '@iov/bns';
 import { TransactionEncoder } from '@iov/core';
 import { Encoding } from '@iov/encoding';
 import { JsonRpcSuccessResponse, parseJsonRpcResponse2 } from '@iov/jsonrpc';
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import Backgroundscript, { IovWindowExtension } from '../../extension/background/model/backgroundscript';
 import { Persona, PersonaAcccount, ProcessedTx } from '../../extension/background/model/persona';
 import {
@@ -24,9 +26,8 @@ import { travelToAccount, whenOnNavigatedToRoute } from '../../utils/test/naviga
 import { withChainsDescribe } from '../../utils/test/testExecutor';
 import { sleep } from '../../utils/timer';
 import * as Drawer from '../account/test/drawer';
-import { RECOVERY_PHRASE_ROUTE, REQUEST_ROUTE, WELCOME_ROUTE, TERMS_URL } from '../paths';
+import { RECOVERY_PHRASE_ROUTE, REQUEST_ROUTE, TERMS_URL, WELCOME_ROUTE } from '../paths';
 import { checkCreateAccount, getTransactionsCount } from './test/operateAccount';
-import { RegisterUsernameTx } from '@iov/bns';
 
 describe('DOM > Feature > Account Status', () => {
   const ACCOUNT = 'Account 0';

--- a/packages/sanes-chrome-extension/src/routes/account/index.e2e.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/account/index.e2e.spec.ts
@@ -1,4 +1,5 @@
 import { Browser, Page } from 'puppeteer';
+
 import { closeBrowser, createPage, launchBrowser } from '../../utils/test/e2e';
 import { randomString } from '../../utils/test/random';
 import { withChainsDescribe } from '../../utils/test/testExecutor';

--- a/packages/sanes-chrome-extension/src/routes/account/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/index.stories.tsx
@@ -1,15 +1,16 @@
 import { Address, Algorithm, ChainId, PublicKeyBytes, SendTransaction, TokenTicker } from '@iov/bcp';
+import { RegisterUsernameTx } from '@iov/bns';
 import { Encoding } from '@iov/encoding';
 import { storiesOf } from '@storybook/react';
 import { ToastProvider } from 'medulas-react-components/lib/context/ToastProvider';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
+
 import { PersonaProvider } from '../../context/PersonaProvider';
 import { GetPersonaResponse } from '../../extension/background/model/backgroundscript';
 import { ProcessedTx } from '../../extension/background/model/persona';
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 import Layout from './index';
-import { RegisterUsernameTx } from '@iov/bns';
 
 export const ACCOUNT_STATUS_PAGE = 'Account Status page';
 

--- a/packages/sanes-chrome-extension/src/routes/account/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/index.tsx
@@ -10,6 +10,7 @@ import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider
 import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
 import * as React from 'react';
 import { useForm } from 'react-final-form-hooks';
+
 import { PersonaContext } from '../../context/PersonaProvider';
 import { history } from '../../store/reducers';
 import { EXTENSION_HEIGHT } from '../../theme/constants';

--- a/packages/sanes-chrome-extension/src/routes/account/test/drawer.ts
+++ b/packages/sanes-chrome-extension/src/routes/account/test/drawer.ts
@@ -1,5 +1,6 @@
 import { DRAWER_HTML_ID } from 'medulas-react-components/lib/components/Drawer';
 import TestUtils from 'react-dom/test-utils';
+
 import { click } from '../../../utils/test/dom';
 import { findRenderedDOMComponentWithId } from '../../../utils/test/reactElemFinder';
 

--- a/packages/sanes-chrome-extension/src/routes/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Route, Switch } from 'react-router-dom';
+
 import AccountStatus from './account';
 import Login from './login';
 import {

--- a/packages/sanes-chrome-extension/src/routes/login/components/LoginControls.tsx
+++ b/packages/sanes-chrome-extension/src/routes/login/components/LoginControls.tsx
@@ -2,6 +2,7 @@ import Block from 'medulas-react-components/lib/components/Block';
 import Link from 'medulas-react-components/lib/components/Link';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+
 import { RESTORE_ACCOUNT } from '../../paths';
 
 const LoginControls = (): JSX.Element => {

--- a/packages/sanes-chrome-extension/src/routes/login/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/login/index.dom.spec.ts
@@ -1,5 +1,6 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import {
   mockCreatePersona,
   mockLoadPersona,

--- a/packages/sanes-chrome-extension/src/routes/login/index.e2e.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/login/index.e2e.spec.ts
@@ -1,4 +1,5 @@
 import { Browser, Page } from 'puppeteer';
+
 import { IovWindowExtension } from '../../extension/background/model/backgroundscript';
 import {
   closeBrowser,

--- a/packages/sanes-chrome-extension/src/routes/login/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/login/index.stories.tsx
@@ -1,6 +1,7 @@
 import { storiesOf } from '@storybook/react';
-import { SanesStorybook, CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 import React from 'react';
+
+import { CHROME_EXTENSION_ROOT, SanesStorybook } from '../../utils/storybook';
 import Layout from './index';
 
 storiesOf(CHROME_EXTENSION_ROOT, module).add(

--- a/packages/sanes-chrome-extension/src/routes/login/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/login/index.tsx
@@ -3,6 +3,7 @@ import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider';
 import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
 import * as React from 'react';
+
 import { PersonaContext } from '../../context/PersonaProvider';
 import { history } from '../../store/reducers';
 import { loadPersona } from '../../utils/chrome';

--- a/packages/sanes-chrome-extension/src/routes/login/test/submitLoginForm.ts
+++ b/packages/sanes-chrome-extension/src/routes/login/test/submitLoginForm.ts
@@ -1,4 +1,5 @@
 import { Page } from 'puppeteer';
+
 import { findRenderedE2EComponentWithId } from '../../../utils/test/reactElemFinder';
 import { ACCOUNT_STATUS_ROUTE } from '../../paths';
 import { PASSWORD_FIELD } from '../components/LoginForm';

--- a/packages/sanes-chrome-extension/src/routes/recovery-phrase/components/PdfDownload.tsx
+++ b/packages/sanes-chrome-extension/src/routes/recovery-phrase/components/PdfDownload.tsx
@@ -1,5 +1,6 @@
-import * as React from 'react';
 import DownloadButton from 'medulas-react-components/lib/components/Button/Download';
+import * as React from 'react';
+
 import PDFGenerator from '../utils/pdfGenerator';
 
 export interface Props {

--- a/packages/sanes-chrome-extension/src/routes/recovery-phrase/components/ShowRecoveryPhrase.tsx
+++ b/packages/sanes-chrome-extension/src/routes/recovery-phrase/components/ShowRecoveryPhrase.tsx
@@ -1,6 +1,7 @@
 import Block from 'medulas-react-components/lib/components/Block';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+
 import PdfDownload from './PdfDownload';
 
 export interface Props {

--- a/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.dom.spec.ts
@@ -1,5 +1,6 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import {
   mockGetPersonaData,
   mockPersonaResponse,

--- a/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.stories.tsx
@@ -1,8 +1,9 @@
 import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
-import RecoveryPhrase from './index';
+
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
+import RecoveryPhrase from './index';
 
 storiesOf(CHROME_EXTENSION_ROOT, module).add(
   'Recovery Phrase page',

--- a/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/recovery-phrase/index.tsx
@@ -1,5 +1,6 @@
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import * as React from 'react';
+
 import { PersonaContext } from '../../context/PersonaProvider';
 import { history } from '../../store/reducers';
 import { RECOVERY_PHRASE_ROUTE } from '../paths';

--- a/packages/sanes-chrome-extension/src/routes/requests/components/RequestList.tsx
+++ b/packages/sanes-chrome-extension/src/routes/requests/components/RequestList.tsx
@@ -7,6 +7,7 @@ import Hairline from 'medulas-react-components/lib/components/Hairline';
 import { List, ListItem, ListItemAvatar, ListItemText } from 'medulas-react-components/lib/components/List';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+
 import { Request } from '../../../extension/background/model/signingServer/requestQueueManager';
 import { history } from '../../../store/reducers';
 import { SHARE_IDENTITY, TX_REQUEST } from '../../paths';

--- a/packages/sanes-chrome-extension/src/routes/requests/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/requests/index.dom.spec.ts
@@ -1,6 +1,7 @@
 import { Address } from '@iov/bcp';
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import { Request } from '../../extension/background/model/signingServer/requestQueueManager';
 import { aNewStore } from '../../store';
 import { resetHistory, RootState } from '../../store/reducers';

--- a/packages/sanes-chrome-extension/src/routes/requests/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/requests/index.stories.tsx
@@ -1,7 +1,8 @@
-import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
+
 import { RequestProvider } from '../../context/RequestProvider';
 import { Request } from '../../extension/background/model/signingServer/requestQueueManager';
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';

--- a/packages/sanes-chrome-extension/src/routes/requests/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/requests/index.tsx
@@ -4,6 +4,7 @@ import Typography from 'medulas-react-components/lib/components/Typography';
 import { ToastContextInterface } from 'medulas-react-components/lib/context/ToastProvider';
 import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
 import * as React from 'react';
+
 import { RequestContext } from '../../context/RequestProvider';
 import { Request } from '../../extension/background/model/signingServer/requestQueueManager';
 import { history } from '../../store/reducers';

--- a/packages/sanes-chrome-extension/src/routes/restore-account/components/SetMnemonicForm.tsx
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/components/SetMnemonicForm.tsx
@@ -12,6 +12,7 @@ import {
 } from 'medulas-react-components/lib/utils/forms/validators';
 import * as React from 'react';
 import { useMemo } from 'react';
+
 import { RESTORE_ACCOUNT } from '../../paths';
 
 export const MNEMONIC_FIELD = 'mnemonicField';

--- a/packages/sanes-chrome-extension/src/routes/restore-account/components/SetPasswordForm.tsx
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/components/SetPasswordForm.tsx
@@ -12,6 +12,7 @@ import Typography from 'medulas-react-components/lib/components/Typography';
 import { composeValidators, longerThan, required } from 'medulas-react-components/lib/utils/forms/validators';
 import * as React from 'react';
 import { useMemo } from 'react';
+
 import { RESTORE_ACCOUNT } from '../../paths';
 
 export const SET_PASSWORD_STEP_RESTORE_ACCOUNT_ROUTE = `${RESTORE_ACCOUNT}2`;

--- a/packages/sanes-chrome-extension/src/routes/restore-account/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/index.dom.spec.ts
@@ -1,5 +1,6 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import {
   mockCreatePersona,
   mockPersonaResponse,

--- a/packages/sanes-chrome-extension/src/routes/restore-account/index.e2e.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/index.e2e.spec.ts
@@ -1,4 +1,5 @@
 import { Browser, Page } from 'puppeteer';
+
 import { closeBrowser, createPage, launchBrowser } from '../../utils/test/e2e';
 import { randomString } from '../../utils/test/random';
 import { withChainsDescribe } from '../../utils/test/testExecutor';

--- a/packages/sanes-chrome-extension/src/routes/restore-account/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/index.stories.tsx
@@ -2,6 +2,7 @@ import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
+
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 import SetMnemonicForm from './components/SetMnemonicForm';
 import SetPasswordForm from './components/SetPasswordForm';

--- a/packages/sanes-chrome-extension/src/routes/restore-account/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/index.tsx
@@ -1,6 +1,8 @@
 import { FormValues } from 'medulas-react-components/lib/components/forms/Form';
 import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider';
+import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
 import * as React from 'react';
+
 import { PersonaContext } from '../../context/PersonaProvider';
 import { PersonaData } from '../../extension/background/model/backgroundscript';
 import { history } from '../../store/reducers';
@@ -8,7 +10,6 @@ import { createPersona } from '../../utils/chrome';
 import { ACCOUNT_STATUS_ROUTE } from '../paths';
 import SetMnemonicForm, { MNEMONIC_FIELD } from './components/SetMnemonicForm';
 import SetPasswordForm, { PASSWORD_FIELD } from './components/SetPasswordForm';
-import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
 
 const onBack = (): void => {
   history.goBack();

--- a/packages/sanes-chrome-extension/src/routes/restore-account/test/operateRestoreAccount.ts
+++ b/packages/sanes-chrome-extension/src/routes/restore-account/test/operateRestoreAccount.ts
@@ -1,5 +1,6 @@
 import { Page } from 'puppeteer';
 import TestUtils from 'react-dom/test-utils';
+
 import { input, submit } from '../../../utils/test/dom';
 import {
   findRenderedDOMComponentWithId,

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/RejectRequest.tsx
@@ -6,6 +6,7 @@ import Form, { FormValues, useForm } from 'medulas-react-components/lib/componen
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+
 import { SHARE_IDENTITY } from '../../paths';
 
 const PERMANENT_REJECT = 'permanentRejectField';

--- a/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/components/ShowRequest.tsx
@@ -5,6 +5,7 @@ import { List, ListItem, ListItemText } from 'medulas-react-components/lib/compo
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+
 import { GetIdentitiesData } from '../../../extension/background/model/signingServer/requestQueueManager';
 import { SHARE_IDENTITY } from '../../paths';
 

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.dom.spec.ts
@@ -1,6 +1,7 @@
 import { Address } from '@iov/bcp';
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import { Request } from '../../extension/background/model/signingServer/requestQueueManager';
 import { aNewStore } from '../../store';
 import { RootState } from '../../store/reducers';

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.stories.tsx
@@ -4,6 +4,7 @@ import { linkTo } from '@storybook/addon-links';
 import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
+
 import { GetIdentitiesRequest } from '../../extension/background/model/signingServer/requestQueueManager';
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
 import { ACCOUNT_STATUS_PAGE } from '../account/index.stories';

--- a/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/index.tsx
@@ -1,6 +1,7 @@
 import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
+
 import { RequestContext } from '../../context/RequestProvider';
 import { isGetIdentityData } from '../../extension/background/model/signingServer/requestQueueManager';
 import { history } from '../../store/reducers';

--- a/packages/sanes-chrome-extension/src/routes/share-identity/test/operateShareIdentity.ts
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/test/operateShareIdentity.ts
@@ -1,7 +1,8 @@
 import TestUtils from 'react-dom/test-utils';
+
 import { findRenderedDOMComponentWithId } from '../../../utils/test/reactElemFinder';
-import { SHARE_IDENTITY_SHOW } from '../components/ShowRequest';
 import { SHARE_IDENTITY_REJECT } from '../components/RejectRequest';
+import { SHARE_IDENTITY_SHOW } from '../components/ShowRequest';
 
 export const clickOnRejectButton = async (ShareIdentityDom: React.Component): Promise<void> => {
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(ShareIdentityDom, 'button');

--- a/packages/sanes-chrome-extension/src/routes/signup/components/NewAccountForm.tsx
+++ b/packages/sanes-chrome-extension/src/routes/signup/components/NewAccountForm.tsx
@@ -1,18 +1,19 @@
-import * as React from 'react';
+import Block from 'medulas-react-components/lib/components/Block';
 import Button from 'medulas-react-components/lib/components/Button';
 import Back from 'medulas-react-components/lib/components/Button/Back';
-import Block from 'medulas-react-components/lib/components/Block';
+import CheckboxField from 'medulas-react-components/lib/components/forms/CheckboxField';
 import Form, {
-  useForm,
   FormValues,
+  useForm,
   ValidationError,
 } from 'medulas-react-components/lib/components/forms/Form';
 import TextFieldForm from 'medulas-react-components/lib/components/forms/TextFieldForm';
-import PageLayout from 'medulas-react-components/lib/components/PageLayout';
-import { SIGNUP_ROUTE, TERMS_URL } from '../../paths';
-import CheckboxField from 'medulas-react-components/lib/components/forms/CheckboxField';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Link from 'medulas-react-components/lib/components/Link';
+import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
+import { SIGNUP_ROUTE, TERMS_URL } from '../../paths';
 
 export const ACCOUNT_NAME_FIELD = 'accountNameField';
 export const PASSWORD_FIELD = 'passwordInputField';

--- a/packages/sanes-chrome-extension/src/routes/signup/components/SecurityHintForm.tsx
+++ b/packages/sanes-chrome-extension/src/routes/signup/components/SecurityHintForm.tsx
@@ -1,15 +1,16 @@
-import * as React from 'react';
-import Button from 'medulas-react-components/lib/components/Button';
 import Block from 'medulas-react-components/lib/components/Block';
+import Button from 'medulas-react-components/lib/components/Button';
 import Back from 'medulas-react-components/lib/components/Button/Back';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Form, {
-  useForm,
   FormValues,
+  useForm,
   ValidationError,
 } from 'medulas-react-components/lib/components/forms/Form';
 import TextFieldForm from 'medulas-react-components/lib/components/forms/TextFieldForm';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
 import { SIGNUP_ROUTE } from '../../paths';
 
 export const SECURITY_HINT = 'securityHintField';

--- a/packages/sanes-chrome-extension/src/routes/signup/components/ShowPhraseForm.tsx
+++ b/packages/sanes-chrome-extension/src/routes/signup/components/ShowPhraseForm.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Block from 'medulas-react-components/lib/components/Block';
 import Button from 'medulas-react-components/lib/components/Button';
 import Back from 'medulas-react-components/lib/components/Button/Back';
+import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import Switch from 'medulas-react-components/lib/components/Switch';
 import Tooltip from 'medulas-react-components/lib/components/Tooltip';
-import PageLayout from 'medulas-react-components/lib/components/PageLayout';
-import { SIGNUP_ROUTE } from '../../paths';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
 import { PersonaContext } from '../../../context/PersonaProvider';
+import { SIGNUP_ROUTE } from '../../paths';
 
 export const SECOND_STEP_SIGNUP_ROUTE = `${SIGNUP_ROUTE}2`;
 

--- a/packages/sanes-chrome-extension/src/routes/signup/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/signup/index.dom.spec.ts
@@ -1,5 +1,6 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import {
   mockCreatePersona,
   mockPersonaResponse,
@@ -24,11 +25,11 @@ import {
   getNewAccountForm,
   getNewAccountInputs,
   getPasswordValidity,
+  getTermsCheckboxLabel,
+  getTermsValidity,
   isButtonDisabled,
   submitNewAccount,
   submitShowPhrase,
-  getTermsValidity,
-  getTermsCheckboxLabel,
 } from './test/operateSignup';
 
 describe('DOM > Feature > Signup', () => {

--- a/packages/sanes-chrome-extension/src/routes/signup/index.e2e.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/signup/index.e2e.spec.ts
@@ -1,11 +1,12 @@
 import { Browser, Page } from 'puppeteer';
+
 import { closeBrowser, createPage, launchBrowser } from '../../utils/test/e2e';
 import { randomString } from '../../utils/test/random';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
 import {
-  submitShowPhraseE2E,
-  submitSecurityHintE2E,
   submitNewAccountE2E,
+  submitSecurityHintE2E,
+  submitShowPhraseE2E,
   travelToSignupNewAccountStep,
 } from './test/operateSignup';
 

--- a/packages/sanes-chrome-extension/src/routes/signup/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/signup/index.stories.tsx
@@ -1,11 +1,12 @@
-import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
-import NewAccountForm from './components/NewAccountForm';
-import ShowPhraseForm from './components/ShowPhraseForm';
-import SecurityHintForm from './components/SecurityHintForm';
+
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
+import NewAccountForm from './components/NewAccountForm';
+import SecurityHintForm from './components/SecurityHintForm';
+import ShowPhraseForm from './components/ShowPhraseForm';
 
 storiesOf(`${CHROME_EXTENSION_ROOT}/Signup`, module)
   .add(

--- a/packages/sanes-chrome-extension/src/routes/signup/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/signup/index.tsx
@@ -1,5 +1,8 @@
 import { FormValues } from 'medulas-react-components/lib/components/forms/Form';
+import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider';
+import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
 import * as React from 'react';
+
 import { PersonaContext } from '../../context/PersonaProvider';
 import { PersonaData } from '../../extension/background/model/backgroundscript';
 import { history } from '../../store/reducers';
@@ -9,8 +12,6 @@ import { ACCOUNT_STATUS_ROUTE } from '../paths';
 import NewAccountForm, { ACCOUNT_NAME_FIELD, PASSWORD_FIELD } from './components/NewAccountForm';
 import SecurityHintForm, { SECURITY_HINT } from './components/SecurityHintForm';
 import ShowPhraseForm from './components/ShowPhraseForm';
-import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
-import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider';
 
 const onBack = (): void => {
   history.goBack();

--- a/packages/sanes-chrome-extension/src/routes/signup/test/operateSignup.ts
+++ b/packages/sanes-chrome-extension/src/routes/signup/test/operateSignup.ts
@@ -1,7 +1,8 @@
 import { Page } from 'puppeteer';
 import TestUtils from 'react-dom/test-utils';
+
 import { getHintPhrase } from '../../../utils/localstorage/hint';
-import { click, input, submit, check } from '../../../utils/test/dom';
+import { check, click, input, submit } from '../../../utils/test/dom';
 import {
   findRenderedDOMComponentWithId,
   findRenderedE2EComponentWithId,

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/RejectRequest.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/RejectRequest.tsx
@@ -7,6 +7,7 @@ import Hairline from 'medulas-react-components/lib/components/Hairline';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+
 import { TX_REQUEST } from '../../paths';
 
 const PERMANENT_REJECT = 'permanentRejectField';

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/ReqRegisterUsernameTx.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/ReqRegisterUsernameTx.tsx
@@ -1,9 +1,10 @@
 import { RegisterUsernameTx } from '@iov/bns';
-import { List, ListItem, ListItemText } from 'medulas-react-components/lib/components/List';
-import * as React from 'react';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Block from 'medulas-react-components/lib/components/Block';
-import TransactionFee, { useTxListItemStyles, txListItemSecondaryProps } from './TransactionFee';
+import { List, ListItem, ListItemText } from 'medulas-react-components/lib/components/List';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
+import TransactionFee, { txListItemSecondaryProps, useTxListItemStyles } from './TransactionFee';
 
 export const REQ_REGISTER_USERNAME = 'req-register-username-tx';
 

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/ReqSendTransaction.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/ReqSendTransaction.tsx
@@ -1,8 +1,9 @@
 import { SendTransaction } from '@iov/bcp';
 import { List, ListItem, ListItemText } from 'medulas-react-components/lib/components/List';
 import * as React from 'react';
+
 import { amountToString } from '../../../../utils/balances';
-import TransactionFee, { useTxListItemStyles, txListItemSecondaryProps } from './TransactionFee';
+import TransactionFee, { txListItemSecondaryProps, useTxListItemStyles } from './TransactionFee';
 
 export const REQ_SEND_TX = 'req-send-tx';
 

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/TransactionFee.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/TransactionFee.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import { Fee } from '@iov/bcp';
 import { makeStyles } from '@material-ui/core';
 import { ListItem, ListItemText } from 'medulas-react-components/lib/components/List';
+import React from 'react';
+
 import { amountToString } from '../../../../utils/balances';
-import { Fee } from '@iov/bcp';
 
 export const useTxListItemStyles = makeStyles({
   root: {

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/index.tsx
@@ -5,6 +5,7 @@ import Button from 'medulas-react-components/lib/components/Button';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import * as React from 'react';
+
 import { SupportedTransaction } from '../../../../extension/background/model/persona';
 import { TX_REQUEST } from '../../../paths';
 import ReqRegisterUsernameTx from './ReqRegisterUsernameTx';

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.dom.spec.ts
@@ -1,12 +1,17 @@
 import { Address } from '@iov/bcp';
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import { Request } from '../../extension/background/model/signingServer/requestQueueManager';
 import { aNewStore } from '../../store';
 import { RootState } from '../../store/reducers';
 import { click } from '../../utils/test/dom';
 import { travelToTXRequest, whenOnNavigatedToRoute } from '../../utils/test/navigation';
+import { findRenderedDOMComponentWithId } from '../../utils/test/reactElemFinder';
 import { sleep } from '../../utils/timer';
+import { REQUEST_ROUTE } from '../paths';
+import { REQ_REGISTER_USERNAME } from './components/ShowRequest/ReqRegisterUsernameTx';
+import { REQ_SEND_TX } from './components/ShowRequest/ReqSendTransaction';
 import { getTransaction, getUsernameTransaction } from './test';
 import {
   checkPermanentRejection,
@@ -14,10 +19,6 @@ import {
   clickOnRejectButton,
   confirmRejectButton,
 } from './test/operateTXRequest';
-import { REQUEST_ROUTE } from '../paths';
-import { findRenderedDOMComponentWithId } from '../../utils/test/reactElemFinder';
-import { REQ_SEND_TX } from './components/ShowRequest/ReqSendTransaction';
-import { REQ_REGISTER_USERNAME } from './components/ShowRequest/ReqRegisterUsernameTx';
 
 const sendRequests: ReadonlyArray<Request> = [
   {

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.stories.tsx
@@ -4,6 +4,7 @@ import { linkTo } from '@storybook/addon-links';
 import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
+
 import {
   Request,
   SignAndPostRequest,

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.tsx
@@ -1,6 +1,7 @@
 import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
+
 import { RequestContext } from '../../context/RequestProvider';
 import { isSignAndPostRequestData } from '../../extension/background/model/signingServer/requestQueueManager';
 import { history } from '../../store/reducers';

--- a/packages/sanes-chrome-extension/src/routes/tx-request/test/index.ts
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/test/index.ts
@@ -8,8 +8,8 @@ import {
   SendTransaction,
   TokenTicker,
 } from '@iov/bcp';
-import { Encoding } from '@iov/encoding';
 import { RegisterUsernameTx } from '@iov/bns';
+import { Encoding } from '@iov/encoding';
 
 export function getTransaction(): SendTransaction {
   const defaultCreator: PublicIdentity = {

--- a/packages/sanes-chrome-extension/src/routes/tx-request/test/operateTXRequest.ts
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/test/operateTXRequest.ts
@@ -1,7 +1,8 @@
 import TestUtils from 'react-dom/test-utils';
+
 import { findRenderedDOMComponentWithId } from '../../../utils/test/reactElemFinder';
-import { TX_REQUEST_SHOW } from '../components/ShowRequest';
 import { TX_REQUEST_REJECT } from '../components/RejectRequest';
+import { TX_REQUEST_SHOW } from '../components/ShowRequest';
 
 export const clickOnRejectButton = async (TXRequestDom: React.Component): Promise<void> => {
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(TXRequestDom, 'button');

--- a/packages/sanes-chrome-extension/src/routes/welcome/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/welcome/index.dom.spec.ts
@@ -1,5 +1,6 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import { aNewStore } from '../../store';
 import { resetHistory, RootState } from '../../store/reducers';
 import { click } from '../../utils/test/dom';

--- a/packages/sanes-chrome-extension/src/routes/welcome/index.e2e.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/welcome/index.e2e.spec.ts
@@ -1,6 +1,7 @@
 import { Browser, Page } from 'puppeteer';
+
+import { closeBrowser, createPage, launchBrowser } from '../../utils/test/e2e';
 import { WELCOME_ROUTE } from '../paths';
-import { launchBrowser, createPage, closeBrowser } from '../../utils/test/e2e';
 
 describe('DOM > Welcome route', (): void => {
   let browser: Browser;

--- a/packages/sanes-chrome-extension/src/routes/welcome/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/welcome/index.stories.tsx
@@ -1,8 +1,9 @@
 import { storiesOf } from '@storybook/react';
 import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import React from 'react';
-import Layout from './index';
+
 import { CHROME_EXTENSION_ROOT } from '../../utils/storybook';
+import Layout from './index';
 
 storiesOf(CHROME_EXTENSION_ROOT, module).add(
   'Welcome page',

--- a/packages/sanes-chrome-extension/src/routes/welcome/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/welcome/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Button from 'medulas-react-components/lib/components/Button';
-import Typography from 'medulas-react-components/lib/components/Typography';
 import Block from 'medulas-react-components/lib/components/Block';
+import Button from 'medulas-react-components/lib/components/Button';
 import PageLayout from 'medulas-react-components/lib/components/PageLayout';
+import Typography from 'medulas-react-components/lib/components/Typography';
+import * as React from 'react';
+
 import { history } from '../../store/reducers';
-import { SIGNUP_ROUTE, LOGIN_ROUTE, WELCOME_ROUTE, RESTORE_ACCOUNT } from '../paths';
+import { LOGIN_ROUTE, RESTORE_ACCOUNT, SIGNUP_ROUTE, WELCOME_ROUTE } from '../paths';
 
 const createNewAccount = (): void => {
   history.push(SIGNUP_ROUTE);

--- a/packages/sanes-chrome-extension/src/store/index.ts
+++ b/packages/sanes-chrome-extension/src/store/index.ts
@@ -1,6 +1,7 @@
 import { routerMiddleware } from 'connected-react-router';
-import { createStore, applyMiddleware, compose, Middleware, Store } from 'redux';
+import { applyMiddleware, compose, createStore, Middleware, Store } from 'redux';
 import thunk from 'redux-thunk';
+
 import { history, reducer, RootState } from './reducers';
 
 const middlewares: ReadonlyArray<Middleware> = [thunk, routerMiddleware(history)];

--- a/packages/sanes-chrome-extension/src/theme/globalStyles.ts
+++ b/packages/sanes-chrome-extension/src/theme/globalStyles.ts
@@ -1,5 +1,6 @@
 import theme from 'medulas-react-components/lib/theme/utils/mui';
 import makeStyles from 'medulas-react-components/lib/theme/utils/styles';
+
 import { EXTENSION_HEIGHT, EXTENSION_WIDTH } from './constants';
 
 export const globalStyles = makeStyles({

--- a/packages/sanes-chrome-extension/src/utils/storybook/index.tsx
+++ b/packages/sanes-chrome-extension/src/utils/storybook/index.tsx
@@ -1,10 +1,11 @@
-import { Storybook } from 'medulas-react-components/lib/utils/storybook';
-import { ToastProvider } from 'medulas-react-components/lib/context/ToastProvider';
-import { Provider } from 'react-redux';
-import { createMemoryHistory, History } from 'history';
 import { ConnectedRouter, connectRouter } from 'connected-react-router';
-import { createStore, combineReducers } from 'redux';
+import { createMemoryHistory, History } from 'history';
+import { ToastProvider } from 'medulas-react-components/lib/context/ToastProvider';
+import { Storybook } from 'medulas-react-components/lib/utils/storybook';
 import * as React from 'react';
+import { Provider } from 'react-redux';
+import { combineReducers, createStore } from 'redux';
+
 import { PersonaProvider } from '../../context/PersonaProvider';
 
 export const CHROME_EXTENSION_ROOT = 'Extension';

--- a/packages/sanes-chrome-extension/src/utils/test/dom.tsx
+++ b/packages/sanes-chrome-extension/src/utils/test/dom.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { Store } from 'redux';
+
 import { PersonaProvider } from '../../context/PersonaProvider';
 import { RequestProvider } from '../../context/RequestProvider';
 import { GetPersonaResponse } from '../../extension/background/model/backgroundscript';

--- a/packages/sanes-chrome-extension/src/utils/test/e2e.ts
+++ b/packages/sanes-chrome-extension/src/utils/test/e2e.ts
@@ -1,4 +1,5 @@
-import puppeteer, { Page, Browser } from 'puppeteer';
+import puppeteer, { Browser, Page } from 'puppeteer';
+
 import { EXTENSION_HEIGHT, EXTENSION_WIDTH } from '../../theme/constants';
 
 export const EXTENSION_ID = 'dafekhlcpidfaopcimocbcpciholgkkb';

--- a/packages/sanes-chrome-extension/src/utils/test/navigation.ts
+++ b/packages/sanes-chrome-extension/src/utils/test/navigation.ts
@@ -1,5 +1,6 @@
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import { GetPersonaResponse } from '../../extension/background/model/backgroundscript';
 import { Request } from '../../extension/background/model/signingServer/requestQueueManager';
 import {

--- a/packages/sanes-chrome-extension/src/utils/test/reactElemFinder.ts
+++ b/packages/sanes-chrome-extension/src/utils/test/reactElemFinder.ts
@@ -1,5 +1,5 @@
-import TestUtils from 'react-dom/test-utils';
 import { Page } from 'puppeteer';
+import TestUtils from 'react-dom/test-utils';
 
 const TIMEOUT = 20000; //msec
 const INTERVAL = 500;

--- a/packages/sil-voting-app/src/communication/identities/index.ts
+++ b/packages/sil-voting-app/src/communication/identities/index.ts
@@ -2,6 +2,7 @@
 import { isPublicIdentity, PublicIdentity } from '@iov/bcp';
 import { TransactionEncoder } from '@iov/core';
 import { isJsonRpcErrorResponse, JsonRpcRequest, makeJsonRpcId, parseJsonRpcResponse2 } from '@iov/jsonrpc';
+
 import { extensionId } from '..';
 
 export const generateGetIdentitiesRequest = (): JsonRpcRequest => ({

--- a/packages/sil-voting-app/src/components/Header.tsx
+++ b/packages/sil-voting-app/src/components/Header.tsx
@@ -2,6 +2,7 @@ import Block from 'medulas-react-components/lib/components/Block';
 import CircleImage from 'medulas-react-components/lib/components/Image/CircleImage';
 import Typography from 'medulas-react-components/lib/components/Typography';
 import React from 'react';
+
 import icon from '../assets/iov-logo.svg';
 
 const Header = (): JSX.Element => {

--- a/packages/sil-voting-app/src/index.tsx
+++ b/packages/sil-voting-app/src/index.tsx
@@ -3,6 +3,7 @@ import MedulasThemeProvider from 'medulas-react-components/lib/theme/MedulasThem
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+
 import Routes from './routes';
 import { configureStore } from './store';
 import { globalStyles } from './theme/globalStyles';

--- a/packages/sil-voting-app/src/routes/dashboard/index.stories.tsx
+++ b/packages/sil-voting-app/src/routes/dashboard/index.stories.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import DecoratedStorybook, { VOTER_ROOT } from '../../utils/storybook';
 import Dashboard from './index';
 

--- a/packages/sil-voting-app/src/routes/dashboard/index.tsx
+++ b/packages/sil-voting-app/src/routes/dashboard/index.tsx
@@ -1,6 +1,7 @@
 import Block from 'medulas-react-components/lib/components/Block';
 import Hairline from 'medulas-react-components/lib/components/Hairline';
 import React from 'react';
+
 import Header from '../../components/Header';
 import AsideFilter from './components/AsideFilter';
 import ProposalsList from './components/ProposalsList';

--- a/packages/sil-voting-app/src/routes/dashboard/test/travelToDashboard.ts
+++ b/packages/sil-voting-app/src/routes/dashboard/test/travelToDashboard.ts
@@ -1,6 +1,7 @@
 import { Page } from 'puppeteer';
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
+
 import { history } from '../..';
 import { createDom } from '../../../utils/test/dom';
 import { whenOnNavigatedToRoute } from '../../../utils/test/navigation';

--- a/packages/sil-voting-app/src/routes/index.tsx
+++ b/packages/sil-voting-app/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { createBrowserHistory } from 'history';
 import React from 'react';
 import { Route, Router, Switch } from 'react-router-dom';
+
 import Dashboard from './dashboard';
 import Login from './login';
 import { DASHBOARD_ROUTE, LOGIN_ROUTE } from './paths';

--- a/packages/sil-voting-app/src/routes/login/index.e2e.spec.ts
+++ b/packages/sil-voting-app/src/routes/login/index.e2e.spec.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response } from 'express';
 import { Server } from 'http';
 import { Browser, Page } from 'puppeteer';
-import { INSTALL_EXTENSION_MSG, LOGIN_EXTENSION_MSG } from '.';
+
 import {
   closeBrowser,
   closeToast,
@@ -20,6 +20,7 @@ import { withChainsDescribe } from '../../utils/test/testExecutor';
 import { sleep } from '../../utils/timer';
 import { travelToDashboardE2e } from '../dashboard/test/travelToDashboard';
 import { DASHBOARD_ROUTE } from '../paths';
+import { INSTALL_EXTENSION_MSG, LOGIN_EXTENSION_MSG } from '.';
 
 withChainsDescribe(
   'E2E > Login route',

--- a/packages/sil-voting-app/src/routes/login/index.stories.tsx
+++ b/packages/sil-voting-app/src/routes/login/index.stories.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
+
 import DecoratedStorybook, { VOTER_ROOT } from '../../utils/storybook';
 import Login from './index';
 

--- a/packages/sil-voting-app/src/routes/login/index.tsx
+++ b/packages/sil-voting-app/src/routes/login/index.tsx
@@ -9,11 +9,12 @@ import { ToastContext } from 'medulas-react-components/lib/context/ToastProvider
 import { ToastVariant } from 'medulas-react-components/lib/context/ToastProvider/Toast';
 import React, { useContext } from 'react';
 import * as ReactRedux from 'react-redux';
+
+import icon from '../../assets/iov-logo.svg';
 import { getExtensionStatus } from '../../communication/status';
 import { setExtensionStateAction } from '../../store/reducers/extension';
 import { history } from '../index';
 import { DASHBOARD_ROUTE } from '../paths';
-import icon from '../../assets/iov-logo.svg';
 
 export const INSTALL_EXTENSION_MSG = 'You need to install IOV extension.';
 export const LOGIN_EXTENSION_MSG = 'Please login to the IOV extension to continue.';

--- a/packages/sil-voting-app/src/store/index.tsx
+++ b/packages/sil-voting-app/src/store/index.tsx
@@ -1,4 +1,5 @@
 import { applyMiddleware, compose, createStore, Middleware, Store } from 'redux';
+
 import reducer, { RootReducer } from './reducers';
 
 const composeEnhancers =

--- a/packages/sil-voting-app/src/store/reducers/extension/reducer.ts
+++ b/packages/sil-voting-app/src/store/reducers/extension/reducer.ts
@@ -1,6 +1,7 @@
-import { ActionType } from 'typesafe-actions';
-import * as actions from './actions';
 import { Action } from 'redux';
+import { ActionType } from 'typesafe-actions';
+
+import * as actions from './actions';
 
 export interface ExtensionState {
   readonly connected: boolean;

--- a/packages/sil-voting-app/src/store/reducers/index.tsx
+++ b/packages/sil-voting-app/src/store/reducers/index.tsx
@@ -1,5 +1,6 @@
 import { combineReducers, Reducer } from 'redux';
 import { StateType } from 'typesafe-actions';
+
 import { extensionReducer, ExtensionState } from './extension';
 
 export interface RootReducer {

--- a/packages/sil-voting-app/src/theme/globalStyles.ts
+++ b/packages/sil-voting-app/src/theme/globalStyles.ts
@@ -1,5 +1,6 @@
-import makeStyles from 'medulas-react-components/lib/theme/utils/styles';
 import 'normalize.css';
+
+import makeStyles from 'medulas-react-components/lib/theme/utils/styles';
 
 export const globalStyles = makeStyles({
   '@global': {

--- a/packages/sil-voting-app/src/utils/storybook/index.tsx
+++ b/packages/sil-voting-app/src/utils/storybook/index.tsx
@@ -1,6 +1,7 @@
 import MedulasThemeProvider from 'medulas-react-components/lib/theme/MedulasThemeProvider';
 import * as React from 'react';
 import { Provider } from 'react-redux';
+
 import { configureStore } from '../../store';
 import { globalStyles } from '../../theme/globalStyles';
 

--- a/packages/sil-voting-app/src/utils/test/dom.tsx
+++ b/packages/sil-voting-app/src/utils/test/dom.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { Store } from 'redux';
+
 import Routes from '../../routes';
 
 export const createDom = (store: Store): React.Component =>

--- a/packages/sil-voting-app/src/utils/test/e2e.ts
+++ b/packages/sil-voting-app/src/utils/test/e2e.ts
@@ -1,4 +1,5 @@
 import puppeteer, { Browser, Page } from 'puppeteer';
+
 import { extensionId } from '../../communication';
 
 export function launchBrowser(slowMo: number = 0, install: boolean = true): Promise<Browser> {

--- a/packages/sil-voting-app/src/utils/test/persona.ts
+++ b/packages/sil-voting-app/src/utils/test/persona.ts
@@ -1,4 +1,5 @@
 import { Page } from 'puppeteer';
+
 import { sleep } from '../timer';
 import { whenOnNavigatedToE2eRoute } from './navigation';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7445,6 +7445,13 @@ eslint-plugin-react@7.12.4:
     prop-types "^15.6.2"
     resolve "^1.9.0"
 
+eslint-plugin-simple-import-sort@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-4.0.0.tgz#048736c170b9b43f0a8c3ef85ba53881c389f3ff"
+  integrity sha512-QsxOMrXhhqvSiTmZafPc/lvSET9lhblaO2kaaSbFo1FVU/AW9mFQDXadiHJ5OqG6i0N6+Qd+RZ95iQbkg4p+0w==
+  dependencies:
+    validate-npm-package-name "^3.0.0"
+
 eslint-scope@3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"


### PR DESCRIPTION
As noted in https://github.com/iov-one/ponferrada/pull/361, we sometimes check-in code with unsorted imports. Right now, this is not detected by the linter/CI and a manual _Organize Imports_ run needs to be done in the IDE. This leads to the problem that the next person who runs an _Organize Imports_ creates a diff in the imports code that is not related to the current work.

In order to avoid this issue, we should have import sorting as part of the default linting process, preferribly with auto-fixing. This gives us:
1. a failing CI in case of unsorted imports
2. automatic saving when the eslint plugin is setup with autofix on save

The explored options were:
1. eslint's native [sort-imports](https://eslint.org/docs/rules/sort-imports): sorts by imported members, not by module. This causes unnecessary diffs when one symbol was imported before and in a PR additional symbols from the same module are imported (multiple vs. single)
2. `eslint-plugin-import`: [does not support sorting within a group](https://github.com/benmosher/eslint-plugin-import/issues/389)
3. `eslint-plugin-simple-import-sort`: simple and does what we need

There are now two groups of imports, separated by a newline. The first group is global modules, the second one relative imports.