### PR TITLE
Remove unnecessary lint ignores

### DIFF
--- a/packages/bierzo-wallet/src/utils/test/dom.tsx
+++ b/packages/bierzo-wallet/src/utils/test/dom.tsx
@@ -13,7 +13,7 @@ export const createDom = (store: Store): React.Component =>
         <Routes />
       </MedulasThemeProvider>
     </Provider>,
-  ) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  ) as any;
 
 export const expectRoute = (route: string): void => {
   const actualRoute = window.location.pathname;

--- a/packages/medulas-react-components/src/context/ToastProvider/Toast/ToastContent.tsx
+++ b/packages/medulas-react-components/src/context/ToastProvider/Toast/ToastContent.tsx
@@ -61,7 +61,6 @@ interface Props {
 }
 
 const ToastContent = React.forwardRef(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ({ className, message, onClose, variant }: Props, ref?: React.Ref<any>): JSX.Element => {
     const Icon = variantIcon[variant];
     const classes = useStyles();

--- a/packages/sanes-chrome-extension/src/extension/background/model/accountManager/index.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/accountManager/index.ts
@@ -105,7 +105,7 @@ export class AccountManager {
     path: ReadonlyArray<Slip10RawIndex>,
   ): Promise<boolean> {
     // FIXME iov-core, please.
-    const wallet: ReadonlyWallet = (this.userProfile as any).findWalletInPrimaryKeyring(walletId); // eslint-disable-line @typescript-eslint/no-explicit-any
+    const wallet: ReadonlyWallet = (this.userProfile as any).findWalletInPrimaryKeyring(walletId);
     const ident = await wallet.previewIdentity(chainId, path);
     const allIdentities = wallet.getIdentities();
     return !!allIdentities.find(x => identityEquals(x, ident));

--- a/packages/sanes-chrome-extension/src/extension/background/model/persona/config/configurationfile.ts
+++ b/packages/sanes-chrome-extension/src/extension/background/model/persona/config/configurationfile.ts
@@ -39,7 +39,6 @@ export interface ConfigurationFile {
 
 const loadConfigurationFile = async (): Promise<ConfigurationFile> => {
   if (process.env.NODE_ENV === 'test') {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const config = (window as any).config;
     return config;
   }

--- a/packages/sanes-chrome-extension/src/routes/share-identity/test/operateShareIdentity.ts
+++ b/packages/sanes-chrome-extension/src/routes/share-identity/test/operateShareIdentity.ts
@@ -37,7 +37,7 @@ export const checkPermanentRejection = async (ShareIdentityDom: React.Component)
   const doNotShowAgainCheckbox = inputs[0];
   TestUtils.act(() => {
     TestUtils.Simulate.change(doNotShowAgainCheckbox, {
-      target: { checked: true } as any, //eslint-disable-line @typescript-eslint/no-explicit-any
+      target: { checked: true } as any,
     });
   });
 };

--- a/packages/sanes-chrome-extension/src/routes/tx-request/test/operateTXRequest.ts
+++ b/packages/sanes-chrome-extension/src/routes/tx-request/test/operateTXRequest.ts
@@ -37,7 +37,7 @@ export const checkPermanentRejection = async (TXRequestDom: React.Component): Pr
   const rejectPermanentlyCheckbox = inputs[0];
   TestUtils.act(() => {
     TestUtils.Simulate.change(rejectPermanentlyCheckbox, {
-      target: { checked: true } as any, //eslint-disable-line @typescript-eslint/no-explicit-any
+      target: { checked: true } as any,
     });
   });
 };

--- a/packages/sil-voting-app/src/utils/test/dom.tsx
+++ b/packages/sil-voting-app/src/utils/test/dom.tsx
@@ -13,7 +13,7 @@ export const createDom = (store: Store): React.Component =>
         <Routes />
       </MedulasThemeProvider>
     </Provider>,
-  ) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  ) as any;
 
 export const expectRoute = (route: string): void => {
   const actualRoute = window.location.pathname;


### PR DESCRIPTION
The rule `@typescript-eslint/no-explicit-any` is turned off, since when we write `any`, we want `any`. Try not to use it but when needed it is okay. This removes unnecessary ignores.