### PR TITLE
Fix – Stabilize account selection

### DIFF
--- a/packages/bierzo-wallet/src/logic/connection.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/connection.unit.spec.ts
@@ -5,9 +5,7 @@ import { withChainsDescribe } from '../utils/test/testExecutor';
 import { disconnect, getConnectionFor } from './connection';
 
 withChainsDescribe('Logic :: connection', () => {
-  afterAll(async () => {
-    await disconnect();
-  });
+  afterAll(() => disconnect());
 
   it('calls connections only once', async () => {
     const config = getConfig();
@@ -35,7 +33,7 @@ withChainsDescribe('Logic :: connection', () => {
     await getConnectionFor(firstChain.chainSpec);
 
     // WHEN
-    await disconnect();
+    disconnect();
 
     // THEN
     expect(ethereumConnectionSpy).toHaveBeenCalledTimes(1);

--- a/packages/bierzo-wallet/src/logic/faucet.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/faucet.unit.spec.ts
@@ -5,9 +5,7 @@ import { disconnect } from './connection';
 import { drinkFaucetIfNeeded } from './faucet';
 
 withChainsDescribe('Logic :: faucet', () => {
-  afterAll(async () => {
-    await disconnect();
-  });
+  afterAll(() => disconnect());
 
   it('works', async () => {
     // generate keys

--- a/packages/bierzo-wallet/src/logic/transactions.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/transactions.unit.spec.ts
@@ -20,9 +20,9 @@ withChainsDescribe('Logic :: transaction subscriptions', () => {
       );
   });
 
-  afterAll(async () => {
+  afterAll(() => {
     jest.spyOn(tokens, 'filterExistingTokens').mockReset();
-    await disconnect();
+    disconnect();
   });
 
   it('fires transaction callback when account does something', async () => {

--- a/packages/bierzo-wallet/src/store/balances/index.unit.spec.ts
+++ b/packages/bierzo-wallet/src/store/balances/index.unit.spec.ts
@@ -7,9 +7,7 @@ import { getExtensionStatus, setExtensionStateAction } from '../extension';
 import { addBalancesAction, getBalances } from './actions';
 
 withChainsDescribe('Tokens reducer', () => {
-  afterAll(async () => {
-    await disconnect();
-  });
+  afterAll(() => disconnect());
 
   it('has correct initial state', async () => {
     const store = aNewStore();

--- a/packages/bierzo-wallet/src/store/extension/actions.ts
+++ b/packages/bierzo-wallet/src/store/extension/actions.ts
@@ -6,7 +6,7 @@ import { ExtensionState } from '../../store/extension';
 import { SetExtensionStateActionType } from './reducer';
 
 /**
- * Groups the identites by blockchain.
+ * Groups the identites by blockchain. Returns the first identity of each chain.
  *
  * TODO: Right now only the last identity per blockchain is returned. This should be generalized
  * to support multiple identities per blockchain.
@@ -14,7 +14,9 @@ import { SetExtensionStateActionType } from './reducer';
 export function groupIdentitiesByChain(identities: readonly Identity[]): { [chainId: string]: Identity } {
   const out: { [chainId: string]: Identity } = {};
   for (const identity of identities) {
-    out[identity.chainId] = identity;
+    if (!out.hasOwnProperty(identity.chainId)) {
+      out[identity.chainId] = identity;
+    }
   }
   return out;
 }

--- a/packages/bierzo-wallet/src/store/extension/actions.ts
+++ b/packages/bierzo-wallet/src/store/extension/actions.ts
@@ -8,8 +8,8 @@ import { SetExtensionStateActionType } from './reducer';
 /**
  * Groups the identites by blockchain. Returns the first identity of each chain.
  *
- * TODO: Right now only the last identity per blockchain is returned. This should be generalized
- * to support multiple identities per blockchain.
+ * The browser extension is supposed to only send one identity per chain.
+ * @see https://github.com/iov-one/ponferrada/issues/447
  */
 export function groupIdentitiesByChain(identities: readonly Identity[]): { [chainId: string]: Identity } {
   const out: { [chainId: string]: Identity } = {};

--- a/packages/bierzo-wallet/src/store/extension/actions.ts
+++ b/packages/bierzo-wallet/src/store/extension/actions.ts
@@ -11,7 +11,7 @@ import { SetExtensionStateActionType } from './reducer';
  * TODO: Right now only the last identity per blockchain is returned. This should be generalized
  * to support multiple identities per blockchain.
  */
-function groupIdentitiesByChain(identities: readonly Identity[]): { [chainId: string]: Identity } {
+export function groupIdentitiesByChain(identities: readonly Identity[]): { [chainId: string]: Identity } {
   const out: { [chainId: string]: Identity } = {};
   for (const identity of identities) {
     out[identity.chainId] = identity;

--- a/packages/bierzo-wallet/src/store/extension/actions.unit.spec.ts
+++ b/packages/bierzo-wallet/src/store/extension/actions.unit.spec.ts
@@ -1,0 +1,53 @@
+import { Algorithm, ChainId, Identity, PubkeyBytes } from '@iov/bcp';
+import { Encoding } from '@iov/encoding';
+
+import { groupIdentitiesByChain } from './actions';
+
+describe('groupIdentitiesByChain', () => {
+  const ethIdentity1: Identity = {
+    chainId: 'ethtest-1234' as ChainId,
+    pubkey: {
+      algo: Algorithm.Secp256k1,
+      data: Encoding.fromHex('aabbcc') as PubkeyBytes,
+    },
+  };
+
+  const ethIdentity2: Identity = {
+    chainId: 'ethtest-1234' as ChainId,
+    pubkey: {
+      algo: Algorithm.Secp256k1,
+      data: Encoding.fromHex('ddeeff') as PubkeyBytes,
+    },
+  };
+
+  const iovIdentity1: Identity = {
+    chainId: 'iovtest-1234' as ChainId,
+    pubkey: {
+      algo: Algorithm.Ed25519,
+      data: Encoding.fromHex('ddeeff') as PubkeyBytes,
+    },
+  };
+
+  it('works for an empty list', () => {
+    expect(groupIdentitiesByChain([])).toEqual({});
+  });
+
+  it('works for a single identity', () => {
+    expect(groupIdentitiesByChain([ethIdentity1])).toEqual({
+      'ethtest-1234': ethIdentity1,
+    });
+  });
+
+  it('works for multiple chains', () => {
+    expect(groupIdentitiesByChain([ethIdentity1, iovIdentity1])).toEqual({
+      'ethtest-1234': ethIdentity1,
+      'iovtest-1234': iovIdentity1,
+    });
+  });
+
+  it('returns last identity for each chain', () => {
+    expect(groupIdentitiesByChain([ethIdentity1, ethIdentity2])).toEqual({
+      'ethtest-1234': ethIdentity2,
+    });
+  });
+});

--- a/packages/bierzo-wallet/src/store/extension/actions.unit.spec.ts
+++ b/packages/bierzo-wallet/src/store/extension/actions.unit.spec.ts
@@ -45,9 +45,9 @@ describe('groupIdentitiesByChain', () => {
     });
   });
 
-  it('returns last identity for each chain', () => {
+  it('returns first identity for each chain', () => {
     expect(groupIdentitiesByChain([ethIdentity1, ethIdentity2])).toEqual({
-      'ethtest-1234': ethIdentity2,
+      'ethtest-1234': ethIdentity1,
     });
   });
 });

--- a/packages/bierzo-wallet/src/store/tokens/index.unit.spec.ts
+++ b/packages/bierzo-wallet/src/store/tokens/index.unit.spec.ts
@@ -4,9 +4,7 @@ import { withChainsDescribe } from '../../utils/test/testExecutor';
 import { addTickersAction, getTokens } from './actions';
 
 withChainsDescribe('Tokens reducer', () => {
-  afterAll(async () => {
-    await disconnect();
-  });
+  afterAll(() => disconnect());
 
   it('has correct initial state', async () => {
     const store = aNewStore();


### PR DESCRIPTION
Before, it was not specified which identity was used when the wallet got multiple per chain. Now it is documented and tested.