### PR TITLE
Feature - store Amount in balances

### DIFF
--- a/packages/bierzo-wallet/src/store/balances/actions.ts
+++ b/packages/bierzo-wallet/src/store/balances/actions.ts
@@ -1,16 +1,15 @@
-import { PublicIdentity } from '@iov/bcp';
+import { Amount, PublicIdentity } from '@iov/bcp';
 import { TransactionEncoder } from '@iov/core';
 
 import { getConfig } from '../../config';
 import { getConnectionFor } from '../../logic/connection';
-import { amountToString } from '../../utils/balances';
 import { AddBalancesActionType } from './reducer';
 
-export async function getBalances(keys: { [chain: string]: string }): Promise<{ [ticker: string]: string }> {
+export async function getBalances(keys: { [chain: string]: string }): Promise<{ [ticker: string]: Amount }> {
   const config = getConfig();
   const chains = config.chains;
 
-  const balances: { [ticker: string]: string } = {};
+  const balances: { [ticker: string]: Amount } = {};
 
   for (const chain of chains) {
     const connection = await getConnectionFor(chain.chainSpec);
@@ -27,14 +26,14 @@ export async function getBalances(keys: { [chain: string]: string }): Promise<{ 
     }
 
     for (const balance of account.balance) {
-      balances[balance.tokenTicker] = amountToString(balance);
+      balances[balance.tokenTicker] = balance;
     }
   }
 
   return balances;
 }
 
-export const addBalancesAction = (tokens: { [key: string]: string }): AddBalancesActionType => ({
+export const addBalancesAction = (tokens: { [key: string]: Amount }): AddBalancesActionType => ({
   type: '@@balances/ADD',
   payload: tokens,
 });

--- a/packages/bierzo-wallet/src/store/balances/index.unit.spec.ts
+++ b/packages/bierzo-wallet/src/store/balances/index.unit.spec.ts
@@ -40,6 +40,11 @@ withChainsDescribe('Tokens reducer', () => {
     store.dispatch(addBalancesAction(tokens));
 
     const balances = store.getState().balances;
-    expect(balances).toEqual({ ETH: '100 ETH' });
+    const ethBalance = {
+      fractionalDigits: 18,
+      quantity: '100000000000000000000',
+      tokenTicker: 'ETH',
+    };
+    expect(balances).toEqual({ ETH: ethBalance });
   });
 });

--- a/packages/bierzo-wallet/src/store/balances/reducer.ts
+++ b/packages/bierzo-wallet/src/store/balances/reducer.ts
@@ -1,3 +1,4 @@
+import { Amount } from '@iov/bcp';
 import { Action } from 'redux';
 import { ActionType } from 'typesafe-actions';
 
@@ -5,13 +6,13 @@ import * as actions from './actions';
 
 export interface AddBalancesActionType extends Action {
   type: '@@balances/ADD';
-  payload: { [key: string]: string };
+  payload: { [key: string]: Amount };
 }
 
 export type BalanceActions = ActionType<typeof actions>;
 
 export interface BalanceState {
-  [token: string]: string;
+  [token: string]: Amount;
 }
 const initState: BalanceState = {};
 


### PR DESCRIPTION
**Description**
In this PR we store amount in balances instead of beautiful strings, the reason is flexibility, we are going to use those balances in different places for doing different checks and not just displaying values, so it is better to store the simple Amount type.