### PR TITLE
Add signAndPost communication function

### DIFF
--- a/packages/sil-voting-app/src/communication/signandpost/index.ts
+++ b/packages/sil-voting-app/src/communication/signandpost/index.ts
@@ -1,0 +1,54 @@
+/* global chrome */
+import { TransactionId, WithCreator } from "@iov/bcp";
+import { BnsConnection, BnsTx } from "@iov/bns";
+import { TransactionEncoder } from "@iov/encoding";
+import { isJsonRpcErrorResponse, JsonRpcRequest, makeJsonRpcId, parseJsonRpcResponse2 } from "@iov/jsonrpc";
+
+import { getConfig } from "../../config";
+
+async function generateSignAndPostRequest(
+  connection: BnsConnection,
+  tx: BnsTx & WithCreator,
+): Promise<JsonRpcRequest> {
+  const txWithFee = connection.withDefaultFee(tx);
+  return {
+    jsonrpc: "2.0",
+    id: makeJsonRpcId(),
+    method: "signAndPost",
+    params: {
+      reason: TransactionEncoder.toJson("I would like you to sign this request"),
+      transaction: TransactionEncoder.toJson(txWithFee),
+    },
+  };
+}
+
+export async function sendSignAndPostRequest(
+  connection: BnsConnection,
+  tx: BnsTx & WithCreator,
+): Promise<TransactionId | null> {
+  const request = await generateSignAndPostRequest(connection, tx);
+  const config = await getConfig();
+
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage(config.extensionId, request, response => {
+      try {
+        const parsedResponse = parseJsonRpcResponse2(response);
+        if (isJsonRpcErrorResponse(parsedResponse)) {
+          reject(parsedResponse.error.message);
+          return;
+        }
+
+        const parsedResult = TransactionEncoder.fromJson(parsedResponse.result);
+        if (typeof parsedResult === "string") {
+          resolve(parsedResult as TransactionId);
+        } else if (parsedResult === null) {
+          resolve(null);
+        } else {
+          reject("Got unexpected type of result");
+        }
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}

--- a/packages/sil-voting-app/src/config/index.ts
+++ b/packages/sil-voting-app/src/config/index.ts
@@ -26,7 +26,6 @@ export interface FaucetSpec {
 }
 
 const configuration = async (): Promise<Config> => {
-  console.log(process.env.REACT_APP_CONFIG);
   if (process.env.REACT_APP_CONFIG === "development") {
     return developmentConfig;
   }


### PR DESCRIPTION
Like in `bierzo-wallet` except this is specific to BNS and accepts a connection and a generic transaction, so it’s up to the caller to build the transaction first, e.g. via `governor.buildProposalTx` or `.buildVoteTx`.

I couldn’t see any analogous tests so what’s the best approach here? Add in some new testing structure or just wait and see if this works for @abefernan ’s purposes?