### PR TITLE
Feature #384 - Add account's balances subscriptions

### DIFF
--- a/packages/bierzo-wallet/src/logic/codec.ts
+++ b/packages/bierzo-wallet/src/logic/codec.ts
@@ -1,0 +1,23 @@
+import { TxCodec } from '@iov/bcp';
+import { bnsCodec } from '@iov/bns';
+import { ethereumCodec } from '@iov/ethereum';
+import { liskCodec } from '@iov/lisk';
+
+import { ChainSpec } from '../config';
+import { isBnsSpec, isEthSpec, isLskSpec } from './connection';
+
+export function getCodec(spec: ChainSpec): TxCodec {
+  if (isEthSpec(spec)) {
+    return ethereumCodec;
+  }
+
+  if (isBnsSpec(spec)) {
+    return bnsCodec;
+  }
+
+  if (isLskSpec(spec)) {
+    return liskCodec;
+  }
+
+  throw new Error('Unsupported codecType for chain spec');
+}

--- a/packages/bierzo-wallet/src/logic/connection.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/connection.unit.spec.ts
@@ -21,6 +21,7 @@ withChainsDescribe('Logic :: connection', () => {
     await getConnectionFor(firstChain.chainSpec);
 
     expect(ethereumConnectionSpy).toHaveBeenCalledTimes(1);
+    await disconnect();
   });
 
   it('reset connections correctly when disconnecting', async () => {
@@ -38,10 +39,11 @@ withChainsDescribe('Logic :: connection', () => {
     await disconnect();
 
     // THEN
-    expect(ethereumConnectionSpy).toHaveBeenCalledTimes(1);
-    await getConnectionFor(firstChain.chainSpec);
-    await getConnectionFor(firstChain.chainSpec);
-    await getConnectionFor(firstChain.chainSpec);
     expect(ethereumConnectionSpy).toHaveBeenCalledTimes(2);
+    await getConnectionFor(firstChain.chainSpec);
+    await getConnectionFor(firstChain.chainSpec);
+    await getConnectionFor(firstChain.chainSpec);
+    expect(ethereumConnectionSpy).toHaveBeenCalledTimes(3);
+    await disconnect();
   });
 });

--- a/packages/bierzo-wallet/src/logic/connection.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/connection.unit.spec.ts
@@ -21,7 +21,6 @@ withChainsDescribe('Logic :: connection', () => {
     await getConnectionFor(firstChain.chainSpec);
 
     expect(ethereumConnectionSpy).toHaveBeenCalledTimes(1);
-    await disconnect();
   });
 
   it('reset connections correctly when disconnecting', async () => {
@@ -44,6 +43,5 @@ withChainsDescribe('Logic :: connection', () => {
     await getConnectionFor(firstChain.chainSpec);
     await getConnectionFor(firstChain.chainSpec);
     expect(ethereumConnectionSpy).toHaveBeenCalledTimes(3);
-    await disconnect();
   });
 });

--- a/packages/bierzo-wallet/src/logic/connection.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/connection.unit.spec.ts
@@ -38,10 +38,10 @@ withChainsDescribe('Logic :: connection', () => {
     await disconnect();
 
     // THEN
+    expect(ethereumConnectionSpy).toHaveBeenCalledTimes(1);
+    await getConnectionFor(firstChain.chainSpec);
+    await getConnectionFor(firstChain.chainSpec);
+    await getConnectionFor(firstChain.chainSpec);
     expect(ethereumConnectionSpy).toHaveBeenCalledTimes(2);
-    await getConnectionFor(firstChain.chainSpec);
-    await getConnectionFor(firstChain.chainSpec);
-    await getConnectionFor(firstChain.chainSpec);
-    expect(ethereumConnectionSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/bierzo-wallet/src/logic/faucet.ts
+++ b/packages/bierzo-wallet/src/logic/faucet.ts
@@ -1,28 +1,10 @@
-import { Identity, TokenTicker, TxCodec } from '@iov/bcp';
-import { bnsCodec } from '@iov/bns';
+import { Identity, TokenTicker } from '@iov/bcp';
 import { TransactionEncoder } from '@iov/core';
-import { ethereumCodec } from '@iov/ethereum';
 import { IovFaucet } from '@iov/faucets';
-import { liskCodec } from '@iov/lisk';
 
-import { ChainSpec, getConfig } from '../config';
-import { getConnectionFor, isBnsSpec, isEthSpec, isLskSpec } from './connection';
-
-function getCodec(spec: ChainSpec): TxCodec {
-  if (isEthSpec(spec)) {
-    return ethereumCodec;
-  }
-
-  if (isBnsSpec(spec)) {
-    return bnsCodec;
-  }
-
-  if (isLskSpec(spec)) {
-    return liskCodec;
-  }
-
-  throw new Error('Unsupported codecType for chain spec');
-}
+import { getConfig } from '../config';
+import { getCodec } from './codec';
+import { getConnectionFor } from './connection';
 
 export async function drinkFaucetIfNeeded(keys: { [chain: string]: string }): Promise<void> {
   const config = getConfig();

--- a/packages/bierzo-wallet/src/logic/faucet.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/faucet.unit.spec.ts
@@ -1,42 +1,8 @@
-import { Algorithm, ChainId, Identity, PubkeyBytes } from '@iov/bcp';
-import { TransactionEncoder } from '@iov/core';
-import { Ed25519, Random, Secp256k1 } from '@iov/crypto';
-
 import { getBalances } from '../store/balances';
+import { createPubkeys } from '../utils/test/pubkeys';
 import { withChainsDescribe } from '../utils/test/testExecutor';
 import { disconnect } from './connection';
 import { drinkFaucetIfNeeded } from './faucet';
-
-async function createPubkeys(): Promise<{ [chain: string]: string }> {
-  const keys: { [chain: string]: string } = {};
-
-  // create ETH pub key
-  const ethChain = 'ethereum-eip155-5777';
-  const keypair = await Secp256k1.makeKeypair(await Random.getBytes(32));
-  const ethIdentity: Identity = {
-    chainId: ethChain as ChainId,
-    pubkey: {
-      algo: Algorithm.Secp256k1,
-      data: keypair.pubkey as PubkeyBytes,
-    },
-  };
-
-  // get BNS pubkey
-  const bnsChain = 'local-bns-devnet';
-  const rawKeypair = await Ed25519.makeKeypair(await Random.getBytes(32));
-  const bnsIdentity: Identity = {
-    chainId: bnsChain as ChainId,
-    pubkey: {
-      algo: Algorithm.Ed25519,
-      data: rawKeypair.pubkey as PubkeyBytes,
-    },
-  };
-
-  keys[ethChain] = JSON.stringify(TransactionEncoder.toJson(ethIdentity));
-  keys[bnsChain] = JSON.stringify(TransactionEncoder.toJson(bnsIdentity));
-
-  return keys;
-}
 
 withChainsDescribe('Logic :: faucet', () => {
   afterAll(async () => {

--- a/packages/bierzo-wallet/src/logic/faucet.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/faucet.unit.spec.ts
@@ -5,7 +5,7 @@ import { disconnect } from './connection';
 import { drinkFaucetIfNeeded } from './faucet';
 
 withChainsDescribe('Logic :: faucet', () => {
-  afterAll(async () => {
+  afterEach(async () => {
     await disconnect();
   });
 

--- a/packages/bierzo-wallet/src/logic/faucet.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/faucet.unit.spec.ts
@@ -5,7 +5,7 @@ import { disconnect } from './connection';
 import { drinkFaucetIfNeeded } from './faucet';
 
 withChainsDescribe('Logic :: faucet', () => {
-  afterEach(async () => {
+  afterAll(async () => {
     await disconnect();
   });
 

--- a/packages/bierzo-wallet/src/logic/subscriptions.ts
+++ b/packages/bierzo-wallet/src/logic/subscriptions.ts
@@ -1,6 +1,7 @@
 import { Identity } from '@iov/bcp';
 import { TransactionEncoder } from '@iov/core';
 import { Dispatch } from 'redux';
+import { Subscription } from 'xstream';
 import debounce from 'xstream/extra/debounce';
 
 import { getConfig } from '../config';
@@ -8,7 +9,7 @@ import { addBalancesAction, getBalances } from '../store/balances';
 import { getCodec } from './codec';
 import { getConnectionFor } from './connection';
 
-const balanceSubscriptions = [];
+let balanceSubscriptions: Subscription[] = [];
 
 export async function subscribeBalance(keys: { [chain: string]: string }, dispatch: Dispatch): Promise<any> {
   const config = getConfig();
@@ -41,4 +42,9 @@ export async function subscribeBalance(keys: { [chain: string]: string }, dispat
   }
   // subscribe to transactions
   // const transactionsStream = connection.liveTx({ sentFromOrTo: address });
+}
+
+export function unsubscribeBalances(): void {
+  balanceSubscriptions.forEach(subs => subs.unsubscribe());
+  balanceSubscriptions = [];
 }

--- a/packages/bierzo-wallet/src/logic/subscriptions.ts
+++ b/packages/bierzo-wallet/src/logic/subscriptions.ts
@@ -1,6 +1,44 @@
-export async function subscribe(): Promise<any> {
+import { Identity } from '@iov/bcp';
+import { TransactionEncoder } from '@iov/core';
+import { Dispatch } from 'redux';
+import debounce from 'xstream/extra/debounce';
+
+import { getConfig } from '../config';
+import { addBalancesAction, getBalances } from '../store/balances';
+import { getCodec } from './codec';
+import { getConnectionFor } from './connection';
+
+const balanceSubscriptions = [];
+
+export async function subscribeBalance(keys: { [chain: string]: string }, dispatch: Dispatch): Promise<any> {
+  const config = getConfig();
+  const chains = config.chains;
+
+  for (const chain of chains) {
+    const codec = getCodec(chain.chainSpec);
+    const connection = await getConnectionFor(chain.chainSpec);
+    const chainId = connection.chainId() as string;
+    const plainPubkey = keys[chainId];
+    if (!plainPubkey) {
+      continue;
+    }
+
+    const identity: Identity = TransactionEncoder.fromJson(JSON.parse(plainPubkey));
+    const address = codec.identityToAddress(identity);
+
+    // subscribe to balance changes via
+    const subscription = connection
+      .watchAccount({ address })
+      .compose(debounce(200))
+      .subscribe({
+        next: () => {
+          getBalances(keys).then(balances => {
+            dispatch(addBalancesAction(balances));
+          });
+        },
+      });
+    balanceSubscriptions.push(subscription);
+  }
   // subscribe to transactions
   // const transactionsStream = connection.liveTx({ sentFromOrTo: address });
-  // subscribe to balance changes via
-  // const accountStream = connection.watchAccount({ address: address });
 }

--- a/packages/bierzo-wallet/src/logic/subscriptions.ts
+++ b/packages/bierzo-wallet/src/logic/subscriptions.ts
@@ -1,0 +1,6 @@
+export async function subscribe(): Promise<any> {
+  // subscribe to transactions
+  // const transactionsStream = connection.liveTx({ sentFromOrTo: address });
+  // subscribe to balance changes via
+  // const accountStream = connection.watchAccount({ address: address });
+}

--- a/packages/bierzo-wallet/src/logic/subscriptions.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/subscriptions.unit.spec.ts
@@ -6,6 +6,7 @@ import { getTokens } from '../store/tokens';
 import { createPubkeys } from '../utils/test/pubkeys';
 import { withChainsDescribe } from '../utils/test/testExecutor';
 import * as tokens from '../utils/tokens';
+import { disconnect } from './connection';
 import { drinkFaucetIfNeeded } from './faucet';
 import { subscribeBalance, unsubscribeBalances } from './subscriptions';
 
@@ -37,5 +38,6 @@ withChainsDescribe('Logic :: balance subscriptions', () => {
     expect(balanceSpy).toHaveBeenCalledTimes(5);
 
     unsubscribeBalances();
+    await disconnect();
   }, 65000);
 });

--- a/packages/bierzo-wallet/src/logic/subscriptions.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/subscriptions.unit.spec.ts
@@ -1,0 +1,41 @@
+import { BlockchainConnection, Identity } from '@iov/bcp';
+
+import { aNewStore } from '../store';
+import * as balanceActions from '../store/balances/actions';
+import { getTokens } from '../store/tokens';
+import { createPubkeys } from '../utils/test/pubkeys';
+import { withChainsDescribe } from '../utils/test/testExecutor';
+import * as tokens from '../utils/tokens';
+import { drinkFaucetIfNeeded } from './faucet';
+import { subscribeBalance, unsubscribeBalances } from './subscriptions';
+
+withChainsDescribe('Logic :: balance subscriptions', () => {
+  beforeAll(() => {
+    jest
+      .spyOn(tokens, 'filterExistingTokens')
+      .mockImplementation(
+        (_connection: BlockchainConnection, _identity: Identity, tokensByChainId: ReadonlyArray<string>) =>
+          Promise.resolve(tokensByChainId),
+      );
+  });
+
+  afterAll(() => {
+    jest.spyOn(tokens, 'filterExistingTokens').mockReset();
+  });
+
+  it('fires subscription callback when account balance changes', async () => {
+    const balanceSpy = jest.spyOn(balanceActions, 'addBalancesAction');
+
+    const store = aNewStore();
+    const keys = await createPubkeys();
+
+    const chainTokens = await getTokens();
+    await drinkFaucetIfNeeded(keys, chainTokens);
+    await subscribeBalance(keys, store.dispatch);
+    await drinkFaucetIfNeeded(keys, chainTokens);
+
+    expect(balanceSpy).toHaveBeenCalledTimes(5);
+
+    unsubscribeBalances();
+  }, 65000);
+});

--- a/packages/bierzo-wallet/src/logic/subscriptions.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/subscriptions.unit.spec.ts
@@ -21,6 +21,10 @@ withChainsDescribe('Logic :: balance subscriptions', () => {
       );
   });
 
+  afterEach(async () => {
+    await disconnect();
+  });
+
   afterAll(() => {
     jest.spyOn(tokens, 'filterExistingTokens').mockReset();
   });
@@ -39,11 +43,13 @@ withChainsDescribe('Logic :: balance subscriptions', () => {
     await drinkFaucetIfNeeded(keys, chainTokens);
 
     // Give some time to open request to be finished
-    await sleep(5000);
+    await sleep(1000);
+    await sleep(1000);
+    await sleep(1000);
+    await sleep(1000);
 
     expect(balanceSpy).toHaveBeenCalledTimes(5);
 
     unsubscribeBalances();
-    await disconnect();
-  }, 65000);
+  }, 35000);
 });

--- a/packages/bierzo-wallet/src/logic/subscriptions.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/subscriptions.unit.spec.ts
@@ -39,11 +39,8 @@ withChainsDescribe('Logic :: balance subscriptions', () => {
 
     // Give some time to open request to be finished
     await sleep(1000);
-    await sleep(1000);
-    await sleep(1000);
-    await sleep(1000);
 
-    expect(balanceSpy).toHaveBeenCalledTimes(5);
+    expect(balanceSpy).toHaveBeenCalledTimes(2);
 
     unsubscribeBalances();
   }, 35000);

--- a/packages/bierzo-wallet/src/logic/subscriptions.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/subscriptions.unit.spec.ts
@@ -2,7 +2,6 @@ import { BlockchainConnection, Identity } from '@iov/bcp';
 
 import { aNewStore } from '../store';
 import * as balanceActions from '../store/balances/actions';
-import { getTokens } from '../store/tokens';
 import { createPubkeys } from '../utils/test/pubkeys';
 import { withChainsDescribe } from '../utils/test/testExecutor';
 import { sleep } from '../utils/timer';
@@ -21,12 +20,9 @@ withChainsDescribe('Logic :: balance subscriptions', () => {
       );
   });
 
-  afterEach(async () => {
-    await disconnect();
-  });
-
-  afterAll(() => {
+  afterAll(async () => {
     jest.spyOn(tokens, 'filterExistingTokens').mockReset();
+    await disconnect();
   });
 
   it('fires subscription callback when account balance changes', async () => {
@@ -35,12 +31,11 @@ withChainsDescribe('Logic :: balance subscriptions', () => {
     const store = aNewStore();
     const keys = await createPubkeys();
 
-    const chainTokens = await getTokens();
-    await drinkFaucetIfNeeded(keys, chainTokens);
+    await drinkFaucetIfNeeded(keys);
     await subscribeBalance(keys, store.dispatch);
 
     // Trick for forcing account to receive balance events updates
-    await drinkFaucetIfNeeded(keys, chainTokens);
+    await drinkFaucetIfNeeded(keys);
 
     // Give some time to open request to be finished
     await sleep(1000);

--- a/packages/bierzo-wallet/src/logic/subscriptions.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/subscriptions.unit.spec.ts
@@ -5,6 +5,7 @@ import * as balanceActions from '../store/balances/actions';
 import { getTokens } from '../store/tokens';
 import { createPubkeys } from '../utils/test/pubkeys';
 import { withChainsDescribe } from '../utils/test/testExecutor';
+import { sleep } from '../utils/timer';
 import * as tokens from '../utils/tokens';
 import { disconnect } from './connection';
 import { drinkFaucetIfNeeded } from './faucet';
@@ -33,7 +34,12 @@ withChainsDescribe('Logic :: balance subscriptions', () => {
     const chainTokens = await getTokens();
     await drinkFaucetIfNeeded(keys, chainTokens);
     await subscribeBalance(keys, store.dispatch);
+
+    // Trick for forcing account to receive balance events updates
     await drinkFaucetIfNeeded(keys, chainTokens);
+
+    // Give some time to open request to be finished
+    await sleep(5000);
 
     expect(balanceSpy).toHaveBeenCalledTimes(5);
 

--- a/packages/bierzo-wallet/src/routes/login/index.tsx
+++ b/packages/bierzo-wallet/src/routes/login/index.tsx
@@ -7,6 +7,7 @@ import { Dispatch } from 'redux';
 
 import { history } from '..';
 import { drinkFaucetIfNeeded } from '../../logic/faucet';
+import { subscribeBalance } from '../../logic/subscriptions';
 import { addBalancesAction, getBalances } from '../../store/balances';
 import { getExtensionStatus, setExtensionStateAction } from '../../store/extension';
 import { addTickersAction, getTokens } from '../../store/tokens';
@@ -27,6 +28,8 @@ export const loginBootSequence = async (
 
   const balances = await getBalances(keys);
   dispatch(addBalancesAction(balances));
+
+  await subscribeBalance(keys, dispatch);
 
   const usernames = await getUsernames(keys);
   dispatch(addUsernamesAction(usernames));

--- a/packages/bierzo-wallet/src/utils/test/pubkeys.ts
+++ b/packages/bierzo-wallet/src/utils/test/pubkeys.ts
@@ -1,0 +1,34 @@
+import { Algorithm, ChainId, Identity, PubkeyBytes } from '@iov/bcp';
+import { TransactionEncoder } from '@iov/core';
+import { Ed25519, Random, Secp256k1 } from '@iov/crypto';
+
+export async function createPubkeys(): Promise<{ [chain: string]: string }> {
+  const keys: { [chain: string]: string } = {};
+
+  // create ETH pub key
+  const ethChain = 'ethereum-eip155-5777';
+  const keypair = await Secp256k1.makeKeypair(await Random.getBytes(32));
+  const ethIdentity: Identity = {
+    chainId: ethChain as ChainId,
+    pubkey: {
+      algo: Algorithm.Secp256k1,
+      data: keypair.pubkey as PubkeyBytes,
+    },
+  };
+
+  // get BNS pubkey
+  const bnsChain = 'local-bns-devnet';
+  const rawKeypair = await Ed25519.makeKeypair(await Random.getBytes(32));
+  const bnsIdentity: Identity = {
+    chainId: bnsChain as ChainId,
+    pubkey: {
+      algo: Algorithm.Ed25519,
+      data: rawKeypair.pubkey as PubkeyBytes,
+    },
+  };
+
+  keys[ethChain] = JSON.stringify(TransactionEncoder.toJson(ethIdentity));
+  keys[bnsChain] = JSON.stringify(TransactionEncoder.toJson(bnsIdentity));
+
+  return keys;
+}

--- a/packages/bierzo-wallet/src/utils/tokens.ts
+++ b/packages/bierzo-wallet/src/utils/tokens.ts
@@ -1,0 +1,19 @@
+import { BlockchainConnection, Identity } from '@iov/bcp';
+
+// exported for testing purposes
+export async function filterExistingTokens(
+  connection: BlockchainConnection,
+  identity: Identity,
+  tokensByChainId: ReadonlyArray<string>,
+): Promise<ReadonlyArray<string>> {
+  const account = await connection.getAccount({ pubkey: identity.pubkey });
+  if (!account) {
+    return tokensByChainId;
+  }
+
+  for (const balance of account.balance) {
+    tokensByChainId = tokensByChainId.filter(ticker => ticker !== balance.tokenTicker);
+  }
+
+  return tokensByChainId;
+}


### PR DESCRIPTION
**Description**
In this PR I include the subscription for blockchain account balances. Now each time we receive an event we call getBalances function and we update the redux store. 

For achieving it I had to change the http connection in bns chain to ws.

It closes #384 

**Note for developers**
The way I have used for testing functionality is calling faucet twice, forcing accounts to receive events. 