### PR TITLE
Feature – Run faucet calls in background and in parallel

### DIFF
--- a/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
+++ b/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
@@ -4,6 +4,7 @@ import { Browser, Page } from 'puppeteer';
 
 import { closeBrowser, createExtensionPage, createPage, launchBrowser } from '../../utils/test/e2e';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
+import { sleep } from '../../utils/timer';
 import { getBalanceTextAtIndex, getUsernameE2E } from './test/operateBalances';
 import { travelToBalanceE2E } from './test/travelToBalance';
 
@@ -30,7 +31,7 @@ withChainsDescribe('E2E > Balance route', () => {
     page = await createPage(browser);
     extensionPage = await createExtensionPage(browser);
     await travelToBalanceE2E(browser, page, extensionPage);
-  }, 60000);
+  }, 30000);
 
   afterEach(async () => {
     await closeBrowser(browser);
@@ -41,6 +42,8 @@ withChainsDescribe('E2E > Balance route', () => {
   });
 
   it('should contain balances', async () => {
+    await sleep(18000); // wait for faucet to finish its job
+
     const balances = [
       await getBalanceTextAtIndex(await page.$$('h6'), 0),
       await getBalanceTextAtIndex(await page.$$('h6'), 1),

--- a/packages/bierzo-wallet/src/routes/login/index.tsx
+++ b/packages/bierzo-wallet/src/routes/login/index.tsx
@@ -25,7 +25,9 @@ export const loginBootSequence = async (
   const chainTokens = await getTokens();
   dispatch(addTickersAction(chainTokens));
 
-  await drinkFaucetIfNeeded(keys);
+  // Do not block the use of the wallet just because the faucet might take
+  // some time send tokens
+  drinkFaucetIfNeeded(keys).catch(console.error);
 
   const balances = await getBalances(keys);
   dispatch(addBalancesAction(balances));

--- a/packages/bierzo-wallet/src/routes/payment/components/CurrencyToSend/index.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/components/CurrencyToSend/index.tsx
@@ -47,23 +47,24 @@ const CurrencyToSend = ({ form }: Props): JSX.Element => {
     .sort()
     .map((ticker): Item => ({ name: ticker }));
 
-  const [balance, setBalance] = useState(balances[currencyItems[0].name]);
+  const firstToken = currencyItems.find(() => true);
+  const [selectedTokenTicker, setSelectedTokenTicker] = useState(firstToken ? firstToken.name : undefined);
 
   const validator = useMemo(() => {
     return composeValidators(
       required,
       number,
-      lowerOrEqualThan(amountToNumber(balance)),
+      lowerOrEqualThan(selectedTokenTicker ? amountToNumber(balances[selectedTokenTicker]) : 0),
       greaterOrEqualThan(QUANTITY_MIN),
     );
-  }, [balance]);
+  }, [balances, selectedTokenTicker]);
 
   const avatarClasses = {
     root: classes.avatar,
   };
 
-  const handleChange = (item: Item): void => {
-    setBalance(balances[item.name]);
+  const onTokenSelectionChanged = (item: Item): void => {
+    setSelectedTokenTicker(item.name);
   };
 
   return (
@@ -93,15 +94,15 @@ const CurrencyToSend = ({ form }: Props): JSX.Element => {
                 form={form}
                 maxWidth="60px"
                 items={currencyItems}
-                initial={balance.tokenTicker}
-                onChangeCallback={handleChange}
+                initial={firstToken ? firstToken.name : '–'}
+                onChangeCallback={onTokenSelectionChanged}
               />
             </Block>
           </Block>
         </Block>
         <Block marginTop={1}>
           <Typography color="textSecondary" variant="subtitle2">
-            balance: {amountToString(balance)}
+            balance: {selectedTokenTicker ? amountToString(balances[selectedTokenTicker]) : '–'}
           </Typography>
         </Block>
       </Block>

--- a/packages/bierzo-wallet/src/routes/payment/components/CurrencyToSend/index.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/components/CurrencyToSend/index.tsx
@@ -43,9 +43,9 @@ const CurrencyToSend = ({ form }: Props): JSX.Element => {
   const balances = ReactRedux.useSelector((state: RootState) => state.balances);
   const classes = useStyles();
 
-  const currencyItems = Object.keys(balances).map(balance => ({
-    name: balance,
-  }));
+  const currencyItems = Object.keys(balances)
+    .sort()
+    .map((ticker): Item => ({ name: ticker }));
 
   const [balance, setBalance] = useState(balances[currencyItems[0].name]);
 

--- a/packages/bierzo-wallet/src/routes/payment/index.e2e.spec.ts
+++ b/packages/bierzo-wallet/src/routes/payment/index.e2e.spec.ts
@@ -13,6 +13,7 @@ import {
 import { openEnqueuedRequest, rejectEnqueuedRequest } from '../../utils/test/persona';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
 import { sleep } from '../../utils/timer';
+import { travelToBalanceE2E } from '../balance/test/travelToBalance';
 import { fillPaymentForm, getPaymentRequestData } from './test/operatePayment';
 import { travelToPaymentE2E } from './test/travelToPayment';
 
@@ -38,7 +39,6 @@ withChainsDescribe('E2E > Payment route', () => {
     browser = await launchBrowser();
     page = await createPage(browser);
     extensionPage = await createExtensionPage(browser);
-    await travelToPaymentE2E(browser, page, extensionPage);
   }, 60000);
 
   afterEach(async () => {
@@ -50,6 +50,10 @@ withChainsDescribe('E2E > Payment route', () => {
   });
 
   it('should have proper information about payment request', async () => {
+    await travelToBalanceE2E(browser, page, extensionPage);
+    await sleep(18000); // wait for faucet to finish its job
+
+    await travelToPaymentE2E(page);
     await fillPaymentForm(page);
     await openEnqueuedRequest(extensionPage);
     await sleep(1000);
@@ -61,9 +65,13 @@ withChainsDescribe('E2E > Payment route', () => {
     expect(beneficiary).toBe('tiov1q5lyl7asgr2dcweqrhlfyexqpkgcuzrm4e0cku');
     expect(amount).toBe('1 BASH');
     expect(fee).toBe('0.01 CASH');
-  }, 25000);
+  }, 35000);
 
   it('should show toast message in case if payment will be rejected', async () => {
+    await travelToBalanceE2E(browser, page, extensionPage);
+    await sleep(18000); // wait for faucet to finish its job
+
+    await travelToPaymentE2E(page);
     await fillPaymentForm(page);
     await rejectEnqueuedRequest(extensionPage);
     await page.bringToFront();
@@ -71,5 +79,5 @@ withChainsDescribe('E2E > Payment route', () => {
     const toastMessage = await getToastMessage(page);
     expect(toastMessage).toBe('Request rejected');
     await closeToast(page);
-  }, 25000);
+  }, 35000);
 });

--- a/packages/bierzo-wallet/src/routes/payment/test/travelToPayment.ts
+++ b/packages/bierzo-wallet/src/routes/payment/test/travelToPayment.ts
@@ -1,11 +1,10 @@
-import { Browser, Page } from 'puppeteer';
+import { Page } from 'puppeteer';
 import TestUtils from 'react-dom/test-utils';
 import { Store } from 'redux';
 
 import { history } from '../../../routes';
 import { createDom } from '../../../utils/test/dom';
 import { whenOnNavigatedToE2eRoute, whenOnNavigatedToRoute } from '../../../utils/test/navigation';
-import { travelToBalanceE2E } from '../../balance/test/travelToBalance';
 import { PAYMENT_ROUTE } from '../../paths';
 
 export const travelToPayment = async (store: Store): Promise<React.Component> => {
@@ -18,8 +17,7 @@ export const travelToPayment = async (store: Store): Promise<React.Component> =>
   return dom;
 };
 
-export async function travelToPaymentE2E(browser: Browser, page: Page, extensionPage: Page): Promise<void> {
-  await travelToBalanceE2E(browser, page, extensionPage);
+export async function travelToPaymentE2E(page: Page): Promise<void> {
   await page.click(`#${PAYMENT_ROUTE.replace('/', '\\/')}`);
   await whenOnNavigatedToE2eRoute(page, PAYMENT_ROUTE);
 }

--- a/packages/bierzo-wallet/src/routes/transactions/index.e2e.spec.ts
+++ b/packages/bierzo-wallet/src/routes/transactions/index.e2e.spec.ts
@@ -6,6 +6,7 @@ import { TRANSACTIONS_TEXT } from '../../components/Header/components/LinksMenu'
 import { closeBrowser, createExtensionPage, createPage, launchBrowser } from '../../utils/test/e2e';
 import { whenOnNavigatedToE2eRoute } from '../../utils/test/navigation';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
+import { sleep } from '../../utils/timer';
 import { travelToBalanceE2E } from '../balance/test/travelToBalance';
 import { TRANSACTIONS_ROUTE } from '../paths';
 
@@ -43,6 +44,8 @@ withChainsDescribe('E2E > Transactions route', () => {
   });
 
   it('contains two transactions', async () => {
+    await sleep(18000); // wait for faucet to finish its job
+
     const [txLink] = await page.$x(`//h6[contains(., '${TRANSACTIONS_TEXT}')]`);
     await txLink.click();
     await whenOnNavigatedToE2eRoute(page, TRANSACTIONS_ROUTE);

--- a/packages/bierzo-wallet/src/utils/test/e2e.ts
+++ b/packages/bierzo-wallet/src/utils/test/e2e.ts
@@ -20,7 +20,7 @@ export async function createPage(browser: Browser): Promise<Page> {
     waitUntil: 'networkidle2',
   });
   page.on('console', msg => console.log('PAGE LOG:', msg.text()));
-  page.bringToFront();
+  await page.bringToFront();
 
   return page;
 }
@@ -33,7 +33,7 @@ export async function createExtensionPage(browser: Browser): Promise<Page> {
     waitUntil: 'networkidle2',
   });
   page.on('console', msg => console.log('EXTENSION PAGE LOG:', msg.text()));
-  page.bringToFront();
+  await page.bringToFront();
 
   return page;
 }

--- a/packages/sanes-chrome-extension/src/utils/test/e2e.ts
+++ b/packages/sanes-chrome-extension/src/utils/test/e2e.ts
@@ -25,7 +25,7 @@ export async function createPage(browser: Browser): Promise<Page> {
   });
   // eslint-disable-next-line no-console
   page.on('console', msg => console.log('PAGE LOG:', msg.text()));
-  page.bringToFront();
+  await page.bringToFront();
 
   return page;
 }

--- a/packages/sil-voting-app/src/utils/test/e2e.ts
+++ b/packages/sil-voting-app/src/utils/test/e2e.ts
@@ -20,7 +20,7 @@ export async function createPage(browser: Browser): Promise<Page> {
     waitUntil: 'networkidle2',
   });
   page.on('console', msg => console.log('PAGE LOG:', msg.text()));
-  page.bringToFront();
+  await page.bringToFront();
 
   return page;
 }
@@ -33,7 +33,7 @@ export async function createExtensionPage(browser: Browser): Promise<Page> {
     waitUntil: 'networkidle2',
   });
   page.on('console', msg => console.log('EXTENSION PAGE LOG:', msg.text()));
-  page.bringToFront();
+  await page.bringToFront();
 
   return page;
 }


### PR DESCRIPTION
This allows the user to go into the app without waiting for the faucet calls to be done (which can be very slow). It also speeds up all tests that do not depend on faucet balances, since the app can be used quickly. Only tests that require the faucet funds have an explicit sleep that can be refactored in a next step to something that checks the incoming balances. This should stabilize e2e tests of the wallet.

Additionally a bug was fixed that crashed the app when the user had no balance (i.e. `balances = []`).