### PR TITLE
Feature – Speedup wait for faucet

### DIFF
--- a/packages/bierzo-wallet/src/config/index.ts
+++ b/packages/bierzo-wallet/src/config/index.ts
@@ -14,6 +14,15 @@ export interface ChainConfig {
   readonly faucetSpec?: FaucetSpec;
 }
 
+/** Like ChainConfig but with non-optional faucet */
+export interface ChainConfigWithFaucet extends ChainConfig {
+  readonly faucetSpec: FaucetSpec;
+}
+
+export function isChainConfigWithFaucet(chain: ChainConfig): chain is ChainConfigWithFaucet {
+  return !!chain.faucetSpec;
+}
+
 export interface ConfigErc20Options {
   readonly contractAddress: string;
   readonly symbol: string;

--- a/packages/bierzo-wallet/src/logic/faucet.ts
+++ b/packages/bierzo-wallet/src/logic/faucet.ts
@@ -2,23 +2,17 @@ import { Identity, TokenTicker } from '@iov/bcp';
 import { TransactionEncoder } from '@iov/encoding';
 import { IovFaucet } from '@iov/faucets';
 
-import { getConfig } from '../config';
+import { getConfig, isChainConfigWithFaucet } from '../config';
 import { filterExistingTokens } from '../utils/tokens';
 import { getCodec } from './codec';
 import { getConnectionFor } from './connection';
 
 export async function drinkFaucetIfNeeded(keys: { [chain: string]: string }): Promise<void> {
-  const config = getConfig();
-  const chains = config.chains;
+  const chainsWithFaucet = getConfig().chains.filter(isChainConfigWithFaucet);
 
-  for (const chain of chains) {
-    const faucetSpec = chain.faucetSpec;
-    if (!faucetSpec) {
-      continue;
-    }
-
-    const codec = getCodec(chain.chainSpec);
-    const connection = await getConnectionFor(chain.chainSpec);
+  for (const { chainSpec, faucetSpec } of chainsWithFaucet) {
+    const codec = getCodec(chainSpec);
+    const connection = await getConnectionFor(chainSpec);
     const chainId = connection.chainId() as string;
     const plainPubkey = keys[chainId];
     if (!plainPubkey) {

--- a/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
+++ b/packages/bierzo-wallet/src/routes/balance/index.e2e.spec.ts
@@ -4,8 +4,7 @@ import { Browser, Page } from 'puppeteer';
 
 import { closeBrowser, createExtensionPage, createPage, launchBrowser } from '../../utils/test/e2e';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
-import { sleep } from '../../utils/timer';
-import { getBalanceTextAtIndex, getUsernameE2E } from './test/operateBalances';
+import { getBalanceTextAtIndex, getUsernameE2E, waitForAllBalances } from './test/operateBalances';
 import { travelToBalanceE2E } from './test/travelToBalance';
 
 withChainsDescribe('E2E > Balance route', () => {
@@ -42,7 +41,7 @@ withChainsDescribe('E2E > Balance route', () => {
   });
 
   it('should contain balances', async () => {
-    await sleep(18000); // wait for faucet to finish its job
+    await waitForAllBalances(page);
 
     const balances = [
       await getBalanceTextAtIndex(await page.$$('h6'), 0),

--- a/packages/bierzo-wallet/src/routes/balance/test/operateBalances.ts
+++ b/packages/bierzo-wallet/src/routes/balance/test/operateBalances.ts
@@ -2,6 +2,9 @@ import { ElementHandle, Page } from 'puppeteer';
 
 import { whenTrue } from '../../../utils/test/navigation';
 
+const nonBalanceH6Elements = 5;
+const numberOfTokensFromFaucet = 4;
+
 export const getNoFundsMessage = (h6Elements: Element[]): string => {
   return h6Elements[4].textContent || '';
 };
@@ -14,14 +17,11 @@ export const getBalanceTextAtIndex = async (
   h6Elements: ElementHandle<Element>[],
   index: number,
 ): Promise<string> => {
-  const property = await h6Elements[5 + index].getProperty('textContent');
+  const property = await h6Elements[nonBalanceH6Elements + index].getProperty('textContent');
   return (await property.jsonValue()) || '';
 };
 
 export function waitForAllBalances(page: Page): Promise<void> {
-  const nonBalanceH6Elements = 5;
-  const numberOfTokensFromFaucet = 4;
-
   return whenTrue(async () => {
     return (await page.$$('h6')).length >= nonBalanceH6Elements + numberOfTokensFromFaucet;
   }, 20000);

--- a/packages/bierzo-wallet/src/routes/balance/test/operateBalances.ts
+++ b/packages/bierzo-wallet/src/routes/balance/test/operateBalances.ts
@@ -1,4 +1,6 @@
-import { ElementHandle } from 'puppeteer';
+import { ElementHandle, Page } from 'puppeteer';
+
+import { whenTrue } from '../../../utils/test/navigation';
 
 export const getNoFundsMessage = (h6Elements: Element[]): string => {
   return h6Elements[4].textContent || '';
@@ -15,6 +17,15 @@ export const getBalanceTextAtIndex = async (
   const property = await h6Elements[5 + index].getProperty('textContent');
   return (await property.jsonValue()) || '';
 };
+
+export function waitForAllBalances(page: Page): Promise<void> {
+  const nonBalanceH6Elements = 5;
+  const numberOfTokensFromFaucet = 4;
+
+  return whenTrue(async () => {
+    return (await page.$$('h6')).length >= nonBalanceH6Elements + numberOfTokensFromFaucet;
+  }, 20000);
+}
 
 export const getUsernameE2E = async (h5Elements: ElementHandle<Element>[]): Promise<string> => {
   return (await (await h5Elements[0].getProperty('textContent')).jsonValue()) || '';

--- a/packages/bierzo-wallet/src/routes/payment/index.e2e.spec.ts
+++ b/packages/bierzo-wallet/src/routes/payment/index.e2e.spec.ts
@@ -14,6 +14,7 @@ import { acceptEnqueuedRequest, openEnqueuedRequest, rejectEnqueuedRequest } fro
 import { findRenderedE2EComponentWithId } from '../../utils/test/reactElemFinder';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
 import { sleep } from '../../utils/timer';
+import { waitForAllBalances } from '../balance/test/operateBalances';
 import { travelToBalanceE2E } from '../balance/test/travelToBalance';
 import { PAYMENT_CONFIRMATION_VIEW_ID } from './components/ConfirmPayment';
 import { fillPaymentForm, getInvalidAddressError, getPaymentRequestData } from './test/operatePayment';
@@ -53,7 +54,7 @@ withChainsDescribe('E2E > Payment route', () => {
 
   it('should make payment and redirected to payment confirmation page', async () => {
     await travelToBalanceE2E(browser, page, extensionPage);
-    await sleep(18000); // wait for faucet to finish its job
+    await waitForAllBalances(page);
 
     await travelToPaymentE2E(page);
     await fillPaymentForm(page, '1', 'tiov1q5lyl7asgr2dcweqrhlfyexqpkgcuzrm4e0cku');
@@ -64,7 +65,7 @@ withChainsDescribe('E2E > Payment route', () => {
 
   it('should not let to make payment address is not valid', async () => {
     await travelToBalanceE2E(browser, page, extensionPage);
-    await sleep(18000); // wait for faucet to finish its job
+    await waitForAllBalances(page);
 
     await travelToPaymentE2E(page);
     await fillPaymentForm(page, '1', 'not_valid_address');
@@ -74,7 +75,7 @@ withChainsDescribe('E2E > Payment route', () => {
 
   it('should have proper information about payment request', async () => {
     await travelToBalanceE2E(browser, page, extensionPage);
-    await sleep(18000); // wait for faucet to finish its job
+    await waitForAllBalances(page);
 
     await travelToPaymentE2E(page);
     await fillPaymentForm(page, '1', 'tiov1q5lyl7asgr2dcweqrhlfyexqpkgcuzrm4e0cku');
@@ -92,7 +93,7 @@ withChainsDescribe('E2E > Payment route', () => {
 
   it('should show toast message in case if payment will be rejected', async () => {
     await travelToBalanceE2E(browser, page, extensionPage);
-    await sleep(18000); // wait for faucet to finish its job
+    await waitForAllBalances(page);
 
     await travelToPaymentE2E(page);
     await fillPaymentForm(page, '1', 'tiov1q5lyl7asgr2dcweqrhlfyexqpkgcuzrm4e0cku');

--- a/packages/bierzo-wallet/src/routes/transactions/index.e2e.spec.ts
+++ b/packages/bierzo-wallet/src/routes/transactions/index.e2e.spec.ts
@@ -4,7 +4,7 @@ import { Browser, Page } from 'puppeteer';
 
 import { TRANSACTIONS_TEXT } from '../../components/Header/components/LinksMenu';
 import { closeBrowser, createExtensionPage, createPage, launchBrowser } from '../../utils/test/e2e';
-import { whenOnNavigatedToE2eRoute } from '../../utils/test/navigation';
+import { whenOnNavigatedToE2eRoute, whenTrue } from '../../utils/test/navigation';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
 import { waitForAllBalances } from '../balance/test/operateBalances';
 import { travelToBalanceE2E } from '../balance/test/travelToBalance';
@@ -43,16 +43,20 @@ withChainsDescribe('E2E > Transactions route', () => {
     server.close();
   });
 
-  it('contains two transactions', async () => {
+  it('contains faucet transactions', async () => {
     await waitForAllBalances(page);
 
     const [txLink] = await page.$x(`//h6[contains(., '${TRANSACTIONS_TEXT}')]`);
     await txLink.click();
     await whenOnNavigatedToE2eRoute(page, TRANSACTIONS_ROUTE);
 
-    // Checking number of rows
+    const expectedRowCount = 3; // TODO update number to show ETH one when #412 is done
+
+    // wait for transaction events to populate screen
+    await whenTrue(async () => (await page.$$('img[alt="Transaction type"]')).length >= expectedRowCount);
+
+    // TODO: Run some tests in the content of those rows
     const rows = await page.$$('img[alt="Transaction type"]');
-    // TODO update number to show ETH one when #412 is done
-    expect(rows.length).toBe(3);
+    expect(rows.length).toBe(expectedRowCount);
   }, 45000);
 });

--- a/packages/bierzo-wallet/src/routes/transactions/index.e2e.spec.ts
+++ b/packages/bierzo-wallet/src/routes/transactions/index.e2e.spec.ts
@@ -6,7 +6,7 @@ import { TRANSACTIONS_TEXT } from '../../components/Header/components/LinksMenu'
 import { closeBrowser, createExtensionPage, createPage, launchBrowser } from '../../utils/test/e2e';
 import { whenOnNavigatedToE2eRoute } from '../../utils/test/navigation';
 import { withChainsDescribe } from '../../utils/test/testExecutor';
-import { sleep } from '../../utils/timer';
+import { waitForAllBalances } from '../balance/test/operateBalances';
 import { travelToBalanceE2E } from '../balance/test/travelToBalance';
 import { TRANSACTIONS_ROUTE } from '../paths';
 
@@ -44,7 +44,7 @@ withChainsDescribe('E2E > Transactions route', () => {
   });
 
   it('contains two transactions', async () => {
-    await sleep(18000); // wait for faucet to finish its job
+    await waitForAllBalances(page);
 
     const [txLink] = await page.$x(`//h6[contains(., '${TRANSACTIONS_TEXT}')]`);
     await txLink.click();

--- a/packages/bierzo-wallet/src/utils/test/navigation.ts
+++ b/packages/bierzo-wallet/src/utils/test/navigation.ts
@@ -1,6 +1,6 @@
 import { Page } from 'puppeteer';
 
-const retryInterval = 500;
+const retryInterval = 400;
 
 /**
  * Calls callback until it returns true or timeout is reachend.

--- a/packages/bierzo-wallet/src/utils/test/navigation.ts
+++ b/packages/bierzo-wallet/src/utils/test/navigation.ts
@@ -1,13 +1,13 @@
 import { Page } from 'puppeteer';
 
-const MAX_TIMES_EXECUTED = 35;
-const INTERVAL = 500;
+const retryInterval = 500;
+const defaultTimeout = 18000;
 
 export const whenOnNavigatedToRoute = (desiredRoute: string): Promise<void> =>
   new Promise((resolve, reject): void => {
-    let times = 0;
+    const startTime = Date.now();
     const interval = setInterval((): void => {
-      if (times >= MAX_TIMES_EXECUTED) {
+      if (Date.now() - startTime >= defaultTimeout) {
         clearInterval(interval);
         reject(`Unable to navigate to ${desiredRoute}`);
       } else {
@@ -16,16 +16,15 @@ export const whenOnNavigatedToRoute = (desiredRoute: string): Promise<void> =>
           clearInterval(interval);
           resolve();
         }
-        times += 1;
       }
-    }, INTERVAL);
+    }, retryInterval);
   });
 
 export const whenOnNavigatedToE2eRoute = (page: Page, desiredRoute: string): Promise<void> =>
   new Promise((resolve, reject): void => {
-    let times = 0;
+    const startTime = Date.now();
     const interval = setInterval((): void => {
-      if (times >= MAX_TIMES_EXECUTED) {
+      if (Date.now() - startTime >= defaultTimeout) {
         clearInterval(interval);
         reject(`Unable to navigate to ${desiredRoute}`);
       } else {
@@ -34,7 +33,6 @@ export const whenOnNavigatedToE2eRoute = (page: Page, desiredRoute: string): Pro
           clearInterval(interval);
           resolve();
         }
-        times += 1;
       }
-    }, INTERVAL);
+    }, retryInterval);
   });

--- a/packages/bierzo-wallet/src/utils/test/navigation.ts
+++ b/packages/bierzo-wallet/src/utils/test/navigation.ts
@@ -10,13 +10,14 @@ export const whenOnNavigatedToRoute = (desiredRoute: string): Promise<void> =>
       if (times >= MAX_TIMES_EXECUTED) {
         clearInterval(interval);
         reject(`Unable to navigate to ${desiredRoute}`);
+      } else {
+        const actualRoute = window.location.pathname;
+        if (actualRoute === desiredRoute) {
+          clearInterval(interval);
+          resolve();
+        }
+        times += 1;
       }
-      const actualRoute = window.location.pathname;
-      if (actualRoute === desiredRoute) {
-        clearInterval(interval);
-        resolve();
-      }
-      times += 1;
     }, INTERVAL);
   });
 
@@ -27,12 +28,13 @@ export const whenOnNavigatedToE2eRoute = (page: Page, desiredRoute: string): Pro
       if (times >= MAX_TIMES_EXECUTED) {
         clearInterval(interval);
         reject(`Unable to navigate to ${desiredRoute}`);
+      } else {
+        const actualRoute = page.url();
+        if (actualRoute.endsWith(desiredRoute)) {
+          clearInterval(interval);
+          resolve();
+        }
+        times += 1;
       }
-      const actualRoute = page.url();
-      if (actualRoute.endsWith(desiredRoute)) {
-        clearInterval(interval);
-        resolve();
-      }
-      times += 1;
     }, INTERVAL);
   });

--- a/packages/bierzo-wallet/src/utils/test/navigation.ts
+++ b/packages/bierzo-wallet/src/utils/test/navigation.ts
@@ -9,16 +9,16 @@ const retryInterval = 400;
  * @param timeout timeout in milliseconds. Defaults to 10 seconds
  * @returns a promise that resolves when the callback returned true and is rejected when timeout is reached.
  */
-export function whenTrue(callback: () => boolean, timeout: number = 10000): Promise<void> {
+export function whenTrue(callback: () => boolean | Promise<boolean>, timeout: number = 10000): Promise<void> {
   return new Promise((resolve, reject): void => {
     const startTime = Date.now();
-    const interval = setInterval((): void => {
+    const interval = setInterval(async () => {
       const runtime = Date.now() - startTime;
       if (runtime >= timeout) {
         clearInterval(interval);
         reject(`Timeout reached after ${runtime} ms`);
       } else {
-        if (callback()) {
+        if (await callback()) {
           clearInterval(interval);
           resolve();
         }


### PR DESCRIPTION
* Faucets run in parallel now (one job per chain)
* Deduplicate logic of `whenOnNavigatedToRoute` and `whenOnNavigatedToE2eRoute`
* Replace 18s sleep with balance list observer
* Replace magic number with `nonBalanceH6Elements` constant
* Reduce retry interval from 500ms to 400ms