### PR TITLE
Feature #337 Introduce balances in store

### DIFF
--- a/packages/bierzo-wallet/src/communication/identities/index.ts
+++ b/packages/bierzo-wallet/src/communication/identities/index.ts
@@ -1,7 +1,6 @@
 /*global chrome*/
 import { isPublicIdentity, PublicIdentity } from '@iov/bcp';
 import { TransactionEncoder } from '@iov/core';
-import { ethereumCodec } from '@iov/ethereum';
 import { isJsonRpcErrorResponse, JsonRpcRequest, makeJsonRpcId, parseJsonRpcResponse2 } from '@iov/jsonrpc';
 
 import { extensionId } from '..';
@@ -29,6 +28,31 @@ function extensionContext(): boolean {
   return typeof chrome.runtime !== 'undefined' && typeof chrome.runtime.sendMessage !== 'undefined';
 }
 
+// exported for testing purposes
+export const parseGetIdentitiesResponse = (
+  response: any,
+  chains: ReadonlyArray<string>,
+): { [chain: string]: PublicIdentity } => {
+  const parsedResponse = parseJsonRpcResponse2(response);
+  if (isJsonRpcErrorResponse(parsedResponse)) {
+    console.error(parsedResponse.error.message);
+    throw new Error('Received unexpected json rpc response');
+  }
+
+  const parsedResult = TransactionEncoder.fromJson(parsedResponse.result);
+  if (!isArrayOfPublicIdentity(parsedResult)) {
+    throw new Error('Got unexpected type of result');
+  }
+
+  const keys: { [chain: string]: PublicIdentity } = {};
+  for (let i = 0; i < parsedResult.length; i++) {
+    const chain = chains[i];
+    keys[chain] = parsedResult[i];
+  }
+
+  return keys;
+};
+
 export const sendGetIdentitiesRequest = async (): Promise<GetIdentitiesResponse> => {
   const chains = ['ethereum-eip155-5777'];
   const request = generateGetIdentitiesRequest(chains);
@@ -46,30 +70,7 @@ export const sendGetIdentitiesRequest = async (): Promise<GetIdentitiesResponse>
       }
 
       try {
-        const parsedResponse = parseJsonRpcResponse2(response);
-        if (isJsonRpcErrorResponse(parsedResponse)) {
-          console.error(parsedResponse.error.message);
-          resolve({});
-          return;
-        }
-
-        const parsedResult = TransactionEncoder.fromJson(parsedResponse.result);
-        if (!isArrayOfPublicIdentity(parsedResult)) {
-          console.error('Got unexpected type of result');
-          resolve({});
-          return;
-        }
-
-        // TODO remove when the app evolves
-        const addresses = parsedResult.map(ident => ethereumCodec.identityToAddress(ident));
-        console.log(addresses);
-
-        const keys: { [chain: string]: PublicIdentity } = {};
-        for (let i = 0; i < parsedResult.length; i++) {
-          const chain = chains[i];
-          keys[chain] = parsedResult[i];
-        }
-
+        const keys = parseGetIdentitiesResponse(response, chains);
         resolve(keys);
       } catch (error) {
         console.error(error);

--- a/packages/bierzo-wallet/src/routes/login/index.tsx
+++ b/packages/bierzo-wallet/src/routes/login/index.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import * as ReactRedux from 'react-redux';
 
 import { history } from '..';
+import { addBalancesAction, getBalances } from '../../store/balances';
 import { getExtensionStatus, setExtensionStateAction } from '../../store/extension';
 import { addTickersAction, getTokens } from '../../store/tokens';
 import { WELCOME_ROUTE } from '../paths';
@@ -16,6 +17,7 @@ const Login = (): JSX.Element => {
   const toast = React.useContext(ToastContext);
   //TODO: Fix this as soon as proper react-redux definitions will be available
   const dispatch = (ReactRedux as any).useDispatch();
+  const store = ReactRedux.useStore();
 
   const onLogin = async (_: object): Promise<void> => {
     const result = await getExtensionStatus();
@@ -33,6 +35,10 @@ const Login = (): JSX.Element => {
 
     const chainTokens = await getTokens();
     dispatch(addTickersAction(chainTokens));
+
+    const keys = store.getState().extension.keys;
+    const balances = await getBalances(keys);
+    dispatch(addBalancesAction(balances));
 
     history.push(WELCOME_ROUTE);
   };

--- a/packages/bierzo-wallet/src/store/balances/actions.ts
+++ b/packages/bierzo-wallet/src/store/balances/actions.ts
@@ -1,4 +1,4 @@
-import { PublicKeyBundle } from '@iov/bcp';
+import { PublicIdentity } from '@iov/bcp';
 import { TransactionEncoder } from '@iov/core';
 
 import { getConfig } from '../../config';
@@ -20,8 +20,8 @@ export async function getBalances(keys: { [chain: string]: string }): Promise<{ 
       continue;
     }
 
-    const pubkey: PublicKeyBundle = TransactionEncoder.fromJson(JSON.parse(plainPubkey));
-    const account = await connection.getAccount({ pubkey });
+    const pubIdentity: PublicIdentity = TransactionEncoder.fromJson(JSON.parse(plainPubkey));
+    const account = await connection.getAccount({ pubkey: pubIdentity.pubkey });
     if (!account) {
       continue;
     }

--- a/packages/bierzo-wallet/src/store/balances/actions.ts
+++ b/packages/bierzo-wallet/src/store/balances/actions.ts
@@ -1,0 +1,33 @@
+import { getConfig } from '../../config';
+import { getConnectionFor } from '../../logic/connection';
+import { amountToString } from '../../utils/balances';
+import { AddBalancesActionType } from './reducer';
+
+export async function getBalances(): Promise<{ [ticker: string]: string }> {
+  const config = getConfig();
+  const chains = config.chains;
+
+  const balances: { [ticker: string]: string } = {};
+  const token = 'FAKE_TOKEN';
+  const pubkey: any = 'fakePubKey';
+
+  for (const chain of chains) {
+    const connection = await getConnectionFor(chain.chainSpec);
+    const account = await connection.getAccount({ pubkey });
+
+    if (!account) {
+      continue;
+    }
+
+    for (const balance of account.balance) {
+      balances[token] = amountToString(balance);
+    }
+  }
+
+  return balances;
+}
+
+export const addBalancesAction = (tokens: { [key: string]: string }): AddBalancesActionType => ({
+  type: '@@balances/ADD',
+  payload: tokens,
+});

--- a/packages/bierzo-wallet/src/store/balances/index.ts
+++ b/packages/bierzo-wallet/src/store/balances/index.ts
@@ -1,0 +1,2 @@
+export * from './actions';
+export * from './reducer';

--- a/packages/bierzo-wallet/src/store/balances/index.unit.spec.ts
+++ b/packages/bierzo-wallet/src/store/balances/index.unit.spec.ts
@@ -1,19 +1,45 @@
+import { parseGetIdentitiesResponse } from '../../communication/identities';
+import * as identities from '../../communication/identities';
 import { aNewStore } from '../../store';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
+import { getExtensionStatus, setExtensionStateAction } from '../extension';
 import { addBalancesAction, getBalances } from './actions';
 
 withChainsDescribe('Tokens reducer', () => {
   it('has correct initial state', async () => {
     const store = aNewStore();
-    const tokens = store.getState().tokens;
-    expect(tokens).toEqual({});
+    const balances = store.getState().balances;
+    expect(balances).toEqual({});
   });
 
-  it('dispatches correctly getTokens action', async () => {
+  it('dispatches correctly addBalances action', async () => {
     const store = aNewStore();
-    const chainBalances = await getBalances();
-    store.dispatch(addBalancesAction(chainBalances));
-    const tokens = store.getState().tokens;
-    expect(tokens).toEqual(chainBalances);
+    const ethResponse = {
+      jsonrpc: '2.0',
+      id: 1,
+      result: [
+        {
+          chainId: 'string:ethereum-eip155-5777',
+          pubkey: {
+            algo: 'string:secp256k1',
+            data:
+              'bytes:04965fb72aad79318cd8c8c975cf18fa8bcac0c091605d10e89cd5a9f7cff564b0cb0459a7c22903119f7a42947c32c1cc6a434a86f0e26aad00ca2b2aff6ba381',
+          },
+        },
+      ],
+    };
+
+    const identitiesResponse = parseGetIdentitiesResponse(ethResponse, ['ethereum-eip155-5777']);
+    jest.spyOn(identities, 'sendGetIdentitiesRequest').mockResolvedValueOnce(identitiesResponse);
+
+    const extension = await getExtensionStatus();
+    store.dispatch(setExtensionStateAction(extension.connected, extension.installed, extension.keys));
+
+    const keys = store.getState().extension.keys;
+    const tokens = await getBalances(keys);
+    store.dispatch(addBalancesAction(tokens));
+
+    const balances = store.getState().balances;
+    expect(balances).toEqual({ ETH: '100 ETH' });
   });
 });

--- a/packages/bierzo-wallet/src/store/balances/index.unit.spec.ts
+++ b/packages/bierzo-wallet/src/store/balances/index.unit.spec.ts
@@ -1,0 +1,19 @@
+import { aNewStore } from '../../store';
+import { withChainsDescribe } from '../../utils/test/testExecutor';
+import { addBalancesAction, getBalances } from './actions';
+
+withChainsDescribe('Tokens reducer', () => {
+  it('has correct initial state', async () => {
+    const store = aNewStore();
+    const tokens = store.getState().tokens;
+    expect(tokens).toEqual({});
+  });
+
+  it('dispatches correctly getTokens action', async () => {
+    const store = aNewStore();
+    const chainBalances = await getBalances();
+    store.dispatch(addBalancesAction(chainBalances));
+    const tokens = store.getState().tokens;
+    expect(tokens).toEqual(chainBalances);
+  });
+});

--- a/packages/bierzo-wallet/src/store/balances/reducer.ts
+++ b/packages/bierzo-wallet/src/store/balances/reducer.ts
@@ -1,0 +1,25 @@
+import { Action } from 'redux';
+import { ActionType } from 'typesafe-actions';
+
+import * as actions from './actions';
+
+export interface AddBalancesActionType extends Action {
+  type: '@@balances/ADD';
+  payload: { [key: string]: string };
+}
+
+export type BalanceActions = ActionType<typeof actions>;
+
+export interface BalanceState {
+  [token: string]: string;
+}
+const initState: BalanceState = {};
+
+export function balancesReducer(state: BalanceState = initState, action: BalanceActions): BalanceState {
+  switch (action.type) {
+    case '@@balances/ADD':
+      return { ...state, ...action.payload };
+    default:
+      return state;
+  }
+}

--- a/packages/bierzo-wallet/src/store/reducers.ts
+++ b/packages/bierzo-wallet/src/store/reducers.ts
@@ -1,6 +1,7 @@
 import { combineReducers, Reducer } from 'redux';
 import { StateType } from 'typesafe-actions';
 
+import { balancesReducer, BalanceState } from './balances';
 import { extensionReducer, ExtensionState } from './extension';
 import { notificationReducer, NotificationState } from './notifications';
 import { tokensReducer, TokenState } from './tokens';
@@ -9,6 +10,7 @@ export interface RootReducer {
   extension: ExtensionState;
   notifications: NotificationState;
   tokens: TokenState;
+  balances: BalanceState;
 }
 
 const createRootReducer = (): Reducer<RootReducer> =>
@@ -16,6 +18,7 @@ const createRootReducer = (): Reducer<RootReducer> =>
     extension: extensionReducer,
     notifications: notificationReducer,
     tokens: tokensReducer,
+    balances: balancesReducer,
   });
 
 export type RootState = StateType<ReturnType<typeof createRootReducer>>;


### PR DESCRIPTION
**Description**
In this PR we store in redux balances. If blockchain accounts have 0 balance they are not injected, only positive balances are shown.

For a quick understanding check the unit tests.

This close #337