### PR TITLE
Fix bnsd init script

### DIFF
--- a/scripts/bnsd/init.sh
+++ b/scripts/bnsd/init.sh
@@ -2,9 +2,12 @@
 set -o errexit -o nounset -o pipefail
 command -v shellcheck > /dev/null && shellcheck "$0"
 
+# get this files directory regardless of pwd when we run it
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 if [ -n "${INIT_PROPOSALS:-}" ]; then
   sleep 3
   echo "Deploying proposals..."
-  node "./deploy_proposals.js"
+  node "${SCRIPT_DIR}/deploy_proposals.js"
   echo "Done."
 fi


### PR DESCRIPTION
Enables use with `scripts/test_start.sh`