### PR TITLE
Feature - Remove generics on parsed tx

### DIFF
--- a/packages/bierzo-wallet/src/components/Header/components/BellMenu/index.tsx
+++ b/packages/bierzo-wallet/src/components/Header/components/BellMenu/index.tsx
@@ -19,8 +19,8 @@ import { BadgeProps, calcBadgeProps } from './badgeCalculator';
 import TxItem from './TxItem';
 
 interface Props {
-  readonly items: ReadonlyArray<ParsedTx<ProcessedTx>>;
-  readonly lastTx?: ParsedTx<ProcessedTx>;
+  readonly items: ReadonlyArray<ParsedTx>;
+  readonly lastTx?: ParsedTx;
 }
 
 const BellMenu = ({ items, lastTx }: Props): JSX.Element => {
@@ -29,12 +29,14 @@ const BellMenu = ({ items, lastTx }: Props): JSX.Element => {
       return;
     }
 
-    storeLastTx(lastTx);
+    // TODO remove automatic casting when supported multiple types
+    storeLastTx(lastTx as ProcessedTx);
   };
 
   const starter = (open: boolean): JSX.Element => {
     const logo = open ? bellGreen : bell;
-    const badgeProps: BadgeProps = calcBadgeProps(lastTx, getLastTx());
+    // TODO remove automatic casting when supported multiple types
+    const badgeProps: BadgeProps = calcBadgeProps(lastTx as ProcessedTx, getLastTx());
 
     return (
       <Block paddingLeft={5} paddingRight={5}>
@@ -60,10 +62,11 @@ const BellMenu = ({ items, lastTx }: Props): JSX.Element => {
       </Block>
       <Hairline />
       {hasItems ? (
-        items.map((item: ProcessedTx, index: number) => {
+        items.map((item: ParsedTx, index: number) => {
           const lastOne = index + 1 === items.length;
 
-          return <TxItem key={item.id} item={item} lastOne={lastOne} />;
+          // TODO remove automatic casting when supported multiple types
+          return <TxItem key={(item as ProcessedTx).id} item={item as ProcessedTx} lastOne={lastOne} />;
         })
       ) : (
         <EmptyListIcon src={upToDate} alt="Up to date" text="Up to date" />

--- a/packages/bierzo-wallet/src/components/Header/index.stories.tsx
+++ b/packages/bierzo-wallet/src/components/Header/index.stories.tsx
@@ -7,7 +7,6 @@ import * as React from 'react';
 import { ReadonlyDate } from 'readonly-date';
 import { DeepPartial } from 'redux';
 
-import { ParsedTx } from '../../logic/transactions/types/BwParser';
 import { ProcessedTx, Tx } from '../../store/notifications';
 import { RootState } from '../../store/reducers';
 import { stringToAmount } from '../../utils/balances';
@@ -29,7 +28,7 @@ const pendingTxs: ReadonlyArray<Tx> = [
   },
 ];
 
-const txs: ReadonlyArray<ParsedTx<ProcessedTx>> = [
+const txs: ReadonlyArray<ProcessedTx> = [
   {
     kind: 'bcp/send',
     received: true,
@@ -52,7 +51,7 @@ const txs: ReadonlyArray<ParsedTx<ProcessedTx>> = [
   },
 ];
 
-const faultTx: ParsedTx<ProcessedTx> = {
+const faultTx: ProcessedTx = {
   kind: 'bcp/error',
   received: false,
   sender: 'me',

--- a/packages/bierzo-wallet/src/components/Header/index.tsx
+++ b/packages/bierzo-wallet/src/components/Header/index.tsx
@@ -4,8 +4,6 @@ import Img from 'medulas-react-components/lib/components/Image';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 
-import { ParsedTx } from '../../logic/transactions/types/BwParser';
-import { ProcessedTx } from '../../store/notifications';
 import { getPendingTransactions } from '../../store/notifications/selectors';
 import logoBlack from './assets/logoBlack.svg';
 import BellMenu from './components/BellMenu';
@@ -31,8 +29,8 @@ interface Props {
 const Header = ({ path }: Props): JSX.Element => {
   const classes = useStyles();
   const pendingTxs = useSelector(getPendingTransactions);
-  const txs = useSelector(confirmedTxSelector) as ParsedTx<ProcessedTx>[];
-  const lastTx = useSelector(lastTxSelector) as ParsedTx<ProcessedTx> | undefined;
+  const txs = useSelector(confirmedTxSelector);
+  const lastTx = useSelector(lastTxSelector);
 
   return (
     <Block className={classes.root} padding={3}>

--- a/packages/bierzo-wallet/src/components/Header/selector.ts
+++ b/packages/bierzo-wallet/src/components/Header/selector.ts
@@ -5,7 +5,7 @@ import { getTransactions } from '../../store/notifications/selectors';
 
 export const confirmedTxSelector = createSelector(
   getTransactions,
-  (txs: ReadonlyArray<ParsedTx<{}>>) => {
+  (txs: ReadonlyArray<ParsedTx>) => {
     const min = Math.min(txs.length, 3);
 
     return txs.slice(0, min);
@@ -14,7 +14,7 @@ export const confirmedTxSelector = createSelector(
 
 export const lastTxSelector = createSelector(
   confirmedTxSelector,
-  (txs: ReadonlyArray<ParsedTx<{}>>) => {
+  (txs: ReadonlyArray<ParsedTx>) => {
     if (txs.length === 0) {
       return undefined;
     }

--- a/packages/bierzo-wallet/src/components/PageMenu/index.stories.tsx
+++ b/packages/bierzo-wallet/src/components/PageMenu/index.stories.tsx
@@ -28,6 +28,7 @@ const pendingTxs: ReadonlyArray<Tx> = [
 
 const txs: ReadonlyArray<ProcessedTx> = [
   {
+    kind: 'bcp/send',
     received: true,
     sender: 'george*iov',
     recipient: 'me',
@@ -37,6 +38,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     id: 'tx1',
   },
   {
+    kind: 'bcp/send',
     received: false,
     sender: 'me',
     recipient: 'alex*iov',
@@ -48,6 +50,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
 ];
 
 const faultTx: ProcessedTx = {
+  kind: 'bcp/send',
   received: false,
   sender: 'me',
   recipient: 'alex*iov',

--- a/packages/bierzo-wallet/src/logic/transactions/index.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/transactions/index.unit.spec.ts
@@ -10,7 +10,6 @@ import * as tokens from '../../utils/tokens';
 import { disconnect } from '../connection';
 import { drinkFaucetIfNeeded } from '../faucet';
 import { subscribeTransaction, unsubscribeTransactions } from '../transactions';
-import { ParsedTx } from './types/BwParser';
 
 withChainsDescribe('Logic :: transaction subscriptions', () => {
   beforeAll(() => {
@@ -30,7 +29,7 @@ withChainsDescribe('Logic :: transaction subscriptions', () => {
   it('fires transaction callback when account does something', async () => {
     const txsSpy = jest.spyOn(transactionActions, 'addTransaction') as jest.SpyInstance<
       transactionActions.AddTransactionActionType<ProcessedTx>,
-      [ParsedTx<ProcessedTx>]
+      [ProcessedTx]
     >;
 
     const store = aNewStore();

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwParser.ts
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwParser.ts
@@ -7,14 +7,14 @@ import {
 } from '@iov/bcp';
 import { ReadonlyDate } from 'readonly-date';
 
-export type ParsedTx<T> = Pick<LightTransaction, 'kind'> & { time: ReadonlyDate } & T;
+export type ParsedTx = Pick<LightTransaction, 'kind'> & { time: ReadonlyDate };
 
 export abstract class BwParser<K> {
   abstract async parse(
     conn: BlockchainConnection,
     transaction: ConfirmedTransaction<LightTransaction> | FailedTransaction,
     currentUserAddress: Address,
-  ): Promise<ParsedTx<K>>;
-  abstract graphicalRepresentation(tx: ParsedTx<K>): JSX.Element;
-  abstract csvRepresentation(tx: ParsedTx<K>): string;
+  ): Promise<ParsedTx>;
+  abstract graphicalRepresentation(tx: ParsedTx): JSX.Element;
+  abstract csvRepresentation(tx: ParsedTx): string;
 }

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwParserFactory.ts
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwParserFactory.ts
@@ -9,19 +9,20 @@ import {
 
 import { BwParser, ParsedTx } from '../types/BwParser';
 import { BwSendParser } from './BwSendTransaction';
+import { BwSendProps } from './BwSendTransaction/ui';
 
 export class BwParserFactory {
-  public static getReactComponent(tx: ParsedTx<any>): JSX.Element {
+  public static getReactComponent(tx: any): JSX.Element {
     if (isSendTransaction({ kind: tx.kind })) {
-      return new BwSendParser().graphicalRepresentation(tx);
+      return new BwSendParser().graphicalRepresentation(tx as BwSendProps);
     }
 
     throw new Error('Not supporting generic components yet');
   }
 
-  public static getCsvRepresentation(tx: ParsedTx<any>): string {
+  public static getCsvRepresentation(tx: any): string {
     if (isSendTransaction({ kind: tx.kind })) {
-      return new BwSendParser().csvRepresentation(tx);
+      return new BwSendParser().csvRepresentation(tx as BwSendProps);
     }
 
     throw new Error('Not supporting generic components yet');
@@ -29,7 +30,7 @@ export class BwParserFactory {
 
   public static getBwTransactionFrom(
     trans: ConfirmedTransaction<LightTransaction> | FailedTransaction,
-  ): BwParser<ParsedTx<any>> {
+  ): BwParser<ParsedTx> {
     if (isFailedTransaction(trans)) {
       throw new Error('Not supported error txs for now');
     }

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwSendTransaction/index.tsx
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwSendTransaction/index.tsx
@@ -1,16 +1,15 @@
 import { Address, BlockchainConnection, ConfirmedTransaction, SendTransaction } from '@iov/bcp';
 import * as React from 'react';
 
-import { ProcessedTx } from '../../../../store/notifications';
-import { BwParser, ParsedTx } from '../../types/BwParser';
-import SendTransactionComponent, { BwSendTransactionProps } from './ui';
+import { BwParser } from '../../types/BwParser';
+import SendTransactionComponent, { BwSendProps } from './ui';
 
-export class BwSendParser extends BwParser<ProcessedTx> {
+export class BwSendParser extends BwParser<BwSendProps> {
   public async parse(
     conn: BlockchainConnection,
     trans: ConfirmedTransaction<SendTransaction>,
     currentUserAddress: Address,
-  ): Promise<ParsedTx<ProcessedTx>> {
+  ): Promise<BwSendProps> {
     const payload = trans.transaction;
 
     const header = await conn.getBlockHeader(trans.height);
@@ -31,11 +30,11 @@ export class BwSendParser extends BwParser<ProcessedTx> {
     };
   }
 
-  public graphicalRepresentation(sendTx: BwSendTransactionProps): JSX.Element {
+  public graphicalRepresentation(sendTx: BwSendProps): JSX.Element {
     return <SendTransactionComponent key={sendTx.id} sendTx={sendTx} />;
   }
 
-  public csvRepresentation(tx: BwSendTransactionProps): string {
+  public csvRepresentation(tx: BwSendProps): string {
     const parties = [`"${tx.id}"`, `"${tx.recipient}"`, `"${tx.sender}"`];
     const payment = [
       `"${tx.amount.quantity}"`,

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwSendTransaction/ui/index.tsx
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwSendTransaction/ui/index.tsx
@@ -17,12 +17,11 @@ import { ProcessedTx } from '../../../../../store/notifications';
 import { getBorderColor } from '../../../../../theme/css';
 import { amountToNumber } from '../../../../../utils/balances';
 import { getDate, getTime } from '../../../../../utils/date';
-import { ParsedTx } from '../../../types/BwParser';
 import dropdownArrow from './assets/dropdownArrowClose.svg';
 import dropdownArrowClose from './assets/dropdownArrowClose.svg';
 import SendTxDetails from './Details';
 
-export type BwSendTransactionProps = ParsedTx<ProcessedTx>;
+export type BwSendProps = ProcessedTx;
 
 const useStyles = makeStyles({
   cell: {
@@ -31,7 +30,7 @@ const useStyles = makeStyles({
 });
 
 interface Props {
-  readonly sendTx: BwSendTransactionProps;
+  readonly sendTx: BwSendProps;
 }
 
 function TxTableRow({ sendTx }: Props): JSX.Element {

--- a/packages/bierzo-wallet/src/routes/transactions/components/sorting.ts
+++ b/packages/bierzo-wallet/src/routes/transactions/components/sorting.ts
@@ -14,17 +14,17 @@ export const TX_AMOUNT_COLUMN = 'Amount';
 export const TX_DATE_COLUMN = 'Date';
 export type TxsOrder = 'Date';
 
-export const filterTxsBy = <K>(
-  txs: ReadonlyArray<ParsedTx<K>>,
+export const filterTxsBy = (
+  txs: ReadonlyArray<ParsedTx>,
   rowsPerPage: number,
   pageNumber: number,
   orderBy: TxsOrder,
   order: SortOrder,
-): ReadonlyArray<ParsedTx<K>> => {
+): ReadonlyArray<ParsedTx> => {
   const orderedTxs = txs.slice(0); // make a mutable copy
 
   if (orderBy === TX_DATE_COLUMN) {
-    orderedTxs.sort((a: ParsedTx<K>, b: ParsedTx<K>) => {
+    orderedTxs.sort((a: ParsedTx, b: ParsedTx) => {
       return (a.time < b.time ? -1 : a.time > b.time ? 1 : 0) * order;
     });
   }

--- a/packages/bierzo-wallet/src/routes/transactions/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/transactions/index.stories.tsx
@@ -2,7 +2,6 @@ import { TokenTicker } from '@iov/bcp';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { ReadonlyDate } from 'readonly-date';
-import { DeepPartial } from 'redux';
 
 import { ProcessedTx } from '../../store/notifications';
 import { RootState } from '../../store/reducers';
@@ -15,6 +14,7 @@ export const TRANSACTIONS_STORY_SHOW_PATH = 'With transactions';
 
 const txs: ReadonlyArray<ProcessedTx> = [
   {
+    kind: 'bcp/send',
     received: true,
     sender: 'george*iov',
     recipient: 'me',
@@ -25,6 +25,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     memo: 'Sample note',
   },
   {
+    kind: 'bcp/send',
     received: false,
     sender: 'me',
     recipient: 'alex*iov',
@@ -34,6 +35,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     id: 'tx2',
   },
   {
+    kind: 'bcp/send',
     received: false,
     sender: 'me',
     recipient: 'alex*iov',
@@ -44,6 +46,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     memo: 'Another note',
   },
   {
+    kind: 'bcp/send',
     received: true,
     sender: 'Lx9oa7re0894eopiahsdpf98as7y908',
     recipient: 'me',
@@ -54,6 +57,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     memo: 'And again note',
   },
   {
+    kind: 'bcp/send',
     received: false,
     sender: 'me',
     recipient: 'alex*iov',
@@ -63,6 +67,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     id: 'tx5',
   },
   {
+    kind: 'bcp/send',
     received: false,
     sender: 'me',
     recipient: 'alex*iov',
@@ -72,6 +77,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     id: 'tx6',
   },
   {
+    kind: 'bcp/send',
     received: true,
     sender: 'george*iov',
     recipient: 'me',
@@ -81,6 +87,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     id: 'tx7',
   },
   {
+    kind: 'bcp/send',
     received: false,
     sender: 'me',
     recipient: 'alex*iov',
@@ -90,6 +97,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     id: 'tx8',
   },
   {
+    kind: 'bcp/send',
     received: false,
     sender: 'me',
     recipient: 'alex*iov',
@@ -99,6 +107,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     id: 'tx9',
   },
   {
+    kind: 'bcp/send',
     received: true,
     sender: 'george*iov',
     recipient: 'me',
@@ -108,6 +117,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     id: 'tx10',
   },
   {
+    kind: 'bcp/send',
     received: false,
     sender: 'me',
     recipient: 'alex*iov',
@@ -117,6 +127,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     id: 'tx11',
   },
   {
+    kind: 'bcp/send',
     received: false,
     sender: 'me',
     recipient: 'alex*iov',
@@ -126,6 +137,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     id: 'tx12',
   },
   {
+    kind: 'bcp/send',
     received: true,
     sender: 'george*iov',
     recipient: 'me',
@@ -135,6 +147,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     id: 'tx13',
   },
   {
+    kind: 'bcp/send',
     received: false,
     sender: 'Lxasdoiu9847ioasdpfuy098q23rui',
     recipient: 'alex*iov',
@@ -144,6 +157,7 @@ const txs: ReadonlyArray<ProcessedTx> = [
     id: 'tx14',
   },
   {
+    kind: 'bcp/send',
     received: false,
     sender: 'me',
     recipient: 'alex*iov',
@@ -154,8 +168,9 @@ const txs: ReadonlyArray<ProcessedTx> = [
   },
 ];
 
-const txStore: DeepPartial<RootState> = {
+const txStore: Pick<RootState, 'notifications'> = {
   notifications: {
+    pending: [],
     transactions: txs,
   },
 };

--- a/packages/bierzo-wallet/src/routes/transactions/index.tsx
+++ b/packages/bierzo-wallet/src/routes/transactions/index.tsx
@@ -22,7 +22,7 @@ const Transactions = (): JSX.Element => {
   const [page, setPage] = React.useState(0);
   const [orderBy, setOrderBy] = React.useState(TX_DATE_COLUMN as TxsOrder);
   const [order, setOrder] = React.useState(ORDER_DESC as SortOrder);
-  const parsedTxs: ReadonlyArray<ParsedTx<any>> = useSelector(
+  const parsedTxs: ReadonlyArray<ParsedTx> = useSelector(
     (state: RootState) => state.notifications.transactions,
   );
 
@@ -62,7 +62,7 @@ const Transactions = (): JSX.Element => {
     // TODO UPDATE HEADER WHEN OTHER TX TYPES ARE ADDED
     const csvHeader =
       '"ID";"Recipient";"Sender";"Quantity";"Fractional Digits";"Token Ticker";"Time";"Received";"Success";"Error";"Note"';
-    const csvBody = orderedTxs.map((tx: ParsedTx<{}>) => BwParserFactory.getCsvRepresentation(tx));
+    const csvBody = orderedTxs.map((tx: ParsedTx) => BwParserFactory.getCsvRepresentation(tx));
 
     const blob = new Blob([`${csvHeader}\n${csvBody.join('\n')}`], { type: 'text/plain;charset=utf-8' });
     FileSaver.saveAs(blob, 'transactions.csv');

--- a/packages/bierzo-wallet/src/store/notifications/actions.ts
+++ b/packages/bierzo-wallet/src/store/notifications/actions.ts
@@ -16,10 +16,10 @@ export const addPendingTransactionAction = (transaction: ProcessedTx): AddPendin
 
 export interface AddTransactionActionType<T> extends Action {
   type: '@@notifications/ADD_TRANSACTION';
-  payload: ParsedTx<T>;
+  payload: ParsedTx;
 }
 
-export const addTransaction = <T>(transaction: ParsedTx<any>): AddTransactionActionType<T> => ({
+export const addTransaction = <T>(transaction: ParsedTx): AddTransactionActionType<T> => ({
   type: '@@notifications/ADD_TRANSACTION',
   payload: transaction,
 });

--- a/packages/bierzo-wallet/src/store/notifications/reducer.ts
+++ b/packages/bierzo-wallet/src/store/notifications/reducer.ts
@@ -12,16 +12,16 @@ export interface Tx {
   readonly memo?: string;
 }
 
-export interface ProcessedTx extends Tx {
+export interface ProcessedTx extends Tx, ParsedTx {
   readonly time: ReadonlyDate;
   readonly received: boolean;
   readonly success: boolean;
   readonly err?: any;
 }
 
-export interface NotificationState<K extends {}> {
+export interface NotificationState {
   readonly pending: ReadonlyArray<Tx>;
-  readonly transactions: ReadonlyArray<ParsedTx<K>>;
+  readonly transactions: ReadonlyArray<ParsedTx>;
 }
 
 const initState = {
@@ -30,9 +30,9 @@ const initState = {
 };
 
 export function notificationReducer(
-  state: NotificationState<{}> = initState,
+  state: NotificationState = initState,
   action: NotificationActions,
-): NotificationState<{}> {
+): NotificationState {
   switch (action.type) {
     case '@@notifications/ADD_PENDING_TRANSACTION':
       return {
@@ -46,8 +46,8 @@ export function notificationReducer(
 
       return {
         ...state,
-        transactions: [action.payload as ParsedTx<any>, ...state.transactions].sort(
-          <T>(a: ParsedTx<T>, b: ParsedTx<T>) => b.time.getTime() - a.time.getTime(),
+        transactions: [action.payload as ParsedTx, ...state.transactions].sort(
+          (a: ParsedTx, b: ParsedTx) => b.time.getTime() - a.time.getTime(),
         ),
       };
     default:

--- a/packages/bierzo-wallet/src/store/notifications/selectors.ts
+++ b/packages/bierzo-wallet/src/store/notifications/selectors.ts
@@ -4,5 +4,5 @@ import { Tx } from './reducer';
 
 export const getPendingTransactions = (state: RootState): ReadonlyArray<Tx> =>
   state.notifications.pending || [];
-export const getTransactions = (state: RootState): ReadonlyArray<ParsedTx<{}>> =>
+export const getTransactions = (state: RootState): ReadonlyArray<ParsedTx> =>
   state.notifications.transactions || [];

--- a/packages/bierzo-wallet/src/store/reducers.ts
+++ b/packages/bierzo-wallet/src/store/reducers.ts
@@ -9,7 +9,7 @@ import { usernamesReducer, UsernamesState } from './usernames';
 
 export interface RootReducer {
   extension: ExtensionState;
-  notifications: NotificationState<{}>;
+  notifications: NotificationState;
   tokens: TokenState;
   balances: BalanceState;
   usernames: UsernamesState;

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2834,7 +2834,7 @@ exports[`Storyshots Bierzo wallet/Transactions With transactions 1`] = `
                   className="makeStyles-root-875"
                   height={10}
                   onClick={[Function]}
-                  src="dropdownArrow.svg"
+                  src="dropdownArrowClose.svg"
                   width={16}
                 />
               </div>
@@ -2907,7 +2907,7 @@ exports[`Storyshots Bierzo wallet/Transactions With transactions 1`] = `
                   className="makeStyles-root-875"
                   height={10}
                   onClick={[Function]}
-                  src="dropdownArrow.svg"
+                  src="dropdownArrowClose.svg"
                   width={16}
                 />
               </div>
@@ -2980,7 +2980,7 @@ exports[`Storyshots Bierzo wallet/Transactions With transactions 1`] = `
                   className="makeStyles-root-875"
                   height={10}
                   onClick={[Function]}
-                  src="dropdownArrow.svg"
+                  src="dropdownArrowClose.svg"
                   width={16}
                 />
               </div>
@@ -3053,7 +3053,7 @@ exports[`Storyshots Bierzo wallet/Transactions With transactions 1`] = `
                   className="makeStyles-root-875"
                   height={10}
                   onClick={[Function]}
-                  src="dropdownArrow.svg"
+                  src="dropdownArrowClose.svg"
                   width={16}
                 />
               </div>
@@ -3126,7 +3126,7 @@ exports[`Storyshots Bierzo wallet/Transactions With transactions 1`] = `
                   className="makeStyles-root-875"
                   height={10}
                   onClick={[Function]}
-                  src="dropdownArrow.svg"
+                  src="dropdownArrowClose.svg"
                   width={16}
                 />
               </div>


### PR DESCRIPTION
In this PR I remove, as an optional step the generics on the ParsedTx. The idea behind this is to take advantage of how TS deals with inheritance in types.

If you think is a better way to do it, just approve this PR. :)