### PR TITLE
Feature – Balance test refinements

### DIFF
--- a/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
+++ b/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
@@ -12,7 +12,7 @@ import {
 } from './test/operateBalances';
 import { travelToBalanceE2E } from './test/travelToBalance';
 
-withChainsDescribe('E2E > Balance route', (): void => {
+withChainsDescribe('E2E > Balance route', () => {
   let browser: Browser;
   let page: Page;
   let extensionPage: Page;
@@ -30,24 +30,22 @@ withChainsDescribe('E2E > Balance route', (): void => {
     server = app.listen(9000);
   });
 
-  beforeEach(async (): Promise<void> => {
+  beforeEach(async () => {
     browser = await launchBrowser();
     page = await createPage(browser);
     extensionPage = await createExtensionPage(browser);
     await travelToBalanceE2E(browser, page, extensionPage);
   }, 45000);
 
-  afterEach(
-    async (): Promise<void> => {
-      await closeBrowser(browser);
-    },
-  );
+  afterEach(async () => {
+    await closeBrowser(browser);
+  });
 
   afterAll(() => {
     server.close();
   });
 
-  it('should contain balances', async (): Promise<void> => {
+  it('should contain balances', async () => {
     const firstBalance = await getFirstCurrencyBalanceE2E(await page.$$('h6'));
     const secondBalance = await getSecondCurrencyBalanceE2E(await page.$$('h6'));
     const thirdBalance = await getThirdCurrencyBalanceE2E(await page.$$('h6'));
@@ -57,7 +55,7 @@ withChainsDescribe('E2E > Balance route', (): void => {
     expect(thirdBalance).toBe('10 ETH');
   }, 45000);
 
-  it('should contain message to get username', async (): Promise<void> => {
+  it('should contain message to get username', async () => {
     const username = await getUsernameE2E(await page.$$('h5'));
 
     expect(username).toBe('No human readable address registered.');

--- a/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
+++ b/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
@@ -4,12 +4,7 @@ import { Browser, Page } from 'puppeteer';
 
 import { closeBrowser, createExtensionPage, createPage, launchBrowser } from '../../utils/test/e2e';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
-import {
-  getFirstCurrencyBalanceE2E,
-  getSecondCurrencyBalanceE2E,
-  getThirdCurrencyBalanceE2E,
-  getUsernameE2E,
-} from './test/operateBalances';
+import { getBalanceTextAtIndex, getUsernameE2E } from './test/operateBalances';
 import { travelToBalanceE2E } from './test/travelToBalance';
 
 withChainsDescribe('E2E > Balance route', () => {
@@ -46,13 +41,13 @@ withChainsDescribe('E2E > Balance route', () => {
   });
 
   it('should contain balances', async () => {
-    const firstBalance = await getFirstCurrencyBalanceE2E(await page.$$('h6'));
-    const secondBalance = await getSecondCurrencyBalanceE2E(await page.$$('h6'));
-    const thirdBalance = await getThirdCurrencyBalanceE2E(await page.$$('h6'));
+    const balances = [
+      await getBalanceTextAtIndex(await page.$$('h6'), 0),
+      await getBalanceTextAtIndex(await page.$$('h6'), 1),
+      await getBalanceTextAtIndex(await page.$$('h6'), 2),
+    ];
 
-    expect(firstBalance).toBe('10 BASH');
-    expect(secondBalance).toBe('10 CASH');
-    expect(thirdBalance).toBe('10 ETH');
+    expect(balances).toEqual(['10 BASH', '10 CASH', '10 ETH']);
   }, 45000);
 
   it('should contain message to get username', async () => {

--- a/packages/bierzo-wallet/src/routes/balance/test/operateBalances.ts
+++ b/packages/bierzo-wallet/src/routes/balance/test/operateBalances.ts
@@ -8,16 +8,12 @@ export const getIovUsername = (h5Elements: Element[]): string => {
   return h5Elements[0].textContent || '';
 };
 
-export const getFirstCurrencyBalanceE2E = async (h6Elements: ElementHandle<Element>[]): Promise<string> => {
-  return (await (await h6Elements[5].getProperty('textContent')).jsonValue()) || '';
-};
-
-export const getSecondCurrencyBalanceE2E = async (h6Elements: ElementHandle<Element>[]): Promise<string> => {
-  return (await (await h6Elements[6].getProperty('textContent')).jsonValue()) || '';
-};
-
-export const getThirdCurrencyBalanceE2E = async (h6Elements: ElementHandle<Element>[]): Promise<string> => {
-  return (await (await h6Elements[7].getProperty('textContent')).jsonValue()) || '';
+export const getBalanceTextAtIndex = async (
+  h6Elements: ElementHandle<Element>[],
+  index: number,
+): Promise<string> => {
+  const property = await h6Elements[5 + index].getProperty('textContent');
+  return (await property.jsonValue()) || '';
 };
 
 export const getUsernameE2E = async (h5Elements: ElementHandle<Element>[]): Promise<string> => {


### PR DESCRIPTION
We'll soon have to deal with many more balance entries (e.g. LSK coming in #420). This improves test code a bit

* Merge `getFirstCurrencyBalanceE2E`, `getSecondCurrencyBalanceE2E`, `getThirdCurrencyBalanceE2E` into `getBalanceTextAtIndex`
* Avoid the use of one new variable name per balance entry