### PR TITLE
Feature – Use redux governor instead of local instance

### DIFF
--- a/packages/sil-voting-app/src/routes/login/index.tsx
+++ b/packages/sil-voting-app/src/routes/login/index.tsx
@@ -61,6 +61,7 @@ const Login = (): JSX.Element => {
 
   const loadProposals = async (): Promise<void> => {
     const governor = store.getState().extension.governor;
+    if (!governor) throw new Error("Governor not set in store. This is a bug.");
     const chainProposals = await getProposals(governor);
     dispatch(addProposalsAction(chainProposals));
   };

--- a/packages/sil-voting-app/src/routes/login/index.tsx
+++ b/packages/sil-voting-app/src/routes/login/index.tsx
@@ -1,4 +1,3 @@
-import { Governor } from "@iov/bns-governance";
 import { Theme } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 import {
@@ -17,6 +16,7 @@ import * as ReactRedux from "react-redux";
 import icon from "../../assets/iov-logo.svg";
 import { getExtensionStatus, setExtensionStateAction } from "../../store/extension";
 import { addProposalsAction, getProposals } from "../../store/proposals";
+import { RootState } from "../../store/reducers";
 import { history } from "../index";
 import { DASHBOARD_ROUTE } from "../paths";
 
@@ -39,12 +39,11 @@ const useStyles = makeStyles((theme: Theme) => ({
 const Login = (): JSX.Element => {
   const classes = useStyles();
   const toast = useContext(ToastContext);
+  const store = ReactRedux.useStore<RootState>();
   const dispatch = ReactRedux.useDispatch();
-  let governor: Governor | undefined = undefined;
 
   const isExtensionConnected = async (): Promise<boolean> => {
     const result = await getExtensionStatus();
-    governor = result.governor;
     dispatch(setExtensionStateAction(result.connected, result.installed, result.governor));
 
     if (!result.installed) {
@@ -61,6 +60,7 @@ const Login = (): JSX.Element => {
   };
 
   const loadProposals = async (): Promise<void> => {
+    const governor = store.getState().extension.governor;
     const chainProposals = await getProposals(governor);
     dispatch(addProposalsAction(chainProposals));
   };

--- a/packages/sil-voting-app/src/store/proposals/actions.ts
+++ b/packages/sil-voting-app/src/store/proposals/actions.ts
@@ -3,9 +3,7 @@ import { Governor } from "@iov/bns-governance";
 
 import { AddProposalsActionType, ProposalsState } from "./reducer";
 
-export async function getProposals(governor: Governor | undefined): Promise<ProposalsState> {
-  if (!governor) return [];
-
+export async function getProposals(governor: Governor): Promise<ProposalsState> {
   const getQuorum = async (proposal: Proposal): Promise<number> => {
     const electionRule = await governor.getElectionRuleById(proposal.electionRule.id);
     const maxVotes = proposal.state.totalElectorateWeight;

--- a/packages/sil-voting-app/src/store/proposals/index.unit.spec.ts
+++ b/packages/sil-voting-app/src/store/proposals/index.unit.spec.ts
@@ -3,7 +3,8 @@ import { Store } from "redux";
 import { aNewStore } from "..";
 import { withChainsDescribe } from "../../utils/test/testExecutor";
 import { RootState } from "../reducers";
-import { addProposalsAction, getProposals } from "./actions";
+import { addProposalsAction } from "./actions";
+import { SilProposal } from "./reducer";
 
 const proposals = [
   {
@@ -62,7 +63,7 @@ withChainsDescribe("Proposals reducer", () => {
   }, 60000);
 
   it("dispatches correctly getProposals action", async () => {
-    const chainProposals = await getProposals(undefined);
+    const chainProposals: SilProposal[] = [];
     store.dispatch(addProposalsAction(chainProposals));
     const proposals = store.getState().proposals;
 
@@ -70,7 +71,7 @@ withChainsDescribe("Proposals reducer", () => {
   }, 60000);
 
   it("stores correctly proposals", async () => {
-    const chainProposals = await getProposals(undefined);
+    const chainProposals: SilProposal[] = [];
     store.dispatch(addProposalsAction(chainProposals));
     const storedProposals = store.getState().proposals;
 


### PR DESCRIPTION
Passing the governor instance from `isExtensionConnected` into `loadProposals` via a component-level instance creates a second way around the redux store. This PR lets `loadProposals` use the updated redux store.