### PR TITLE
Feature – Use natural identities response type

### DIFF
--- a/packages/bierzo-wallet/src/communication/identities/index.ts
+++ b/packages/bierzo-wallet/src/communication/identities/index.ts
@@ -24,7 +24,7 @@ function isArrayOfIdentity(data: any): data is ReadonlyArray<Identity> {
 
 /**
  * The response of a "getIdentities" RPC call to the browser extension.
- * `undefined` represents the case that the website cound not connect to the
+ * `undefined` represents the case that the website could not connect to the
  * extension, i.e. the extension is not available.
  */
 export type GetIdentitiesResponse = readonly Identity[] | undefined;


### PR DESCRIPTION
~Based on #389. Only check last commit.~

--------------

The type `GetIdentitiesResponse` is now a list of identities to better represent the [return type of the RPC method getIdentities](https://github.com/iov-one/iov-core/blob/master/docs/out-of-process-rpc.md#methods).

The logic of the grouping is unchanged. It was just made explicit in the `groupIdentitiesByChain` method. This prepares the expansion to multiple identities per chainId but does not change the current redux logic.