### PR TITLE
Feature #252 - Show human readable address on balance route.

### DIFF
--- a/packages/bierzo-wallet/src/routes/balance/components/index.tsx
+++ b/packages/bierzo-wallet/src/routes/balance/components/index.tsx
@@ -13,7 +13,7 @@ import receive from '../assets/transactionReceive.svg';
 import send from '../assets/transactionSend.svg';
 
 interface Props {
-  readonly name: string | undefined;
+  readonly iovAddress: string | undefined;
   readonly tokens: { [token: string]: Amount };
   readonly onSendPayment: () => void;
   readonly onReceivePayment: () => void;
@@ -55,7 +55,7 @@ const Card = ({ id, text, logo, onAction }: CardProps): JSX.Element => {
   );
 };
 
-const BalanceLayout = ({ name, tokens, onSendPayment, onReceivePayment }: Props): JSX.Element => {
+const BalanceLayout = ({ iovAddress, tokens, onSendPayment, onReceivePayment }: Props): JSX.Element => {
   const hasTokens = tokens && Object.keys(tokens).length;
   const theme = useTheme<Theme>();
 
@@ -72,7 +72,7 @@ const BalanceLayout = ({ name, tokens, onSendPayment, onReceivePayment }: Props)
       <Block bgcolor={theme.palette.background.paper} height="unset" width={450}>
         <Block padding={4} display="flex" flexDirection="column">
           <Typography variant="h5" align="center" weight="light">
-            {name ? name : '--'}
+            {iovAddress ? iovAddress : 'Get your human readable address.'}
           </Typography>
           <Hairline space={4} />
           <Typography variant="subtitle2" align="center">

--- a/packages/bierzo-wallet/src/routes/balance/components/index.tsx
+++ b/packages/bierzo-wallet/src/routes/balance/components/index.tsx
@@ -72,7 +72,7 @@ const BalanceLayout = ({ iovAddress, tokens, onSendPayment, onReceivePayment }: 
       <Block bgcolor={theme.palette.background.paper} height="unset" width={450}>
         <Block padding={4} display="flex" flexDirection="column">
           <Typography variant="h5" align="center" weight="light">
-            {iovAddress ? iovAddress : 'Get your human readable address.'}
+            {iovAddress ? iovAddress : 'No human readable address registered.'}
           </Typography>
           <Hairline space={4} />
           <Typography variant="subtitle2" align="center">

--- a/packages/bierzo-wallet/src/routes/balance/index.dom.spec.ts
+++ b/packages/bierzo-wallet/src/routes/balance/index.dom.spec.ts
@@ -9,7 +9,7 @@ import { UsernamesState } from '../../store/usernames';
 import { expectRoute } from '../../utils/test/dom';
 import { findRenderedDOMComponentWithId } from '../../utils/test/reactElemFinder';
 import { PAYMENT_ROUTE, RECEIVE_FROM_IOV_USER } from '../paths';
-import { getIOVUsername, getNoFundsMessage } from './test/operateBalances';
+import { getIovUsername, getNoFundsMessage } from './test/operateBalances';
 import { travelToBalance } from './test/travelToBalance';
 
 const balancesAmount: DeepPartial<BalanceState> = {
@@ -84,7 +84,7 @@ describe('The /balance route', () => {
     });
 
     it('should show bns username', async () => {
-      const noUsernameMessage = getIOVUsername(TestUtils.scryRenderedDOMComponentsWithTag(balanceDom, 'h5'));
+      const noUsernameMessage = getIovUsername(TestUtils.scryRenderedDOMComponentsWithTag(balanceDom, 'h5'));
 
       expect(noUsernameMessage).toBe('albert*iov');
     });
@@ -110,9 +110,9 @@ describe('The /balance route', () => {
     });
 
     it('should show that there is no bns username available', async () => {
-      const noUsernameMessage = getIOVUsername(TestUtils.scryRenderedDOMComponentsWithTag(balanceDom, 'h5'));
+      const noUsernameMessage = getIovUsername(TestUtils.scryRenderedDOMComponentsWithTag(balanceDom, 'h5'));
 
-      expect(noUsernameMessage).toBe('Get your human readable address.');
+      expect(noUsernameMessage).toBe('No human readable address registered.');
     });
   });
 });

--- a/packages/bierzo-wallet/src/routes/balance/index.dom.spec.ts
+++ b/packages/bierzo-wallet/src/routes/balance/index.dom.spec.ts
@@ -25,10 +25,10 @@ const balancesAmount: DeepPartial<BalanceState> = {
   },
 };
 
-const bnsChaingId = 'local-bns-devnet';
+const bnsChainId = 'local-bns-devnet';
 const usernames: DeepPartial<UsernamesState> = {
-  [bnsChaingId]: {
-    chainId: bnsChaingId,
+  [bnsChainId]: {
+    chainId: bnsChainId,
     address: 'some_address',
     username: 'albert',
   },

--- a/packages/bierzo-wallet/src/routes/balance/index.dom.spec.ts
+++ b/packages/bierzo-wallet/src/routes/balance/index.dom.spec.ts
@@ -5,10 +5,11 @@ import { DeepPartial, Store } from 'redux';
 import { aNewStore } from '../../store';
 import { BalanceState } from '../../store/balances';
 import { RootState } from '../../store/reducers';
+import { UsernamesState } from '../../store/usernames';
 import { expectRoute } from '../../utils/test/dom';
 import { findRenderedDOMComponentWithId } from '../../utils/test/reactElemFinder';
 import { PAYMENT_ROUTE, RECEIVE_FROM_IOV_USER } from '../paths';
-import { getNoFundsMessage } from './test/operateBalances';
+import { getIOVUsername, getNoFundsMessage } from './test/operateBalances';
 import { travelToBalance } from './test/travelToBalance';
 
 const balancesAmount: DeepPartial<BalanceState> = {
@@ -24,6 +25,15 @@ const balancesAmount: DeepPartial<BalanceState> = {
   },
 };
 
+const bnsChaingId = 'local-bns-devnet';
+const usernames: DeepPartial<UsernamesState> = {
+  [bnsChaingId]: {
+    chainId: bnsChaingId,
+    address: 'some_address',
+    username: 'albert',
+  },
+};
+
 describe('The /balance route', () => {
   let store: Store<RootState>;
   let balanceDom: React.Component;
@@ -36,6 +46,7 @@ describe('The /balance route', () => {
             installed: true,
           },
           balances: balancesAmount,
+          usernames,
         });
         balanceDom = await travelToBalance(store);
       },
@@ -71,9 +82,15 @@ describe('The /balance route', () => {
       expect(balances[0].textContent).toBe('8.25 BASH');
       expect(balances[1].textContent).toBe('12.26775 CASH');
     });
+
+    it('should show bns username', async () => {
+      const noUsernameMessage = getIOVUsername(TestUtils.scryRenderedDOMComponentsWithTag(balanceDom, 'h5'));
+
+      expect(noUsernameMessage).toBe('albert*iov');
+    });
   });
 
-  describe('without balance', () => {
+  describe('without balance and username', () => {
     beforeEach(
       async (): Promise<void> => {
         store = aNewStore({
@@ -90,6 +107,12 @@ describe('The /balance route', () => {
       const noFundsMessage = getNoFundsMessage(TestUtils.scryRenderedDOMComponentsWithTag(balanceDom, 'h6'));
 
       expect(noFundsMessage).toBe('No funds available');
+    });
+
+    it('should show that there is no bns username available', async () => {
+      const noUsernameMessage = getIOVUsername(TestUtils.scryRenderedDOMComponentsWithTag(balanceDom, 'h5'));
+
+      expect(noUsernameMessage).toBe('Get your human readable address.');
     });
   });
 });

--- a/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
+++ b/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
@@ -8,6 +8,7 @@ import {
   getFirstCurrencyBalanceE2E,
   getSecondCurrencyBalanceE2E,
   getThirdCurrencyBalanceE2E,
+  getUsernameE2E,
 } from './test/operateBalances';
 import { travelToBalanceE2E } from './test/travelToBalance';
 
@@ -54,5 +55,11 @@ withChainsDescribe('E2E > Balance route', (): void => {
     expect(firstBalance).toBe('10 BASH');
     expect(secondBalance).toBe('10 CASH');
     expect(thirdBalance).toBe('10 ETH');
+  }, 45000);
+
+  it('should contain username', async (): Promise<void> => {
+    const username = await getUsernameE2E(await page.$$('h5'));
+
+    expect(username).toBe('test*iov');
   }, 45000);
 });

--- a/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
+++ b/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
@@ -57,9 +57,9 @@ withChainsDescribe('E2E > Balance route', (): void => {
     expect(thirdBalance).toBe('10 ETH');
   }, 45000);
 
-  it('should contain username', async (): Promise<void> => {
+  fit('should contain message to get username', async (): Promise<void> => {
     const username = await getUsernameE2E(await page.$$('h5'));
 
-    expect(username).toBe('test*iov');
+    expect(username).toBe('Get your human readable address.');
   }, 45000);
 });

--- a/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
+++ b/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
@@ -57,9 +57,9 @@ withChainsDescribe('E2E > Balance route', (): void => {
     expect(thirdBalance).toBe('10 ETH');
   }, 45000);
 
-  fit('should contain message to get username', async (): Promise<void> => {
+  it('should contain message to get username', async (): Promise<void> => {
     const username = await getUsernameE2E(await page.$$('h5'));
 
-    expect(username).toBe('Get your human readable address.');
+    expect(username).toBe('No human readable address registered.');
   }, 45000);
 });

--- a/packages/bierzo-wallet/src/routes/balance/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/balance/index.stories.tsx
@@ -31,7 +31,7 @@ storiesOf(`${WALLET_ROOT}/balance`, module)
     <DecoratedStorybook>
       <PageMenu>
         <Layout
-          name={ACCOUNT_NAME}
+          iovAddress={ACCOUNT_NAME}
           tokens={BALANCE}
           onReceivePayment={action('onReceivePayment')}
           onSendPayment={action('onSendPayment')}
@@ -39,11 +39,11 @@ storiesOf(`${WALLET_ROOT}/balance`, module)
       </PageMenu>
     </DecoratedStorybook>
   ))
-  .add('View without tokens', () => (
+  .add('View without tokens and without name', () => (
     <DecoratedStorybook>
       <PageMenu>
         <Layout
-          name={ACCOUNT_NAME}
+          iovAddress={undefined}
           tokens={NO_BALANCE}
           onReceivePayment={action('onReceivePayment')}
           onSendPayment={action('onSendPayment')}

--- a/packages/bierzo-wallet/src/routes/balance/index.tsx
+++ b/packages/bierzo-wallet/src/routes/balance/index.tsx
@@ -4,6 +4,7 @@ import * as ReactRedux from 'react-redux';
 import { history } from '..';
 import PageMenu from '../../components/PageMenu';
 import { RootState } from '../../store/reducers';
+import { getUsername } from '../../store/usernames/selectors';
 import { PAYMENT_ROUTE, RECEIVE_FROM_IOV_USER } from '../paths';
 import Layout from './components';
 
@@ -17,10 +18,7 @@ function onReceivePayment(): void {
 
 const Balance = (): JSX.Element => {
   const tokens = ReactRedux.useSelector((state: RootState) => state.balances);
-  const bnsChainId = 'local-bns-devnet';
-  const bnsUsername = ReactRedux.useSelector((state: RootState) =>
-    Object.values(state.usernames).find(username => username.chainId === bnsChainId),
-  );
+  const bnsUsername = ReactRedux.useSelector(getUsername);
   const iovAddress = bnsUsername ? `${bnsUsername.username}*iov` : undefined;
 
   return (

--- a/packages/bierzo-wallet/src/routes/balance/index.tsx
+++ b/packages/bierzo-wallet/src/routes/balance/index.tsx
@@ -4,7 +4,7 @@ import * as ReactRedux from 'react-redux';
 import { history } from '..';
 import PageMenu from '../../components/PageMenu';
 import { RootState } from '../../store/reducers';
-import { getUsername } from '../../store/usernames/selectors';
+import { getFirstUsername } from '../../store/usernames/selectors';
 import { PAYMENT_ROUTE, RECEIVE_FROM_IOV_USER } from '../paths';
 import Layout from './components';
 
@@ -18,7 +18,7 @@ function onReceivePayment(): void {
 
 const Balance = (): JSX.Element => {
   const tokens = ReactRedux.useSelector((state: RootState) => state.balances);
-  const bnsUsername = ReactRedux.useSelector(getUsername);
+  const bnsUsername = ReactRedux.useSelector(getFirstUsername);
   const iovAddress = bnsUsername ? `${bnsUsername.username}*iov` : undefined;
 
   return (

--- a/packages/bierzo-wallet/src/routes/balance/index.tsx
+++ b/packages/bierzo-wallet/src/routes/balance/index.tsx
@@ -17,15 +17,18 @@ function onReceivePayment(): void {
 
 const Balance = (): JSX.Element => {
   const tokens = ReactRedux.useSelector((state: RootState) => state.balances);
-  const name = 'test';
-  const iovAddress = `${name}*iov`;
+  const bnsChainId = 'local-bns-devnet';
+  const bnsUsername = ReactRedux.useSelector((state: RootState) =>
+    Object.values(state.usernames).find(username => username.chainId === bnsChainId),
+  );
+  const iovAddress = bnsUsername ? `${bnsUsername.username}*iov` : undefined;
 
   return (
     <PageMenu>
       <Layout
         onSendPayment={onSendPayment}
         onReceivePayment={onReceivePayment}
-        name={iovAddress}
+        iovAddress={iovAddress}
         tokens={tokens}
       />
     </PageMenu>

--- a/packages/bierzo-wallet/src/routes/balance/test/operateBalances.ts
+++ b/packages/bierzo-wallet/src/routes/balance/test/operateBalances.ts
@@ -4,7 +4,7 @@ export const getNoFundsMessage = (h6Elements: Element[]): string => {
   return h6Elements[4].textContent || '';
 };
 
-export const getIOVUsername = (h5Elements: Element[]): string => {
+export const getIovUsername = (h5Elements: Element[]): string => {
   return h5Elements[0].textContent || '';
 };
 

--- a/packages/bierzo-wallet/src/routes/balance/test/operateBalances.ts
+++ b/packages/bierzo-wallet/src/routes/balance/test/operateBalances.ts
@@ -5,6 +5,10 @@ export const getNoFundsMessage = (h6Elements: Element[]): string => {
   return h6Elements[NO_FUNDS_IDX].textContent || '';
 };
 
+export const getIOVUsername = (h5Elements: Element[]): string => {
+  return h5Elements[0].textContent || '';
+};
+
 export const getFirstCurrencyBalanceE2E = async (h6Elements: ElementHandle<Element>[]): Promise<string> => {
   return (await (await h6Elements[5].getProperty('textContent')).jsonValue()) || '';
 };

--- a/packages/bierzo-wallet/src/routes/balance/test/operateBalances.ts
+++ b/packages/bierzo-wallet/src/routes/balance/test/operateBalances.ts
@@ -1,8 +1,7 @@
 import { ElementHandle } from 'puppeteer';
 
-const NO_FUNDS_IDX = 4;
 export const getNoFundsMessage = (h6Elements: Element[]): string => {
-  return h6Elements[NO_FUNDS_IDX].textContent || '';
+  return h6Elements[4].textContent || '';
 };
 
 export const getIOVUsername = (h5Elements: Element[]): string => {
@@ -19,4 +18,8 @@ export const getSecondCurrencyBalanceE2E = async (h6Elements: ElementHandle<Elem
 
 export const getThirdCurrencyBalanceE2E = async (h6Elements: ElementHandle<Element>[]): Promise<string> => {
   return (await (await h6Elements[7].getProperty('textContent')).jsonValue()) || '';
+};
+
+export const getUsernameE2E = async (h5Elements: ElementHandle<Element>[]): Promise<string> => {
+  return (await (await h5Elements[0].getProperty('textContent')).jsonValue()) || '';
 };

--- a/packages/bierzo-wallet/src/store/usernames/selectors.ts
+++ b/packages/bierzo-wallet/src/store/usernames/selectors.ts
@@ -1,0 +1,5 @@
+import { RootState } from '../reducers';
+import { BwUsername } from '.';
+
+export const getUsername = (state: RootState): BwUsername | undefined =>
+  Object.values(state.usernames).find(username => username);

--- a/packages/bierzo-wallet/src/store/usernames/selectors.ts
+++ b/packages/bierzo-wallet/src/store/usernames/selectors.ts
@@ -1,5 +1,7 @@
 import { RootState } from '../reducers';
 import { BwUsername } from '.';
 
-export const getUsername = (state: RootState): BwUsername | undefined =>
-  Object.values(state.usernames).find(username => username);
+export const getFirstUsername = (state: RootState): BwUsername | undefined => {
+  const firstUsername = Object.values(state.usernames).find(() => true);
+  return firstUsername;
+};

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2415,7 +2415,7 @@ exports[`Storyshots Bierzo wallet/balance View without tokens and without name 1
           <h5
             className="MuiTypography-root makeStyles-weight-563 makeStyles-weight-656 MuiTypography-h5 MuiTypography-alignCenter"
           >
-            Get your human readable address.
+            No human readable address registered.
           </h5>
           <div
             className="MuiBox-root MuiBox-root-657"

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2179,7 +2179,7 @@ exports[`Storyshots Bierzo wallet/balance View 1`] = `
 </div>
 `;
 
-exports[`Storyshots Bierzo wallet/balance View without tokens 1`] = `
+exports[`Storyshots Bierzo wallet/balance View without tokens and without name 1`] = `
 <div
   className="MuiBox-root MuiBox-root-543"
 >
@@ -2415,7 +2415,7 @@ exports[`Storyshots Bierzo wallet/balance View without tokens 1`] = `
           <h5
             className="MuiTypography-root makeStyles-weight-563 makeStyles-weight-656 MuiTypography-h5 MuiTypography-alignCenter"
           >
-            adolfo*iov
+            Get your human readable address.
           </h5>
           <div
             className="MuiBox-root MuiBox-root-657"


### PR DESCRIPTION
**Description**
This PR will add support of BNS name to the balance route component. It will close #252.

**Without name**
![balance-without-name](https://user-images.githubusercontent.com/3502260/61623789-0919fc00-ac80-11e9-8706-0ef9740f878c.png)

**With name**
![balance-need-funds](https://user-images.githubusercontent.com/3502260/61532992-396d5a80-aa34-11e9-921a-5e37ccd35830.png)


