### PR TITLE
Feature – Refactor getUsernames

### DIFF
--- a/packages/bierzo-wallet/src/logic/connection.ts
+++ b/packages/bierzo-wallet/src/logic/connection.ts
@@ -43,17 +43,9 @@ export function isEthSpec(spec: ChainSpec): boolean {
 }
 
 export async function getConnectionFor(spec: ChainSpec): Promise<BlockchainConnection> {
-  if (spec.codecType === 'eth') {
-    return getEthereumConnection(spec.node);
-  }
-
-  if (isBnsSpec(spec)) {
-    return getBnsConnection(spec.node);
-  }
-
-  if (spec.codecType === 'lsk') {
-    return getLiskConnection(spec.node);
-  }
+  if (isEthSpec(spec)) return getEthereumConnection(spec.node);
+  if (isBnsSpec(spec)) return getBnsConnection(spec.node);
+  if (isLskSpec(spec)) return getLiskConnection(spec.node);
 
   throw new Error('Chain spec not supported');
 }

--- a/packages/bierzo-wallet/src/routes/balance/index.dom.spec.ts
+++ b/packages/bierzo-wallet/src/routes/balance/index.dom.spec.ts
@@ -26,13 +26,17 @@ const balancesAmount: DeepPartial<BalanceState> = {
 };
 
 const bnsChainId = 'local-bns-devnet';
-const usernames: DeepPartial<UsernamesState> = {
-  [bnsChainId]: {
-    chainId: bnsChainId,
-    address: 'some_address',
+const usernames: DeepPartial<UsernamesState> = [
+  {
     username: 'albert',
+    addresses: [
+      {
+        chainId: bnsChainId,
+        address: 'some_address',
+      },
+    ],
   },
-};
+];
 
 describe('The /balance route', () => {
   let store: Store<RootState>;

--- a/packages/bierzo-wallet/src/store/usernames/actions.ts
+++ b/packages/bierzo-wallet/src/store/usernames/actions.ts
@@ -23,6 +23,8 @@ export async function getUsernames(keys: {
   const bnsAddress = bnsCodec.identityToAddress(bnsIdentity);
 
   const usernames = await bnsConnection.getUsernames({ owner: bnsAddress });
+  // We ignore all usernames other than the first one. This is a simplification
+  // we can do as long as the wallet is not use for name traders.
   const firstUsername = usernames.find(() => true);
 
   if (!firstUsername) return {};

--- a/packages/bierzo-wallet/src/store/usernames/actions.ts
+++ b/packages/bierzo-wallet/src/store/usernames/actions.ts
@@ -1,5 +1,5 @@
 import { Identity } from '@iov/bcp';
-import { BnsConnection } from '@iov/bns';
+import { bnsCodec, BnsConnection } from '@iov/bns';
 import { TransactionEncoder } from '@iov/core';
 
 import { getConfig } from '../../config';
@@ -9,47 +9,33 @@ import { AddUsernamesActionType, BwUsername } from './reducer';
 export async function getUsernames(keys: {
   [chain: string]: string;
 }): Promise<{ [chainId: string]: BwUsername }> {
-  const config = getConfig();
-  const usernames: { [chainId: string]: BwUsername } = {};
-  const chains = config.chains;
+  const bnsChainSpec = getConfig()
+    .chains.map(chain => chain.chainSpec)
+    .find(isBnsSpec);
+  if (!bnsChainSpec) throw new Error('Missing BNS chain spec in config');
 
-  for (const chain of chains) {
-    if (!isBnsSpec(chain.chainSpec)) {
-      continue;
-    }
+  const bnsConnection = (await getConnectionFor(bnsChainSpec)) as BnsConnection;
 
-    const connection = (await getConnectionFor(chain.chainSpec)) as BnsConnection;
-    const chainId = connection.chainId();
+  const plainPubkey = keys[bnsConnection.chainId()];
+  if (!plainPubkey) return {};
 
-    const plainPubkey = keys[chainId];
-    if (!plainPubkey) {
-      break;
-    }
+  const bnsIdentity: Identity = TransactionEncoder.fromJson(JSON.parse(plainPubkey));
+  const bnsAddress = bnsCodec.identityToAddress(bnsIdentity);
 
-    const identity: Identity = TransactionEncoder.fromJson(JSON.parse(plainPubkey));
-    const account = await connection.getAccount({ pubkey: identity.pubkey });
-    if (!account) {
-      break;
-    }
+  const usernames = await bnsConnection.getUsernames({ owner: bnsAddress });
+  const firstUsername = usernames.find(() => true);
 
-    const names = await connection.getUsernames({ owner: account.address });
-    const hasName = names.length > 0;
-    if (!hasName) {
-      break;
-    }
+  if (!firstUsername) return {};
 
-    const name = names[0];
-
-    for (const address of name.addresses) {
-      usernames[address.chainId as string] = {
-        chainId: address.chainId,
-        address: address.address,
-        username: name.id,
-      };
-    }
+  const out: { [chainId: string]: BwUsername } = {};
+  for (const address of firstUsername.addresses) {
+    out[address.chainId as string] = {
+      chainId: address.chainId,
+      address: address.address,
+      username: firstUsername.id,
+    };
   }
-
-  return usernames;
+  return out;
 }
 
 export const addUsernamesAction = (usernames: { [chainId: string]: BwUsername }): AddUsernamesActionType => ({

--- a/packages/bierzo-wallet/src/store/usernames/index.unit.spec.ts
+++ b/packages/bierzo-wallet/src/store/usernames/index.unit.spec.ts
@@ -10,9 +10,7 @@ import { addUsernamesAction, getUsernames } from './actions';
 import { BwUsername } from './reducer';
 
 withChainsDescribe('Usernames reducer', () => {
-  afterAll(async () => {
-    await disconnect();
-  });
+  afterAll(() => disconnect());
 
   it('has correct initial state', async () => {
     const store = aNewStore();

--- a/packages/bierzo-wallet/src/store/usernames/index.unit.spec.ts
+++ b/packages/bierzo-wallet/src/store/usernames/index.unit.spec.ts
@@ -14,12 +14,12 @@ withChainsDescribe('Usernames reducer', () => {
   it('has correct initial state', async () => {
     const store = aNewStore();
     const usernames = store.getState().usernames;
-    expect(usernames).toEqual({});
+    expect(usernames).toEqual([]);
   });
 
   it('returns empty when no keys passed to getUsernames function', async () => {
     const usernames = await getUsernames({});
-    expect(usernames).toEqual({});
+    expect(usernames).toEqual([]);
   });
 
   it('returns empty when no key bns identity key is s passed to getUsernames function', async () => {
@@ -47,7 +47,7 @@ withChainsDescribe('Usernames reducer', () => {
 
     const keys = store.getState().extension.keys;
     const usernames = await getUsernames(keys);
-    expect(usernames).toEqual({});
+    expect(usernames).toEqual([]);
   });
 
   it('dispatches correctly addUsernames action', async () => {
@@ -81,6 +81,6 @@ withChainsDescribe('Usernames reducer', () => {
     store.dispatch(addUsernamesAction(chainUsernames));
 
     const usernames = store.getState().usernames;
-    expect(usernames).toEqual({});
+    expect(usernames).toEqual([]);
   });
 });

--- a/packages/bierzo-wallet/src/store/usernames/reducer.ts
+++ b/packages/bierzo-wallet/src/store/usernames/reducer.ts
@@ -7,7 +7,7 @@ import * as actions from './actions';
 export interface BwUsername {
   readonly chainId: ChainId;
   readonly address: Address;
-  readonly username?: string;
+  readonly username: string;
 }
 
 export interface AddUsernamesActionType extends Action {

--- a/packages/bierzo-wallet/src/store/usernames/reducer.ts
+++ b/packages/bierzo-wallet/src/store/usernames/reducer.ts
@@ -1,31 +1,28 @@
-import { Address, ChainId } from '@iov/bcp';
+import { ChainAddressPair } from '@iov/bns';
 import { Action } from 'redux';
 import { ActionType } from 'typesafe-actions';
 
 import * as actions from './actions';
 
 export interface BwUsername {
-  readonly chainId: ChainId;
-  readonly address: Address;
   readonly username: string;
+  readonly addresses: readonly ChainAddressPair[];
 }
 
 export interface AddUsernamesActionType extends Action {
-  type: '@@usernames/ADD';
-  payload: { [chainId: string]: BwUsername };
+  readonly type: '@@usernames/ADD';
+  readonly payload: readonly BwUsername[];
 }
 
 export type UserNameActions = ActionType<typeof actions>;
 
-export interface UsernamesState {
-  [chainId: string]: BwUsername;
-}
-const initState: UsernamesState = {};
+export type UsernamesState = readonly BwUsername[];
+const initState: UsernamesState = [];
 
 export function usernamesReducer(state: UsernamesState = initState, action: UserNameActions): UsernamesState {
   switch (action.type) {
     case '@@usernames/ADD':
-      return { ...state, ...action.payload };
+      return [...state, ...action.payload];
     default:
       return state;
   }

--- a/packages/bierzo-wallet/src/store/usernames/reducer.ts
+++ b/packages/bierzo-wallet/src/store/usernames/reducer.ts
@@ -21,8 +21,11 @@ const initState: UsernamesState = [];
 
 export function usernamesReducer(state: UsernamesState = initState, action: UserNameActions): UsernamesState {
   switch (action.type) {
-    case '@@usernames/ADD':
-      return [...state, ...action.payload];
+    case '@@usernames/ADD': {
+      const updatedNames = action.payload.map(name => name.username);
+      const oldNamesToCopy = state.filter(name => !updatedNames.includes(name.username));
+      return [...oldNamesToCopy, ...action.payload];
+    }
     default:
       return state;
   }

--- a/packages/bierzo-wallet/src/store/usernames/selectors.ts
+++ b/packages/bierzo-wallet/src/store/usernames/selectors.ts
@@ -2,6 +2,6 @@ import { RootState } from '../reducers';
 import { BwUsername } from '.';
 
 export const getFirstUsername = (state: RootState): BwUsername | undefined => {
-  const firstUsername = Object.values(state.usernames).find(() => true);
+  const firstUsername = state.usernames.find(() => true);
   return firstUsername;
 };


### PR DESCRIPTION
Closes #407; closes #408

------

- Avoid looping over chain connections
- Avoid connection.getAccount call for address calculation
- Store usernames in list
- Update and test usernamesReducer