### PR TITLE
Fix #439 - Float number validator

### DIFF
--- a/packages/bierzo-wallet/src/routes/payment/components/CurrencyToSend/index.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/components/CurrencyToSend/index.tsx
@@ -89,7 +89,7 @@ const CurrencyToSend = ({ form, onTokenSelectionChanged }: Props): JSX.Element =
                 name={QUANTITY_FIELD}
                 form={form}
                 validate={validator}
-                placeholder="0,00"
+                placeholder="0.00"
                 fullWidth
                 margin="none"
               />

--- a/packages/medulas-react-components/src/utils/forms/validators/index.tsx
+++ b/packages/medulas-react-components/src/utils/forms/validators/index.tsx
@@ -20,12 +20,8 @@ export const required: FieldValidator = (value): ValidationError => {
   return value ? undefined : 'Required';
 };
 
-export const toValidFloat = (value: string): number => {
-  return Number(value.replace(',', '.'));
-};
-
 export const number: FieldValidator = (value): ValidationError => {
-  return Number.isNaN(toValidFloat(value)) ? 'Must be a number' : undefined;
+  return Number.isNaN(value) ? 'Must be a number' : undefined;
 };
 
 export const validAddress: FieldValidator = (value): ValidationError => {

--- a/packages/medulas-react-components/src/utils/forms/validators/index.tsx
+++ b/packages/medulas-react-components/src/utils/forms/validators/index.tsx
@@ -20,8 +20,12 @@ export const required: FieldValidator = (value): ValidationError => {
   return value ? undefined : 'Required';
 };
 
+export const toValidFloat = (value: string): number => {
+  return Number(value.replace(',', '.'));
+};
+
 export const number: FieldValidator = (value): ValidationError => {
-  return !isNaN(value) ? undefined : 'Must be a number';
+  return Number.isNaN(toValidFloat(value)) ? 'Must be a number' : undefined;
 };
 
 export const validAddress: FieldValidator = (value): ValidationError => {

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2171,7 +2171,7 @@ exports[`Storyshots Bierzo wallet/Payment Payment 1`] = `
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
-                      placeholder="0,00"
+                      placeholder="0.00"
                       required={false}
                       type="text"
                     />


### PR DESCRIPTION
**Description**
This PR will fix float number validator and will allow to use float numbers with comma and point as decimal separator. It will close #439.

**Before**
<img width="921" alt="number-comma-error" src="https://user-images.githubusercontent.com/3502260/62193680-ec1cb180-b380-11e9-9fbc-253d043272c6.png">

**After**
![payment-number-placeholder](https://user-images.githubusercontent.com/3502260/62200176-8a167900-b38d-11e9-86c3-4fc4cdc9571d.png)

