### PR TITLE
Feature – Simplify disconnect

### DIFF
--- a/packages/bierzo-wallet/src/logic/connection.ts
+++ b/packages/bierzo-wallet/src/logic/connection.ts
@@ -63,7 +63,7 @@ export async function getConnectionFor(spec: ChainSpec): Promise<BlockchainConne
  * Disconnects all blockchain connections. Calling getConnectionFor after
  * this will establich a new connection.
  */
-export async function disconnect(): Promise<void> {
+export function disconnect(): void {
   if (bnsConnection) bnsConnection.disconnect();
   if (ethereumConnection) ethereumConnection.disconnect();
   if (liskConnection) liskConnection.disconnect();


### PR DESCRIPTION
This is what I had in mind. The code should behave exactly like before. Improvements to before

* External singleton method not needed
* The connection instances are explicitly visible, which separated instances from the creation
* The disconnect method only clears stuff and doe not need to prepare something for later
* Async only needed for connecting, not disconnecting