### PR TITLE
Fix - Bell icon layout

### DIFF
--- a/packages/sanes-chrome-extension/src/routes/account/components/Empty.tsx
+++ b/packages/sanes-chrome-extension/src/routes/account/components/Empty.tsx
@@ -12,6 +12,7 @@ const useStyles = makeStyles(theme => ({
   empty: {
     marginTop: theme.spacing(1),
     marginBottom: theme.spacing(3),
+    justifyContent: "center",
   },
   center: {
     display: "flex",


### PR DESCRIPTION
**Description**
In this PR we center the bell icon when no transactions are shown in the box.

It closes #538 

<img width="593" alt="Screenshot 2019-08-21 10 35 46" src="https://user-images.githubusercontent.com/4266059/63416496-c888dc00-c3ff-11e9-8704-6e04dea690b5.png">
