### PR TITLE
Feature #424 - Personalized address transactions support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,2 @@
 build/
-types/
+packages/medulas-react-components/types/

--- a/packages/bierzo-wallet/src/components/AddressesTable/index.tsx
+++ b/packages/bierzo-wallet/src/components/AddressesTable/index.tsx
@@ -7,7 +7,7 @@ import { makeStyles, ToastContext, ToastVariant } from "medulas-react-components
 import React from "react";
 import CopyToClipboard from "react-copy-to-clipboard";
 
-import { getChainName } from "../../config";
+import { chainAddressPairSortedMapping } from "../../utils/tokens";
 
 export interface ChainAddress {
   readonly chainId: ChainId;
@@ -40,17 +40,7 @@ const AddressesTable = ({ addresses }: AddressesTableProps): JSX.Element => {
 
   React.useEffect(() => {
     async function processAddresses(addresses: ChainAddressPair[]): Promise<void> {
-      const chainAddresses: ChainAddress[] = [];
-      for (const address of addresses) {
-        chainAddresses.push({
-          ...address,
-          chainName: await getChainName(address.chainId),
-        });
-      }
-      chainAddresses.sort((a: ChainAddress, b: ChainAddress) =>
-        a.chainName.localeCompare(b.chainName, undefined, { sensitivity: "base" }),
-      );
-
+      const chainAddresses = await chainAddressPairSortedMapping(addresses);
       setChainAddresses(chainAddresses);
     }
     processAddresses(addresses);

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwParserFactory.ts
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwParserFactory.ts
@@ -6,9 +6,11 @@ import {
   isSendTransaction,
   LightTransaction,
 } from "@iov/bcp";
+import { isRegisterUsernameTx, RegisterUsernameTx } from "@iov/bns";
 
 import { ProcessedSendTransaction } from "../../../store/notifications";
 import { BwParser, ProcessedTx } from "../types/BwParser";
+import { BwRegisterUsernameParser } from "./BwRegisterUsernameTx";
 import { BwSendParser } from "./BwSendTransaction";
 import { BwUnkownParser } from "./BwUnkownTransaction";
 
@@ -20,6 +22,8 @@ export class BwParserFactory {
   public static getReactComponent(tx: ProcessedTx): JSX.Element {
     if (isProcessedSendTransaction(tx)) {
       return new BwSendParser().graphicalRepresentation(tx);
+    } else if (isRegisterUsernameTx(tx.original)) {
+      return new BwRegisterUsernameParser().graphicalRepresentation(tx as ProcessedTx<RegisterUsernameTx>);
     }
 
     return new BwUnkownParser().graphicalRepresentation(tx);
@@ -28,6 +32,11 @@ export class BwParserFactory {
   public static getHeaderRepresentation(tx: ProcessedTx, lastOne: boolean): JSX.Element {
     if (isProcessedSendTransaction(tx)) {
       return new BwSendParser().headerRepresentation(tx, lastOne);
+    } else if (isRegisterUsernameTx(tx.original)) {
+      return new BwRegisterUsernameParser().headerRepresentation(
+        tx as ProcessedTx<RegisterUsernameTx>,
+        lastOne,
+      );
     }
 
     return new BwUnkownParser().headerRepresentation(tx, lastOne);
@@ -36,6 +45,8 @@ export class BwParserFactory {
   public static getCsvRepresentation(tx: ProcessedTx): string {
     if (isProcessedSendTransaction(tx)) {
       return new BwSendParser().csvRepresentation(tx);
+    } else if (isRegisterUsernameTx(tx.original)) {
+      return new BwRegisterUsernameParser().csvRepresentation(tx as ProcessedTx<RegisterUsernameTx>);
     }
 
     return new BwUnkownParser().csvRepresentation(tx);
@@ -55,6 +66,8 @@ export class BwParserFactory {
     const { transaction: payload } = trans;
     if (isSendTransaction(payload)) {
       return new BwSendParser();
+    } else if (isRegisterUsernameTx(payload)) {
+      return new BwRegisterUsernameParser();
     }
 
     return new BwUnkownParser();

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwParserFactory.ts
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwParserFactory.ts
@@ -18,12 +18,16 @@ function isProcessedSendTransaction(tx: ProcessedTx): tx is ProcessedSendTransac
   return isSendTransaction(tx.original);
 }
 
+function isProcessedRegisterUsernameTx(tx: ProcessedTx): tx is ProcessedTx<RegisterUsernameTx> {
+  return isRegisterUsernameTx(tx.original);
+}
+
 export class BwParserFactory {
   public static getReactComponent(tx: ProcessedTx): JSX.Element {
     if (isProcessedSendTransaction(tx)) {
       return new BwSendParser().graphicalRepresentation(tx);
-    } else if (isRegisterUsernameTx(tx.original)) {
-      return new BwRegisterUsernameParser().graphicalRepresentation(tx as ProcessedTx<RegisterUsernameTx>);
+    } else if (isProcessedRegisterUsernameTx(tx)) {
+      return new BwRegisterUsernameParser().graphicalRepresentation(tx);
     }
 
     return new BwUnkownParser().graphicalRepresentation(tx);
@@ -32,11 +36,8 @@ export class BwParserFactory {
   public static getHeaderRepresentation(tx: ProcessedTx, lastOne: boolean): JSX.Element {
     if (isProcessedSendTransaction(tx)) {
       return new BwSendParser().headerRepresentation(tx, lastOne);
-    } else if (isRegisterUsernameTx(tx.original)) {
-      return new BwRegisterUsernameParser().headerRepresentation(
-        tx as ProcessedTx<RegisterUsernameTx>,
-        lastOne,
-      );
+    } else if (isProcessedRegisterUsernameTx(tx)) {
+      return new BwRegisterUsernameParser().headerRepresentation(tx, lastOne);
     }
 
     return new BwUnkownParser().headerRepresentation(tx, lastOne);
@@ -45,8 +46,8 @@ export class BwParserFactory {
   public static getCsvRepresentation(tx: ProcessedTx): string {
     if (isProcessedSendTransaction(tx)) {
       return new BwSendParser().csvRepresentation(tx);
-    } else if (isRegisterUsernameTx(tx.original)) {
-      return new BwRegisterUsernameParser().csvRepresentation(tx as ProcessedTx<RegisterUsernameTx>);
+    } else if (isProcessedRegisterUsernameTx(tx)) {
+      return new BwRegisterUsernameParser().csvRepresentation(tx);
     }
 
     return new BwUnkownParser().csvRepresentation(tx);

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/index.tsx
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/index.tsx
@@ -22,8 +22,8 @@ export class BwRegisterUsernameParser extends BwParser<RegisterUsernameTx> {
     };
   }
 
-  public graphicalRepresentation(sendTx: ProcessedTx<RegisterUsernameTx>): JSX.Element {
-    return <TransactionRow key={sendTx.id} sendTx={sendTx} />;
+  public graphicalRepresentation(tx: ProcessedTx<RegisterUsernameTx>): JSX.Element {
+    return <TransactionRow key={tx.id} tx={tx} />;
   }
 
   public csvRepresentation(tx: ProcessedTx<RegisterUsernameTx>): string {

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/index.tsx
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/index.tsx
@@ -1,0 +1,44 @@
+import { Address, BlockchainConnection, ConfirmedTransaction } from "@iov/bcp";
+import { RegisterUsernameTx } from "@iov/bns";
+import * as React from "react";
+
+import { BwParser, ProcessedTx } from "../../types/BwParser";
+import TransactionHeader from "./ui/TransactionHeader";
+import TransactionRow from "./ui/TransactionRow";
+
+export class BwRegisterUsernameParser extends BwParser<RegisterUsernameTx> {
+  public async parse(
+    conn: BlockchainConnection,
+    trans: ConfirmedTransaction<RegisterUsernameTx>,
+    _: Address,
+  ): Promise<ProcessedTx<RegisterUsernameTx>> {
+    const header = await conn.getBlockHeader(trans.height);
+    const time = header.time;
+
+    return {
+      id: trans.transactionId,
+      time,
+      original: trans.transaction,
+    };
+  }
+
+  public graphicalRepresentation(sendTx: ProcessedTx<RegisterUsernameTx>): JSX.Element {
+    return <TransactionRow key={sendTx.id} sendTx={sendTx} />;
+  }
+
+  public csvRepresentation(tx: ProcessedTx<RegisterUsernameTx>): string {
+    const { original } = tx;
+    const parties = [`"${tx.id}"`, `"Personalized address registration"`, `"N/A"`];
+    const payment = ['"N/A"', '"N/A"', '"N/A"'];
+    const date = [`"${tx.time.toISOString()}"`];
+    const status = [`"${original.username}"`];
+
+    const txRow = [...parties, ...payment, ...date, ...status];
+
+    return txRow.join(";");
+  }
+
+  public headerRepresentation(tx: ProcessedTx<RegisterUsernameTx>, lastOne: boolean): JSX.Element {
+    return <TransactionHeader key={tx.id} item={tx} lastOne={lastOne} />;
+  }
+}

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionHeader/MsgSuccess.tsx
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionHeader/MsgSuccess.tsx
@@ -1,0 +1,22 @@
+import { Typography } from "medulas-react-components";
+import * as React from "react";
+
+interface MsgProps {
+  readonly username: string;
+}
+
+const Msg = ({ username }: MsgProps): JSX.Element => {
+  return (
+    <React.Fragment>
+      <Typography variant="body2" weight="semibold" inline>
+        {username}
+      </Typography>
+      <Typography variant="body2" inline>
+        {" "}
+        personalized address has been registered
+      </Typography>
+    </React.Fragment>
+  );
+};
+
+export default Msg;

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionHeader/index.tsx
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionHeader/index.tsx
@@ -1,0 +1,53 @@
+import { RegisterUsernameTx } from "@iov/bns";
+import { makeStyles, Theme } from "@material-ui/core";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemText from "@material-ui/core/ListItemText";
+import { Block, Hairline, Image } from "medulas-react-components";
+import * as React from "react";
+
+import { itemBackground } from "../../../../../../theme/css";
+import { ProcessedTx } from "../../../../types/BwParser";
+import sendTx from "../assets/transactionSend.svg";
+import Msg from "./MsgSuccess";
+
+interface ItemProps {
+  readonly item: ProcessedTx<RegisterUsernameTx>;
+  readonly lastOne: boolean;
+}
+
+const useStyles = makeStyles((theme: Theme) => ({
+  msg: {
+    "& > span": {
+      lineHeight: 1.3,
+      marginBottom: `${theme.spacing(1)}px`,
+    },
+  },
+  item: {
+    backgroundColor: itemBackground,
+  },
+}));
+
+const TransactionHeader = ({ item, lastOne }: ItemProps): JSX.Element => {
+  const classes = useStyles();
+  const { time, original } = item;
+
+  const msg = <Msg username={original.username} />;
+
+  return (
+    <Block padding={1} className={classes.item}>
+      <ListItem>
+        <Image src={sendTx} height={30} alt="Tx operation" />
+        <Block paddingLeft={2}>
+          <ListItemText className={classes.msg} primary={msg} secondary={time.toLocaleString()} />
+        </Block>
+      </ListItem>
+      {!lastOne && (
+        <Block padding="md">
+          <Hairline />
+        </Block>
+      )}
+    </Block>
+  );
+};
+
+export default TransactionHeader;

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionRow/Details.tsx
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionRow/Details.tsx
@@ -5,7 +5,7 @@ import { Block, Typography } from "medulas-react-components";
 import * as React from "react";
 
 import { ChainAddress } from "../../../../../../components/AddressesTable";
-import { getChainName } from "../../../../../../config";
+import { chainAddressPairSortedMapping } from "../../../../../../utils/tokens";
 import { ProcessedTx } from "../../../../types/BwParser";
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -35,21 +35,11 @@ interface Props {
 
 const TxDetails = ({ tx }: Props): JSX.Element => {
   const classes = useStyles();
-  const [addresses, setAddresses] = React.useState<ChainAddress[]>([]);
+  const [addresses, setAddresses] = React.useState<readonly ChainAddress[]>([]);
 
   React.useEffect(() => {
     async function processAddresses(addresses: readonly ChainAddressPair[]): Promise<void> {
-      const chainAddresses: ChainAddress[] = [];
-      for (const address of addresses) {
-        chainAddresses.push({
-          ...address,
-          chainName: await getChainName(address.chainId),
-        });
-      }
-      chainAddresses.sort((a: ChainAddress, b: ChainAddress) =>
-        a.chainName.localeCompare(b.chainName, undefined, { sensitivity: "base" }),
-      );
-
+      const chainAddresses = await chainAddressPairSortedMapping(addresses);
       setAddresses(chainAddresses);
     }
     processAddresses(tx.original.targets);

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionRow/Details.tsx
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionRow/Details.tsx
@@ -1,0 +1,95 @@
+import { ChainAddressPair, RegisterUsernameTx } from "@iov/bns";
+import { makeStyles } from "@material-ui/core";
+import { Table, TableBody, TableCell, TableHead, TableRow, Theme } from "@material-ui/core";
+import { Block, Typography } from "medulas-react-components";
+import * as React from "react";
+
+import { ChainAddress } from "../../../../../../components/AddressesTable";
+import { getChainName } from "../../../../../../config";
+import { ProcessedTx } from "../../../../types/BwParser";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  sectionName: {
+    overflowWrap: "break-word",
+  },
+  tableHeader: {
+    "& > th": {
+      fontSize: "1.4rem",
+      color: theme.palette.text.primary,
+      padding: `${theme.spacing(1)}px ${theme.spacing(4)}px ${theme.spacing(1)}px 0`,
+    },
+  },
+  tableBody: {
+    "& > td": {
+      fontSize: "1.4rem",
+      color: theme.palette.text.secondary,
+      paddingLeft: 0,
+      padding: `${theme.spacing(1)}px ${theme.spacing(4)}px ${theme.spacing(1)}px 0`,
+    },
+  },
+}));
+
+interface Props {
+  readonly tx: ProcessedTx<RegisterUsernameTx>;
+}
+
+const TxDetails = ({ tx }: Props): JSX.Element => {
+  const classes = useStyles();
+  const [addresses, setAddresses] = React.useState<ChainAddress[]>([]);
+
+  React.useEffect(() => {
+    async function processAddresses(addresses: readonly ChainAddressPair[]): Promise<void> {
+      const chainAddresses: ChainAddress[] = [];
+      for (const address of addresses) {
+        chainAddresses.push({
+          ...address,
+          chainName: await getChainName(address.chainId),
+        });
+      }
+      chainAddresses.sort((a: ChainAddress, b: ChainAddress) =>
+        a.chainName.localeCompare(b.chainName, undefined, { sensitivity: "base" }),
+      );
+
+      setAddresses(chainAddresses);
+    }
+    processAddresses(tx.original.targets);
+  }, [tx.original.targets]);
+
+  return (
+    <Block paddingLeft="56px" display="flex" flexDirection="column">
+      <Block margin={2} />
+      <Block>
+        <Typography variant="subtitle2" weight="regular" gutterBottom>
+          Personalized address:
+        </Typography>
+        <Typography
+          variant="subtitle2"
+          weight="regular"
+          color="textSecondary"
+          className={classes.sectionName}
+        >
+          {tx.original.username}
+        </Typography>
+        <Typography>&nbsp;</Typography>
+        <Table>
+          <TableHead>
+            <TableRow className={classes.tableHeader}>
+              <TableCell align="left">Blockchain</TableCell>
+              <TableCell align="left">Address</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {addresses.map(chain => (
+              <TableRow key={chain.chainId} className={classes.tableBody}>
+                <TableCell align="left">{chain.chainName}</TableCell>
+                <TableCell align="left">{chain.address}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Block>
+    </Block>
+  );
+};
+
+export default TxDetails;

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionRow/index.tsx
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionRow/index.tsx
@@ -1,0 +1,80 @@
+import { RegisterUsernameTx } from "@iov/bns";
+import { makeStyles, Theme } from "@material-ui/core";
+import { useTheme } from "@material-ui/styles";
+import { Block, CircleImage, Hairline, Image, Typography, useOpen } from "medulas-react-components";
+import * as React from "react";
+
+import toAddress from "../../../../../../routes/transactions/assets/toAddress.svg";
+import { DEFAULT_ADDRESS } from "../../../../../../routes/transactions/components/TxTable/rowTxBuilder";
+import { getBorderColor } from "../../../../../../theme/css";
+import { formatDate, formatTime } from "../../../../../../utils/date";
+import { ProcessedTx } from "../../../../types/BwParser";
+import dropdownArrow from "../assets/dropdownArrow.svg";
+import dropdownArrowClose from "../assets/dropdownArrowClose.svg";
+import SendTxDetails from "./Details";
+
+const useStyles = makeStyles({
+  cell: {
+    flex: "1 0 50px",
+  },
+});
+
+interface Props {
+  readonly sendTx: ProcessedTx<RegisterUsernameTx>;
+}
+
+function TransactionRow({ sendTx }: Props): JSX.Element {
+  const classes = useStyles();
+  const theme = useTheme<Theme>();
+  const [isOpen, toggle] = useOpen();
+
+  const onClick = (): void => {
+    toggle();
+  };
+
+  return (
+    <Block display="flex" flexDirection="column" paddingLeft={3} paddingRight={3}>
+      <Block margin={2} />
+      <Block display="flex" alignItems="center">
+        <CircleImage
+          icon={toAddress}
+          circleColor={theme.palette.background.default}
+          borderColor={getBorderColor(theme)}
+          alt="Transaction type"
+          dia={40}
+          width={24}
+          height={24}
+        />
+        <Block className={classes.cell} paddingLeft={2} paddingRight={2}>
+          <Typography variant="subtitle2" weight="semibold" gutterBottom>
+            Personalized address registration
+          </Typography>
+          <Typography variant="subtitle2" weight="regular" color="secondary">
+            {formatTime(sendTx.time)}
+          </Typography>
+        </Block>
+        <Block flexGrow={1} />
+        <Typography variant="subtitle2" weight="regular" color="secondary" className={classes.cell}>
+          {formatDate(sendTx.time)}
+        </Typography>
+        <Block flexGrow={1} />
+        <Typography variant="subtitle2" weight="regular" align="right" className={classes.cell}>
+          -
+        </Typography>
+        <Block padding={0.5} />
+        <Image
+          src={isOpen ? dropdownArrowClose : dropdownArrow}
+          width={16}
+          height={10}
+          alt="Sorting"
+          onClick={onClick}
+        />
+      </Block>
+      {isOpen && <SendTxDetails tx={sendTx} />}
+      <Block margin={2} />
+      <Hairline />
+    </Block>
+  );
+}
+
+export default TransactionRow;

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionRow/index.tsx
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionRow/index.tsx
@@ -5,7 +5,6 @@ import { Block, CircleImage, Hairline, Image, Typography, useOpen } from "medula
 import * as React from "react";
 
 import toAddress from "../../../../../../routes/transactions/assets/toAddress.svg";
-import { DEFAULT_ADDRESS } from "../../../../../../routes/transactions/components/TxTable/rowTxBuilder";
 import { getBorderColor } from "../../../../../../theme/css";
 import { formatDate, formatTime } from "../../../../../../utils/date";
 import { ProcessedTx } from "../../../../types/BwParser";

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionRow/index.tsx
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/TransactionRow/index.tsx
@@ -10,7 +10,7 @@ import { formatDate, formatTime } from "../../../../../../utils/date";
 import { ProcessedTx } from "../../../../types/BwParser";
 import dropdownArrow from "../assets/dropdownArrow.svg";
 import dropdownArrowClose from "../assets/dropdownArrowClose.svg";
-import SendTxDetails from "./Details";
+import TxDetails from "./Details";
 
 const useStyles = makeStyles({
   cell: {
@@ -19,10 +19,10 @@ const useStyles = makeStyles({
 });
 
 interface Props {
-  readonly sendTx: ProcessedTx<RegisterUsernameTx>;
+  readonly tx: ProcessedTx<RegisterUsernameTx>;
 }
 
-function TransactionRow({ sendTx }: Props): JSX.Element {
+function TransactionRow({ tx }: Props): JSX.Element {
   const classes = useStyles();
   const theme = useTheme<Theme>();
   const [isOpen, toggle] = useOpen();
@@ -49,12 +49,12 @@ function TransactionRow({ sendTx }: Props): JSX.Element {
             Personalized address registration
           </Typography>
           <Typography variant="subtitle2" weight="regular" color="secondary">
-            {formatTime(sendTx.time)}
+            {formatTime(tx.time)}
           </Typography>
         </Block>
         <Block flexGrow={1} />
         <Typography variant="subtitle2" weight="regular" color="secondary" className={classes.cell}>
-          {formatDate(sendTx.time)}
+          {formatDate(tx.time)}
         </Typography>
         <Block flexGrow={1} />
         <Typography variant="subtitle2" weight="regular" align="right" className={classes.cell}>
@@ -69,7 +69,7 @@ function TransactionRow({ sendTx }: Props): JSX.Element {
           onClick={onClick}
         />
       </Block>
-      {isOpen && <SendTxDetails tx={sendTx} />}
+      {isOpen && <TxDetails tx={tx} />}
       <Block margin={2} />
       <Hairline />
     </Block>

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/assets/dropdownArrow.svg
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/assets/dropdownArrow.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="10" fill="none" viewBox="0 0 16 10">
+    <path stroke="#edeef1" stroke-width="2" d="M.714.707l7.464 7.537 7.108-7.178"/>
+</svg>

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/assets/dropdownArrowClose.svg
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/assets/dropdownArrowClose.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="10" fill="none" viewBox="0 0 16 10">
+  <path stroke="#edeef1" stroke-width="2" d="m 15.286024,8.9615127 -7.4640004,-7.537 -7.10799999,7.178"/>
+</svg>

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/assets/transactionSend.svg
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwRegisterUsernameTx/ui/assets/transactionSend.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" fill="none" viewBox="0 0 36 36">
+    <circle cx="18" cy="18" r="17.5" fill="#fff" stroke="#F3F3F3"/>
+    <path fill="#31E6C9" d="M9.731 14.254a.5.5 0 0 0-.294.866l.12.11 4.823 4.455 1.48 6.56a.5.5 0 0 0 .896.178L25.74 13.65a.5.5 0 0 0-.453-.786l-15.555 1.39z"/>
+</svg>

--- a/packages/bierzo-wallet/src/routes/registerName/components/ConfirmRegistration.tsx
+++ b/packages/bierzo-wallet/src/routes/registerName/components/ConfirmRegistration.tsx
@@ -34,10 +34,14 @@ const ConfirmRegistration = ({ transactionId, onSeeTrasactions, onReturnToBalanc
       flexDirection="column"
     >
       <Block width="75%">
-        <Button fullWidth>See Transactions</Button>
+        <Button fullWidth onClick={onSeeTrasactions}>
+          See Transactions
+        </Button>
       </Block>
       <Block width="75%" marginTop={2}>
-        <Button fullWidth>Return to Balance</Button>
+        <Button fullWidth onClick={onReturnToBalance}>
+          Return to Balance
+        </Button>
       </Block>
     </Block>
   );

--- a/packages/bierzo-wallet/src/routes/transactions/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/transactions/index.stories.tsx
@@ -1,8 +1,10 @@
-import { Address, Token, TokenTicker, TransactionId } from "@iov/bcp";
+import { Address, ChainId, Token, TokenTicker, TransactionId } from "@iov/bcp";
+import { RegisterUsernameTx } from "@iov/bns";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import { ReadonlyDate } from "readonly-date";
 
+import { ProcessedTx } from "../../logic/transactions/types/BwParser";
 import { BwUnknownProps } from "../../logic/transactions/types/BwUnkownTransaction";
 import { ProcessedSendTransaction } from "../../store/notifications";
 import { RootState } from "../../store/reducers";
@@ -37,12 +39,27 @@ const incomingAndOutgoingSendTransaction: ProcessedSendTransaction = {
   outgoing: true,
 };
 
-const txs: readonly (ProcessedSendTransaction | BwUnknownProps)[] = [
+const txs: readonly (ProcessedSendTransaction | ProcessedTx<RegisterUsernameTx> | BwUnknownProps)[] = [
   {
     id: "DA9A61A3CA28C772E468D772D642978180332780ADB6410909E51487C0F61050" as TransactionId,
     time: new ReadonlyDate("2019-12-24T10:51:33.763Z"),
     original: {
       kind: "bns/register_username",
+      username: "albert*iov",
+      targets: [
+        {
+          chainId: "local-iov-devnet" as ChainId,
+          address: "tiov1yeyyqj3zxgs500xvzp38vu3c336yj8q48a5jx0" as Address,
+        },
+        {
+          chainId: "lisk-198f2b61a8" as ChainId,
+          address: "13751834438426525516L" as Address,
+        },
+        {
+          chainId: "ethereum-eip155-5777" as ChainId,
+          address: "0x695874053fcB8D9cF038ee4E53b7b24fB0baFa4c" as Address,
+        },
+      ],
     },
   },
   {

--- a/packages/bierzo-wallet/src/utils/tokens.ts
+++ b/packages/bierzo-wallet/src/utils/tokens.ts
@@ -2,6 +2,8 @@ import { BlockchainConnection, Identity } from "@iov/bcp";
 import { ChainAddressPair } from "@iov/bns";
 import { TransactionEncoder } from "@iov/encoding";
 
+import { ChainAddress } from "../components/AddressesTable";
+import { getChainName } from "../config";
 import { getCodecForChainId } from "../logic/codec";
 
 // exported for testing purposes
@@ -37,4 +39,24 @@ export async function getChainAddressPair(pubKeys: { [chain: string]: string }):
   }
 
   return addresses;
+}
+
+/**
+ * This method will convert ChainAddressPair to ChainAddress
+ */
+export async function chainAddressPairSortedMapping(
+  addresses: readonly ChainAddressPair[],
+): Promise<readonly ChainAddress[]> {
+  const chainAddresses: ChainAddress[] = [];
+  for (const address of addresses) {
+    chainAddresses.push({
+      ...address,
+      chainName: await getChainName(address.chainId),
+    });
+  }
+  chainAddresses.sort((a: ChainAddress, b: ChainAddress) =>
+    a.chainName.localeCompare(b.chainName, undefined, { sensitivity: "base" }),
+  );
+
+  return chainAddresses;
 }

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2356,6 +2356,7 @@ exports[`Storyshots Bierzo wallet/Register Username Registeration confirmation 1
           className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
           disabled={false}
           onBlur={[Function]}
+          onClick={[Function]}
           onDragLeave={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
@@ -2383,6 +2384,7 @@ exports[`Storyshots Bierzo wallet/Register Username Registeration confirmation 1
           className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-fullWidth"
           disabled={false}
           onBlur={[Function]}
+          onClick={[Function]}
           onDragLeave={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
@@ -2735,17 +2737,13 @@ exports[`Storyshots Bierzo wallet/Transactions With transactions 1`] = `
                 <div
                   className="MuiBox-root MuiBox-root"
                 >
-                  <svg
-                    aria-hidden="true"
-                    className="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeLarge"
-                    focusable="false"
-                    role="presentation"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M20 6H10v2h10v12H4V8h2v4h2V4h6V0H6v6H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"
-                    />
-                  </svg>
+                  <img
+                    alt="Transaction type"
+                    className="makeStyles-root"
+                    height={24}
+                    src="toAddress.svg"
+                    width={24}
+                  />
                 </div>
                 <div
                   className="MuiBox-root MuiBox-root makeStyles-cell"
@@ -2753,15 +2751,41 @@ exports[`Storyshots Bierzo wallet/Transactions With transactions 1`] = `
                   <h6
                     className="MuiTypography-root makeStyles-weight makeStyles-weight MuiTypography-subtitle2 MuiTypography-gutterBottom"
                   >
-                    This is an unknown transaction
+                    Personalized address registration
                   </h6>
                   <h6
                     className="MuiTypography-root makeStyles-weight makeStyles-weight MuiTypography-subtitle2 MuiTypography-colorSecondary"
                   >
-                    The transaction ID is: 
-                    DA9A61A3CA28C772E468D772D642978180332780ADB6410909E51487C0F61050
+                    10:51 am
                   </h6>
                 </div>
+                <div
+                  className="MuiBox-root MuiBox-root"
+                />
+                <h6
+                  className="MuiTypography-root makeStyles-cell makeStyles-weight makeStyles-weight MuiTypography-subtitle2 MuiTypography-colorSecondary"
+                >
+                  24 Dec 2019
+                </h6>
+                <div
+                  className="MuiBox-root MuiBox-root"
+                />
+                <h6
+                  className="MuiTypography-root makeStyles-cell makeStyles-weight makeStyles-weight MuiTypography-subtitle2 MuiTypography-alignRight"
+                >
+                  -
+                </h6>
+                <div
+                  className="MuiBox-root MuiBox-root"
+                />
+                <img
+                  alt="Sorting"
+                  className="makeStyles-root"
+                  height={10}
+                  onClick={[Function]}
+                  src="dropdownArrow.svg"
+                  width={16}
+                />
               </div>
               <div
                 className="MuiBox-root MuiBox-root"
@@ -2924,17 +2948,13 @@ exports[`Storyshots Bierzo wallet/Transactions With transactions 1`] = `
                 <div
                   className="MuiBox-root MuiBox-root"
                 >
-                  <svg
-                    aria-hidden="true"
-                    className="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeLarge"
-                    focusable="false"
-                    role="presentation"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M20 6H10v2h10v12H4V8h2v4h2V4h6V0H6v6H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"
-                    />
-                  </svg>
+                  <img
+                    alt="Transaction type"
+                    className="makeStyles-root"
+                    height={24}
+                    src="toAddress.svg"
+                    width={24}
+                  />
                 </div>
                 <div
                   className="MuiBox-root MuiBox-root makeStyles-cell"
@@ -2942,15 +2962,41 @@ exports[`Storyshots Bierzo wallet/Transactions With transactions 1`] = `
                   <h6
                     className="MuiTypography-root makeStyles-weight makeStyles-weight MuiTypography-subtitle2 MuiTypography-gutterBottom"
                   >
-                    This is an unknown transaction
+                    Personalized address registration
                   </h6>
                   <h6
                     className="MuiTypography-root makeStyles-weight makeStyles-weight MuiTypography-subtitle2 MuiTypography-colorSecondary"
                   >
-                    The transaction ID is: 
-                    0xaaffBdjuhyu8898scchjsg
+                    3:35 am
                   </h6>
                 </div>
+                <div
+                  className="MuiBox-root MuiBox-root"
+                />
+                <h6
+                  className="MuiTypography-root makeStyles-cell makeStyles-weight makeStyles-weight MuiTypography-subtitle2 MuiTypography-colorSecondary"
+                >
+                  24 Dec 2019
+                </h6>
+                <div
+                  className="MuiBox-root MuiBox-root"
+                />
+                <h6
+                  className="MuiTypography-root makeStyles-cell makeStyles-weight makeStyles-weight MuiTypography-subtitle2 MuiTypography-alignRight"
+                >
+                  -
+                </h6>
+                <div
+                  className="MuiBox-root MuiBox-root"
+                />
+                <img
+                  alt="Sorting"
+                  className="makeStyles-root"
+                  height={10}
+                  onClick={[Function]}
+                  src="dropdownArrow.svg"
+                  width={16}
+                />
               </div>
               <div
                 className="MuiBox-root MuiBox-root"


### PR DESCRIPTION
**Description**
This PR will add personalized address support to the transactions screen and to header menu. Closes #424.
Closes #521.

**Before**
![transactions-pers-old](https://user-images.githubusercontent.com/3502260/62970969-5457a280-be19-11e9-9d93-0bcda9c76c15.png)

![transactions-pers-header-old](https://user-images.githubusercontent.com/3502260/62970980-5c174700-be19-11e9-8c41-c1cf8c627829.png)

**After**
![transactions-pers](https://user-images.githubusercontent.com/3502260/62970255-bfa07500-be17-11e9-89f8-9b4aa4f999e2.png)

![transactions-pers-header](https://user-images.githubusercontent.com/3502260/62970260-c3cc9280-be17-11e9-9a1e-acd7d47df0dd.png)
