### PR TITLE
Feature – Remove obsolete transaction creator address

### DIFF
--- a/packages/sanes-chrome-extension/src/extension/background/model/signingServer/index.requests.unit.spec.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/signingServer/index.requests.unit.spec.ts
@@ -222,9 +222,5 @@ withChainsDescribe('background script handler for website request', () => {
 
     const request = signingServer['requestHandler'].next();
     if (!isSignAndPostRequest(request)) throw new Error('Unexpected request type');
-    const requestData = request.data;
-    expect(requestData.creator).not.toBe(undefined);
-    expect(requestData.creator).not.toBe(null);
-    expect(requestData.creator).toMatch(/0x/);
   }, 8000);
 });

--- a/packages/sanes-chrome-extension/src/extension/background/model/signingServer/index.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/signingServer/index.ts
@@ -60,7 +60,7 @@ export default class SigningServer {
     );
   };
 
-  public signAndPostCallback = (signer: MultiChainSigner) => (
+  public signAndPostCallback = (_signer: MultiChainSigner) => (
     reason: string,
     transaction: UnsignedTransaction,
     meta: any,
@@ -77,7 +77,6 @@ export default class SigningServer {
 
     const data: SignAndPostData = {
       senderUrl,
-      creator: signer.identityToAddress(transaction.creator),
       tx: transaction,
     };
 

--- a/packages/sanes-chrome-extension/src/extension/background/model/signingServer/requestQueueManager/index.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/signingServer/requestQueueManager/index.ts
@@ -53,7 +53,6 @@ export function isGetIdentitiesData(data: unknown): data is GetIdentitiesData {
 
 export interface SignAndPostData extends RequestMeta {
   readonly tx: SupportedTransaction;
-  readonly creator: Address;
 }
 
 export function isSignAndPostData(data: unknown): data is SignAndPostData {
@@ -62,12 +61,11 @@ export function isSignAndPostData(data: unknown): data is SignAndPostData {
   }
 
   const hasSender = typeof (data as SignAndPostData).senderUrl === 'string';
-  const hasCreator = typeof (data as SignAndPostData).creator === 'string';
 
   const tx: unknown = (data as SignAndPostData).tx;
   const hasSupportedTransaction = isUnsignedTransaction(tx) && isSupportedTransaction(tx);
 
-  return hasSender && hasCreator && hasSupportedTransaction;
+  return hasSender && hasSupportedTransaction;
 }
 
 export interface Request<

--- a/packages/sanes-chrome-extension/src/routes/requests/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/requests/index.dom.spec.ts
@@ -1,4 +1,3 @@
-import { Address } from '@iov/bcp';
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
 
@@ -25,7 +24,6 @@ describe('DOM > Feature > Requests', () => {
     reason: 'Reason 2',
     data: {
       senderUrl: 'www.sender2.com',
-      creator: '0x873fAA4cdDd5b157e8E5a57e7a5479AFC5aaaaaa' as Address,
       tx: getCashTransaction(),
     },
     accept: jest.fn(),

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/ReqRegisterUsernameTx.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/ReqRegisterUsernameTx.tsx
@@ -9,7 +9,6 @@ import TransactionFee, { txListItemSecondaryProps, useTxListItemStyles } from '.
 export const REQ_REGISTER_USERNAME = 'req-register-username-tx';
 
 interface Props {
-  readonly creator: string;
   readonly tx: RegisterUsernameTx;
 }
 

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/ReqSendTransaction.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/ReqSendTransaction.tsx
@@ -8,11 +8,10 @@ import TransactionFee, { txListItemSecondaryProps, useTxListItemStyles } from '.
 export const REQ_SEND_TX = 'req-send-tx';
 
 interface Props {
-  readonly creator: string;
   readonly tx: SendTransaction;
 }
 
-const ReqSendTransaction = ({ tx, creator }: Props): JSX.Element => {
+const ReqSendTransaction = ({ tx }: Props): JSX.Element => {
   const listItemClasses = useTxListItemStyles();
 
   return (
@@ -20,8 +19,8 @@ const ReqSendTransaction = ({ tx, creator }: Props): JSX.Element => {
       <ListItem>
         <ListItemText
           classes={listItemClasses}
-          primary="Creator"
-          secondary={creator}
+          primary="Sender"
+          secondary={tx.sender}
           secondaryTypographyProps={txListItemSecondaryProps}
         />
       </ListItem>

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/index.tsx
@@ -17,7 +17,6 @@ interface Props {
   readonly onAcceptRequest: () => void;
   readonly showRejectView: () => void;
   readonly sender: string;
-  readonly creator: string;
   readonly tx: SupportedTransaction;
 }
 

--- a/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/components/ShowRequest/index.tsx
@@ -21,13 +21,13 @@ interface Props {
   readonly tx: SupportedTransaction;
 }
 
-const Layout = ({ sender, tx, creator, onAcceptRequest, showRejectView }: Props): JSX.Element => {
+const Layout = ({ sender, tx, onAcceptRequest, showRejectView }: Props): JSX.Element => {
   let req: JSX.Element;
 
   if (isSendTransaction(tx)) {
-    req = <ReqSendTransaction tx={tx} creator={creator} />;
+    req = <ReqSendTransaction tx={tx} />;
   } else if (isRegisterUsernameTx(tx)) {
-    req = <ReqRegisterUsernameTx tx={tx} creator={creator} />;
+    req = <ReqRegisterUsernameTx tx={tx} />;
   } else {
     throw new Error('Received transaction type that cannot be displayed');
   }

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.dom.spec.ts
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.dom.spec.ts
@@ -1,4 +1,3 @@
-import { Address } from '@iov/bcp';
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
 
@@ -26,7 +25,6 @@ const sendRequests: ReadonlyArray<Request> = [
     reason: 'Test get Identities',
     data: {
       senderUrl: 'http://finnex.com',
-      creator: '0x873fAA4cdDd5b157e8E5a57e7a5479AFC5aaaaaa' as Address,
       tx: getCashTransaction(),
     },
     accept: jest.fn(),
@@ -96,7 +94,6 @@ describe('DOM > Feature > Username Registration Request', (): void => {
       reason: 'Test username registration',
       data: {
         senderUrl: 'http://finnex.com',
-        creator: '0x873fAA4cdDd5b157e8E5a57e7a5479AFC5aaaaaa' as Address,
         tx: getUsernameTransaction(),
       },
       accept: jest.fn(),

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.stories.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.stories.tsx
@@ -1,4 +1,3 @@
-import { Address } from '@iov/bcp';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 import { storiesOf } from '@storybook/react';
@@ -25,7 +24,6 @@ const txRequest: Request<SignAndPostData> = {
   reason: 'I would like you to sign this TX',
   data: {
     senderUrl: 'http://localhost/',
-    creator: '0x873fAA4cdDd5b157e8E5a57e7a5479AFC5aaaaaa' as Address,
     tx: getCashTransaction(),
   },
 };
@@ -37,7 +35,6 @@ const ethereumTxRequest: Request<SignAndPostData> = {
   reason: 'I would like you to sign this Ethereum TX',
   data: {
     senderUrl: 'http://localhost/',
-    creator: '0x873fAA4cdDd5b157e8E5a57e7a5479AFC5aaaaaa' as Address,
     tx: getEthTransaction(),
   },
 };
@@ -49,20 +46,18 @@ const usernameRequest: Request<SignAndPostData> = {
   reason: 'I would like you to sign this TX',
   data: {
     senderUrl: 'http://localhost/',
-    creator: '0x873fAA4cdDd5b157e8E5a57e7a5479AFC5aaaaaa' as Address,
     tx: getUsernameTransaction(),
   },
 };
 
 storiesOf(TX_REQUEST_PATH, module)
   .add(SHOW_TX_REQUEST_PAGE, () => {
-    const { creator, tx } = txRequest.data;
+    const { tx } = txRequest.data;
 
     return (
       <Storybook>
         <ShowRequest
           tx={tx}
-          creator={creator}
           sender={txRequest.data.senderUrl}
           onAcceptRequest={linkTo(CHROME_EXTENSION_ROOT, ACCOUNT_STATUS_PAGE)}
           showRejectView={linkTo(TX_REQUEST_PATH, REJECT_REQUEST_PAGE)}
@@ -71,13 +66,12 @@ storiesOf(TX_REQUEST_PATH, module)
     );
   })
   .add(SHOW_ETHEREUM_TX_REQUEST_PAGE, () => {
-    const { creator, tx, senderUrl } = ethereumTxRequest.data;
+    const { tx, senderUrl } = ethereumTxRequest.data;
 
     return (
       <Storybook>
         <ShowRequest
           tx={tx}
-          creator={creator}
           sender={senderUrl}
           onAcceptRequest={linkTo(CHROME_EXTENSION_ROOT, ACCOUNT_STATUS_PAGE)}
           showRejectView={linkTo(TX_REQUEST_PATH, REJECT_REQUEST_PAGE)}
@@ -86,13 +80,12 @@ storiesOf(TX_REQUEST_PATH, module)
     );
   })
   .add(SHOW_USERNAME_REQUEST_PAGE, () => {
-    const { creator, tx } = usernameRequest.data;
+    const { tx } = usernameRequest.data;
 
     return (
       <Storybook>
         <ShowRequest
           tx={tx}
-          creator={creator}
           sender={usernameRequest.data.senderUrl}
           onAcceptRequest={linkTo(CHROME_EXTENSION_ROOT, ACCOUNT_STATUS_PAGE)}
           showRejectView={linkTo(TX_REQUEST_PATH, REJECT_REQUEST_PAGE)}

--- a/packages/sanes-chrome-extension/src/routes/tx-request/index.tsx
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/index.tsx
@@ -41,7 +41,6 @@ const TxRequest = ({ location }: RouteComponentProps): JSX.Element => {
       {action === 'show' && (
         <ShowRequest
           tx={data.tx}
-          creator={data.creator}
           sender={data.senderUrl}
           onAcceptRequest={onAcceptRequest}
           showRejectView={showRejectView}

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -7971,12 +7971,12 @@ exports[`Storyshots Extension/Transaction Request Show TX Request page (Ethereum
           <span
             className="MuiTypography-root MuiListItemText-primary MuiTypography-body1"
           >
-            Creator
+            Sender
           </span>
           <p
             className="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-noWrap"
           >
-            0x873fAA4cdDd5b157e8E5a57e7a5479AFC5aaaaaa
+            0x7c15484EA11FD233AE566469af15d84335023c30
           </p>
         </div>
       </li>
@@ -8186,12 +8186,12 @@ exports[`Storyshots Extension/Transaction Request Show TX Request page 1`] = `
           <span
             className="MuiTypography-root MuiListItemText-primary MuiTypography-body1"
           >
-            Creator
+            Sender
           </span>
           <p
             className="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-noWrap"
           >
-            0x873fAA4cdDd5b157e8E5a57e7a5479AFC5aaaaaa
+            tiov1dcg3fat5zrvw00xezzjk3jgedm7pg70y222af3
           </p>
         </div>
       </li>


### PR DESCRIPTION
What was the transaction creator address before is now `SendTransaction.sender`.