### PR TITLE
Await click calls in sil dashboard test

### DIFF
--- a/packages/sil-voting-app/src/routes/dashboard/index.dom.spec.ts
+++ b/packages/sil-voting-app/src/routes/dashboard/index.dom.spec.ts
@@ -87,11 +87,11 @@ describe("DOM > Feature > Dashboard", () => {
     let longProposal = (await getProposals(dashboardDom))[1].children[0];
     let readToggle = longProposal.children[2].children[0].children[1];
 
-    click(readToggle);
+    await click(readToggle);
     let description = longProposal.children[2].children[0].children[0].textContent;
     expect(description).toBe(longDescription);
 
-    click(readToggle);
+    await click(readToggle);
     description = longProposal.children[2].children[0].children[0].textContent;
     expect(description).toBe(shortenedDescription);
   }, 60000);


### PR DESCRIPTION
To avoid the following:
```
    ✓ has a Read more / Read less toggle when description too long (1349ms)

  console.error ../../node_modules/react-dom/cjs/react-dom-test-utils.development.js:80
    Warning: You seem to have overlapping act() calls, this is not supported. Be sure to await previous act() calls before making a new one.
```

Edit: A quick search shows there are actually a lot of these that are missing across the monorepo.