### PR TITLE
Feature #379 Drink from faucet in bierzo-wallet

### DIFF
--- a/packages/bierzo-wallet/package.json
+++ b/packages/bierzo-wallet/package.json
@@ -9,6 +9,7 @@
     "@iov/bcp": "^0.15.0",
     "@iov/core": "^0.15.0",
     "@iov/ethereum": "^0.15.0",
+    "@iov/faucets": "^0.15.0",
     "@iov/jsonrpc": "^0.15.0",
     "@material-ui/core": "4.0.2",
     "@material-ui/icons": "4.0.1",

--- a/packages/bierzo-wallet/package.json
+++ b/packages/bierzo-wallet/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "lint": "tsc --noEmit && eslint -c .eslintrc.js --max-warnings 0 'src/**/*.ts{,x}'",
     "format": "prettier --write --loglevel warn './src/**/*.{ts,tsx,json,md,css}'",
-    "start": "react-scripts start",
+    "start": "REACT_APP_CONFIG=development react-scripts start",
     "build-development": "REACT_APP_CONFIG=development react-scripts build",
     "build-staging": "REACT_APP_CONFIG=staging react-scripts build",
     "build-production": "REACT_APP_CONFIG=production react-scripts build",

--- a/packages/bierzo-wallet/src/logic/connection.ts
+++ b/packages/bierzo-wallet/src/logic/connection.ts
@@ -28,6 +28,14 @@ export function isBnsSpec(spec: ChainSpec): boolean {
   return spec.codecType === 'bns';
 }
 
+export function isLskSpec(spec: ChainSpec): boolean {
+  return spec.codecType === 'lsk';
+}
+
+export function isEthSpec(spec: ChainSpec): boolean {
+  return spec.codecType === 'eth';
+}
+
 export async function getConnectionFor(spec: ChainSpec): Promise<BlockchainConnection> {
   const url = spec.bootstrapNodes[0];
   if (spec.codecType === 'eth') {

--- a/packages/bierzo-wallet/src/logic/connection.ts
+++ b/packages/bierzo-wallet/src/logic/connection.ts
@@ -24,7 +24,7 @@ async function createLiskConnection(url: string): Promise<BlockchainConnection> 
 
 let getLiskConnection = singleton<typeof createLiskConnection>(createLiskConnection);
 
-export function isBnsConnection(spec: ChainSpec): boolean {
+export function isBnsSpec(spec: ChainSpec): boolean {
   return spec.codecType === 'bns';
 }
 
@@ -34,7 +34,7 @@ export async function getConnectionFor(spec: ChainSpec): Promise<BlockchainConne
     return getEthereumConnection(url);
   }
 
-  if (isBnsConnection(spec)) {
+  if (isBnsSpec(spec)) {
     return getBnsConnection(url);
   }
 

--- a/packages/bierzo-wallet/src/logic/faucet.ts
+++ b/packages/bierzo-wallet/src/logic/faucet.ts
@@ -1,0 +1,39 @@
+import { Identity } from '@iov/bcp';
+import { TransactionEncoder } from '@iov/core';
+import { IovFaucet } from '@iov/faucets';
+
+import { getConfig } from '../config';
+import { getConnectionFor } from './connection';
+
+export async function drinkFaucetIfNeeded(keys: { [chain: string]: string }): Promise<void> {
+  const config = getConfig();
+  const chains = config.chains;
+
+  let faucetCredits: ReadonlyArray<Promise<void>> = [];
+  for (const chain of chains) {
+    const faucetSpec = chain.faucetSpec;
+    if (!faucetSpec) {
+      continue;
+    }
+
+    const connection = await getConnectionFor(chain.chainSpec);
+    const chainId = connection.chainId() as string;
+    const plainPubkey = keys[chainId];
+    if (!plainPubkey) {
+      continue;
+    }
+
+    const identity: Identity = TransactionEncoder.fromJson(JSON.parse(plainPubkey));
+    const account = await connection.getAccount({ pubkey: identity.pubkey });
+    if (!account) {
+      continue;
+    }
+
+    for (const balance of account.balance) {
+      const faucet = new IovFaucet(faucetSpec.uri);
+      faucetCredits = [...faucetCredits, faucet.credit(account.address, balance.tokenTicker)];
+    }
+  }
+
+  await Promise.all(faucetCredits);
+}

--- a/packages/bierzo-wallet/src/logic/faucet.ts
+++ b/packages/bierzo-wallet/src/logic/faucet.ts
@@ -1,39 +1,69 @@
-import { Identity } from '@iov/bcp';
+import { Identity, TokenTicker, TxCodec } from '@iov/bcp';
+import { bnsCodec } from '@iov/bns';
 import { TransactionEncoder } from '@iov/core';
+import { ethereumCodec } from '@iov/ethereum';
 import { IovFaucet } from '@iov/faucets';
+import { liskCodec } from '@iov/lisk';
 
-import { getConfig } from '../config';
-import { getConnectionFor } from './connection';
+import { ChainSpec, getConfig } from '../config';
+import { BwToken } from '../store/tokens';
+import { getConnectionFor, isBnsSpec, isEthSpec, isLskSpec } from './connection';
 
-export async function drinkFaucetIfNeeded(keys: { [chain: string]: string }): Promise<void> {
+function getCodec(spec: ChainSpec): TxCodec {
+  if (isEthSpec(spec)) {
+    return ethereumCodec;
+  }
+
+  if (isBnsSpec(spec)) {
+    return bnsCodec;
+  }
+
+  if (isLskSpec(spec)) {
+    return liskCodec;
+  }
+
+  throw new Error('Unsupported codecType for chain spec');
+}
+
+function getTokensByChainId(chainId: string, tokens: { [ticker: string]: BwToken }): ReadonlyArray<string> {
+  return Object.entries(tokens).reduce((filteredTokens: ReadonlyArray<string>, pair) => {
+    const [key, value] = pair;
+    return value.chainId === chainId ? [...filteredTokens, key] : filteredTokens;
+  }, []);
+}
+
+export async function drinkFaucetIfNeeded(
+  keys: { [chain: string]: string },
+  tokens: { [ticker: string]: BwToken },
+): Promise<void> {
   const config = getConfig();
   const chains = config.chains;
 
-  let faucetCredits: ReadonlyArray<Promise<void>> = [];
   for (const chain of chains) {
     const faucetSpec = chain.faucetSpec;
     if (!faucetSpec) {
       continue;
     }
 
+    const codec = getCodec(chain.chainSpec);
     const connection = await getConnectionFor(chain.chainSpec);
     const chainId = connection.chainId() as string;
+    const tokensByChainId = getTokensByChainId(chainId, tokens);
     const plainPubkey = keys[chainId];
     if (!plainPubkey) {
       continue;
     }
 
     const identity: Identity = TransactionEncoder.fromJson(JSON.parse(plainPubkey));
-    const account = await connection.getAccount({ pubkey: identity.pubkey });
-    if (!account) {
-      continue;
-    }
+    const faucet = new IovFaucet(faucetSpec.uri);
+    const address = codec.identityToAddress(identity);
 
-    for (const balance of account.balance) {
-      const faucet = new IovFaucet(faucetSpec.uri);
-      faucetCredits = [...faucetCredits, faucet.credit(account.address, balance.tokenTicker)];
+    for (const token of tokensByChainId) {
+      try {
+        await faucet.credit(address, token as TokenTicker);
+      } catch (err) {
+        console.log(`Error using faucet for ${chainId}: ${err.message}`);
+      }
     }
   }
-
-  await Promise.all(faucetCredits);
 }

--- a/packages/bierzo-wallet/src/logic/faucet.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/faucet.unit.spec.ts
@@ -1,0 +1,118 @@
+import { Algorithm, ChainId, Identity, PubkeyBytes, TokenTicker } from '@iov/bcp';
+import { TransactionEncoder } from '@iov/core';
+import { Ed25519, Random, Secp256k1 } from '@iov/crypto';
+
+import { getBalances } from '../store/balances';
+import { BwToken } from '../store/tokens';
+import { withChainsDescribe } from '../utils/test/testExecutor';
+import { disconnect } from './connection';
+import { drinkFaucetIfNeeded } from './faucet';
+
+const tokens: { [ticker: string]: BwToken } = {
+  ETH: {
+    chainId: 'ethereum-eip155-5777' as ChainId,
+    token: {
+      fractionalDigits: 18,
+      tokenName: 'Ether',
+      tokenTicker: 'ETH' as TokenTicker,
+    },
+  },
+  ASH: {
+    chainId: 'local-bns-devnet' as ChainId,
+    token: {
+      fractionalDigits: 9,
+      tokenName: 'Let the Phoenix arise',
+      tokenTicker: 'ASH' as TokenTicker,
+    },
+  },
+  BASH: {
+    chainId: 'local-bns-devnet' as ChainId,
+    token: {
+      fractionalDigits: 9,
+      tokenName: 'Another token of this chain',
+      tokenTicker: 'BASH' as TokenTicker,
+    },
+  },
+  CASH: {
+    chainId: 'local-bns-devnet' as ChainId,
+    token: {
+      fractionalDigits: 9,
+      tokenName: 'Main token of this chain',
+      tokenTicker: 'CASH' as TokenTicker,
+    },
+  },
+  LSK: {
+    chainId: 'lisk-198f2b61a8' as ChainId,
+    token: {
+      fractionalDigits: 8,
+      tokenName: 'Lisk',
+      tokenTicker: 'LSK' as TokenTicker,
+    },
+  },
+};
+
+async function createPubkeys(): Promise<{ [chain: string]: string }> {
+  const keys: { [chain: string]: string } = {};
+
+  // create ETH pub key
+  const ethChain = 'ethereum-eip155-5777';
+  const keypair = await Secp256k1.makeKeypair(await Random.getBytes(32));
+  const ethIdentity: Identity = {
+    chainId: ethChain as ChainId,
+    pubkey: {
+      algo: Algorithm.Secp256k1,
+      data: keypair.pubkey as PubkeyBytes,
+    },
+  };
+
+  // get BNS pubkey
+  const bnsChain = 'local-bns-devnet';
+  const rawKeypair = await Ed25519.makeKeypair(await Random.getBytes(32));
+  const bnsIdentity: Identity = {
+    chainId: bnsChain as ChainId,
+    pubkey: {
+      algo: Algorithm.Ed25519,
+      data: rawKeypair.pubkey as PubkeyBytes,
+    },
+  };
+
+  keys[ethChain] = JSON.stringify(TransactionEncoder.toJson(ethIdentity));
+  keys[bnsChain] = JSON.stringify(TransactionEncoder.toJson(bnsIdentity));
+
+  return keys;
+}
+
+withChainsDescribe('Logic :: faucet', () => {
+  afterAll(async () => {
+    await disconnect();
+  });
+
+  it('works', async () => {
+    // generate keys
+    const keys = await createPubkeys();
+    // check their balance are 0
+    const initialBalances = await getBalances(keys);
+    expect(initialBalances).toEqual({});
+    // drink faucet
+    await drinkFaucetIfNeeded(keys, tokens);
+    // check their balances
+    const balances = await getBalances(keys);
+    expect(balances).toEqual({
+      BASH: {
+        fractionalDigits: 9,
+        quantity: '10000000000',
+        tokenTicker: 'BASH',
+      },
+      CASH: {
+        fractionalDigits: 9,
+        quantity: '10000000000',
+        tokenTicker: 'CASH',
+      },
+      ETH: {
+        fractionalDigits: 18,
+        quantity: '10000000000000000000',
+        tokenTicker: 'ETH',
+      },
+    });
+  }, 15000);
+});

--- a/packages/bierzo-wallet/src/logic/faucet.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/faucet.unit.spec.ts
@@ -115,4 +115,31 @@ withChainsDescribe('Logic :: faucet', () => {
       },
     });
   }, 15000);
+
+  it('does not drink from faucet if tokens are already available', async () => {
+    // generate keys
+    const keys = await createPubkeys();
+    // drink faucet twice
+    await drinkFaucetIfNeeded(keys, tokens);
+    await drinkFaucetIfNeeded(keys, tokens);
+    // check their balances
+    const balances = await getBalances(keys);
+    expect(balances).toEqual({
+      BASH: {
+        fractionalDigits: 9,
+        quantity: '10000000000',
+        tokenTicker: 'BASH',
+      },
+      CASH: {
+        fractionalDigits: 9,
+        quantity: '10000000000',
+        tokenTicker: 'CASH',
+      },
+      ETH: {
+        fractionalDigits: 18,
+        quantity: '10000000000000000000',
+        tokenTicker: 'ETH',
+      },
+    });
+  }, 15000);
 });

--- a/packages/bierzo-wallet/src/routes/login/index.tsx
+++ b/packages/bierzo-wallet/src/routes/login/index.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import * as ReactRedux from 'react-redux';
 
 import { history } from '..';
+import { drinkFaucetIfNeeded } from '../../logic/faucet';
 import { addBalancesAction, getBalances } from '../../store/balances';
 import { getExtensionStatus, setExtensionStateAction } from '../../store/extension';
 import { addTickersAction, getTokens } from '../../store/tokens';
@@ -38,6 +39,8 @@ const Login = (): JSX.Element => {
     dispatch(addTickersAction(chainTokens));
 
     const keys = store.getState().extension.keys;
+    await drinkFaucetIfNeeded(keys, chainTokens);
+
     const balances = await getBalances(keys);
     dispatch(addBalancesAction(balances));
 

--- a/packages/bierzo-wallet/src/store/usernames/actions.ts
+++ b/packages/bierzo-wallet/src/store/usernames/actions.ts
@@ -3,7 +3,7 @@ import { BnsConnection } from '@iov/bns';
 import { TransactionEncoder } from '@iov/core';
 
 import { getConfig } from '../../config';
-import { getConnectionFor, isBnsConnection } from '../../logic/connection';
+import { getConnectionFor, isBnsSpec } from '../../logic/connection';
 import { AddUsernamesActionType, BwUsername } from './reducer';
 
 export async function getUsernames(keys: {
@@ -14,7 +14,7 @@ export async function getUsernames(keys: {
   const chains = config.chains;
 
   for (const chain of chains) {
-    if (!isBnsConnection(chain.chainSpec)) {
+    if (!isBnsSpec(chain.chainSpec)) {
       continue;
     }
 


### PR DESCRIPTION
**Description**
This PR after login we drink from the faucets of all available tokens from all chains specified in the config file.

It closes #379

Note this solution has an improvement for not using the faucet if the account has balances present.

<img width="1918" alt="Screenshot 2019-07-16 12 40 19" src="https://user-images.githubusercontent.com/4266059/61288624-ceb7e700-a7c7-11e9-9d54-eff0e3dba65f.png">
