### PR TITLE
Improve Recovery Phrase screen

### DIFF
--- a/packages/sanes-browser-extension/src/routes/account/index.e2e.spec.ts
+++ b/packages/sanes-browser-extension/src/routes/account/index.e2e.spec.ts
@@ -20,7 +20,7 @@ withChainsDescribe("E2E > Account route", () => {
     const password = randomString(10);
     const mnemonic = "degree tackle suggest window test behind mesh extra cover prepare oak script";
     await submitRecoveryPhraseE2E(page, mnemonic, password);
-  }, 10000);
+  }, 15000);
 
   afterEach(async () => {
     await closeBrowser(browser);

--- a/packages/sanes-browser-extension/src/routes/signup/components/ShowPhraseForm.tsx
+++ b/packages/sanes-browser-extension/src/routes/signup/components/ShowPhraseForm.tsx
@@ -30,7 +30,7 @@ const ShowPhraseForm = ({ mnemonic, onBack, onHintPassword }: Props): JSX.Elemen
         <Block display="flex" alignItems="center">
           <Block marginRight={1}>
             <Typography variant="subtitle2" inline>
-              Activate Recovery Phrase?
+              Show/hide Recovery Phrase
             </Typography>
           </Block>
         </Block>
@@ -39,7 +39,7 @@ const ShowPhraseForm = ({ mnemonic, onBack, onHintPassword }: Props): JSX.Elemen
 
       <Block
         padding={2}
-        marginTop={1}
+        marginTop={0}
         marginBottom={4}
         minHeight={24}
         border={1}

--- a/packages/sanes-browser-extension/src/routes/signup/components/ShowPhraseForm.tsx
+++ b/packages/sanes-browser-extension/src/routes/signup/components/ShowPhraseForm.tsx
@@ -1,4 +1,4 @@
-import { Back, Block, Button, PageLayout, Switch, Tooltip, Typography } from "medulas-react-components";
+import { Back, Block, Button, PageLayout, Switch, Typography } from "medulas-react-components";
 import * as React from "react";
 
 import { SIGNUP_ROUTE } from "../../paths";
@@ -20,6 +20,12 @@ const ShowPhraseForm = ({ mnemonic, onBack, onHintPassword }: Props): JSX.Elemen
 
   return (
     <PageLayout id={SECOND_STEP_SIGNUP_ROUTE} primaryTitle="Recovery" title="Phrase">
+      <Typography variant="body1" inline>
+        Your secret Recovery Phrase consists of 12 words that act as a tool to recover your wallet on any
+        platform.
+      </Typography>
+      <Block marginTop={2} />
+
       <Block display="flex" justifyContent="space-between" alignItems="center">
         <Block display="flex" alignItems="center">
           <Block marginRight={1}>
@@ -27,12 +33,6 @@ const ShowPhraseForm = ({ mnemonic, onBack, onHintPassword }: Props): JSX.Elemen
               Activate Recovery Phrase?
             </Typography>
           </Block>
-          <Tooltip>
-            <Typography variant="body2">
-              Your Recovery Phrase are 12 random words that are set in a particular order that acts as a tool
-              to recover or back up your wallet on any platform.
-            </Typography>
-          </Tooltip>
         </Block>
         <Switch color="primary" onChange={onToggleMnemonic} />
       </Block>

--- a/packages/sanes-browser-extension/src/routes/signup/components/ShowPhraseForm.tsx
+++ b/packages/sanes-browser-extension/src/routes/signup/components/ShowPhraseForm.tsx
@@ -1,27 +1,21 @@
 import { Back, Block, Button, PageLayout, Switch, Tooltip, Typography } from "medulas-react-components";
 import * as React from "react";
 
-import { PersonaContext } from "../../../context/PersonaProvider";
 import { SIGNUP_ROUTE } from "../../paths";
 
 export const SECOND_STEP_SIGNUP_ROUTE = `${SIGNUP_ROUTE}2`;
 
 export interface Props {
+  readonly mnemonic: string;
   readonly onHintPassword: () => void;
   readonly onBack: () => void;
 }
 
-const ShowPhraseForm = ({ onBack, onHintPassword }: Props): JSX.Element => {
-  const [mnemonic, setMnemonic] = React.useState<string>("");
-  const persona = React.useContext(PersonaContext);
+const ShowPhraseForm = ({ mnemonic, onBack, onHintPassword }: Props): JSX.Element => {
+  const [visibleMnemonic, setVisibleMnemonic] = React.useState<string>("");
 
-  const onShowMnemonic = async (_: React.ChangeEvent<HTMLInputElement>, checked: boolean): Promise<void> => {
-    if (checked) {
-      setMnemonic(persona.mnemonic);
-      return;
-    }
-
-    setMnemonic("");
+  const onToggleMnemonic = (_: React.ChangeEvent<HTMLInputElement>, checked: boolean): void => {
+    setVisibleMnemonic(checked ? mnemonic : "");
   };
 
   return (
@@ -40,7 +34,7 @@ const ShowPhraseForm = ({ onBack, onHintPassword }: Props): JSX.Element => {
             </Typography>
           </Tooltip>
         </Block>
-        <Switch color="primary" onChange={onShowMnemonic} />
+        <Switch color="primary" onChange={onToggleMnemonic} />
       </Block>
 
       <Block
@@ -54,7 +48,7 @@ const ShowPhraseForm = ({ onBack, onHintPassword }: Props): JSX.Element => {
         bgcolor="grey.300"
       >
         <Typography variant="body1" inline>
-          {mnemonic}
+          {visibleMnemonic}
         </Typography>
       </Block>
       <Block display="flex" justifyContent="space-between">

--- a/packages/sanes-browser-extension/src/routes/signup/components/ShowPhraseForm.tsx
+++ b/packages/sanes-browser-extension/src/routes/signup/components/ShowPhraseForm.tsx
@@ -21,7 +21,7 @@ const ShowPhraseForm = ({ mnemonic, onBack, onHintPassword }: Props): JSX.Elemen
   return (
     <PageLayout id={SECOND_STEP_SIGNUP_ROUTE} primaryTitle="Recovery" title="Phrase">
       <Typography variant="body1" inline>
-        Your secret Recovery Phrase consists of 12 words that act as a tool to recover your wallet on any
+        Your secret recovery phrase consists of 12 words that act as a tool to recover your wallet on any
         platform.
       </Typography>
       <Block marginTop={2} />
@@ -30,7 +30,7 @@ const ShowPhraseForm = ({ mnemonic, onBack, onHintPassword }: Props): JSX.Elemen
         <Block display="flex" alignItems="center">
           <Block marginRight={1}>
             <Typography variant="subtitle2" inline>
-              Show/hide Recovery Phrase
+              Show/hide recovery phrase
             </Typography>
           </Block>
         </Block>

--- a/packages/sanes-browser-extension/src/routes/signup/components/ShowPhraseForm.tsx
+++ b/packages/sanes-browser-extension/src/routes/signup/components/ShowPhraseForm.tsx
@@ -19,7 +19,7 @@ const ShowPhraseForm = ({ mnemonic, onBack, onHintPassword }: Props): JSX.Elemen
   };
 
   return (
-    <PageLayout id={SECOND_STEP_SIGNUP_ROUTE} primaryTitle="New" title="Account">
+    <PageLayout id={SECOND_STEP_SIGNUP_ROUTE} primaryTitle="Recovery" title="Phrase">
       <Block display="flex" justifyContent="space-between" alignItems="center">
         <Block display="flex" alignItems="center">
           <Block marginRight={1}>

--- a/packages/sanes-browser-extension/src/routes/signup/index.dom.spec.ts
+++ b/packages/sanes-browser-extension/src/routes/signup/index.dom.spec.ts
@@ -183,7 +183,6 @@ describe("DOM > Feature > Signup", () => {
   });
 
   describe("Show Phrase Step", () => {
-    let questionMark: Element;
     let checkbox: Element;
     let buttons: Element[];
     let backButton: Element;
@@ -193,24 +192,18 @@ describe("DOM > Feature > Signup", () => {
       mockCreatePersona(mockPersonaResponse([], mnemonic, []));
       await submitNewAccount(signupDom, accountName, password);
 
-      questionMark = TestUtils.scryRenderedDOMComponentsWithTag(signupDom, "img")[0];
       checkbox = TestUtils.findRenderedDOMComponentWithTag(signupDom, "input");
       buttons = TestUtils.scryRenderedDOMComponentsWithTag(signupDom, "button");
       [backButton, continueButton] = buttons;
     });
 
-    it("has a question mark button that toggles a tooltip when clicked", async () => {
-      let paragraphs = TestUtils.scryRenderedDOMComponentsWithTag(signupDom, "p");
-      expect(paragraphs.length).toBe(1);
-
-      await click(questionMark);
-
-      paragraphs = TestUtils.scryRenderedDOMComponentsWithTag(signupDom, "p");
-      expect(paragraphs.length).toBe(2);
-    }, 10000);
+    it("has an explanation text", async () => {
+      const explanation = TestUtils.scryRenderedDOMComponentsWithTag(signupDom, "p")[0];
+      expect(explanation.textContent || "").toMatch(/^Your secret recovery phrase/);
+    });
 
     it("has a toggle button that shows the mnemonic when active", async () => {
-      const renderedMnemonic = TestUtils.findRenderedDOMComponentWithTag(signupDom, "p");
+      const renderedMnemonic = TestUtils.scryRenderedDOMComponentsWithTag(signupDom, "p")[1];
       expect(renderedMnemonic.textContent).toBe("");
 
       await check(checkbox);

--- a/packages/sanes-browser-extension/src/routes/signup/index.e2e.spec.ts
+++ b/packages/sanes-browser-extension/src/routes/signup/index.e2e.spec.ts
@@ -10,24 +10,20 @@ import {
   travelToSignupNewAccountStep,
 } from "./test/operateSignup";
 
-withChainsDescribe("DOM > Signup route", (): void => {
+withChainsDescribe("DOM > Signup route", () => {
   let browser: Browser;
   let page: Page;
 
-  beforeEach(async (): Promise<void> => {
+  beforeEach(async () => {
     browser = await launchBrowser();
     page = await createPage(browser);
   }, 45000);
 
-  afterEach(
-    async (): Promise<void> => {
-      await closeBrowser(browser);
-    },
-  );
+  afterEach(async () => {
+    await closeBrowser(browser);
+  });
 
-  it("should redirect to signup route, fill required data, show recovery phrase and hint", async (): Promise<
-    void
-  > => {
+  it("should redirect to signup route, fill required data, show recovery phrase and hint", async () => {
     await travelToSignupNewAccountStep(page);
     await submitNewAccountE2E(page, randomString(10), randomString(10));
     await submitShowPhraseE2E(page);

--- a/packages/sanes-browser-extension/src/routes/signup/index.stories.tsx
+++ b/packages/sanes-browser-extension/src/routes/signup/index.stories.tsx
@@ -8,6 +8,9 @@ import NewAccountForm from "./components/NewAccountForm";
 import SecurityHintForm from "./components/SecurityHintForm";
 import ShowPhraseForm from "./components/ShowPhraseForm";
 
+const exampleMnemonic =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
 storiesOf(`${CHROME_EXTENSION_ROOT}/Signup`, module)
   .add(
     "New Account page",
@@ -21,7 +24,11 @@ storiesOf(`${CHROME_EXTENSION_ROOT}/Signup`, module)
     "Recovery Phrase page",
     (): JSX.Element => (
       <Storybook>
-        <ShowPhraseForm onBack={action("back in history")} onHintPassword={action("hint step")} />
+        <ShowPhraseForm
+          mnemonic={exampleMnemonic}
+          onBack={action("back in history")}
+          onHintPassword={action("hint step")}
+        />
       </Storybook>
     ),
   )

--- a/packages/sanes-browser-extension/src/routes/signup/index.tsx
+++ b/packages/sanes-browser-extension/src/routes/signup/index.tsx
@@ -60,7 +60,13 @@ const Signup = (): JSX.Element => {
   return (
     <React.Fragment>
       {step === "first" && <NewAccountForm onBack={onBack} onSignup={onSignup} />}
-      {step === "second" && <ShowPhraseForm onBack={onNewAccount} onHintPassword={onHintPassword} />}
+      {step === "second" && (
+        <ShowPhraseForm
+          mnemonic={personaProvider.mnemonic}
+          onBack={onNewAccount}
+          onHintPassword={onHintPassword}
+        />
+      )}
       {step === "third" && <SecurityHintForm onBack={onShowPhrase} onSaveHint={onSaveHint} />}
     </React.Fragment>
   );

--- a/packages/sanes-browser-extension/src/routes/signup/test/operateSignup.ts
+++ b/packages/sanes-browser-extension/src/routes/signup/test/operateSignup.ts
@@ -124,7 +124,7 @@ export const submitShowPhraseE2E = async (page: Page): Promise<void> => {
   await checkbox!.click();
 
   const mnemonic = await page.evaluate(() => {
-    const element = document.querySelector("p");
+    const element = document.querySelectorAll("p")[1];
     if (!element) throw new Error("Paragraph element not found");
     return element.textContent || "";
   });

--- a/packages/sanes-browser-extension/src/routes/signup/test/operateSignup.ts
+++ b/packages/sanes-browser-extension/src/routes/signup/test/operateSignup.ts
@@ -123,18 +123,12 @@ export const submitShowPhraseE2E = async (page: Page): Promise<void> => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   await checkbox!.click();
 
-  const mnemonic = await page.evaluate((): string | null => {
+  const mnemonic = await page.evaluate(() => {
     const element = document.querySelector("p");
-    if (!element) {
-      return null;
-    }
-
-    return element.textContent;
+    if (!element) throw new Error("Paragraph element not found");
+    return element.textContent || "";
   });
-
-  expect(mnemonic).not.toBe(null);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  expect(mnemonic!.split(" ").length).toBe(12);
+  expect(mnemonic.split(" ").length).toBe(12);
 
   const buttons = await page.$$("button");
   await buttons[1].click();

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -10338,18 +10338,26 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
     <h4
       className="MuiTypography-root makeStyles-inline MuiTypography-h4 MuiTypography-colorPrimary"
     >
-      New
+      Recovery
     </h4>
     <h4
       className="MuiTypography-root makeStyles-inline MuiTypography-h4"
     >
        
-      Account
+      Phrase
     </h4>
   </div>
   <div
     className="MuiBox-root MuiBox-root"
   >
+    <p
+      className="MuiTypography-root makeStyles-inline MuiTypography-body1"
+    >
+      Your secret recovery phrase consists of 12 words that act as a tool to recover your wallet on any platform.
+    </p>
+    <div
+      className="MuiBox-root MuiBox-root"
+    />
     <div
       className="MuiBox-root MuiBox-root"
     >
@@ -10362,20 +10370,8 @@ exports[`Storyshots Extension/Signup Recovery Phrase page 1`] = `
           <h6
             className="MuiTypography-root makeStyles-inline MuiTypography-subtitle2"
           >
-            Activate Recovery Phrase?
+            Show/hide recovery phrase
           </h6>
-        </div>
-        <div
-          className="makeStyles-container"
-          onClick={[Function]}
-        >
-          <img
-            alt="Info"
-            className="makeStyles-root"
-            height={16}
-            src="info_normal.svg"
-            width={16}
-          />
         </div>
       </div>
       <label


### PR DESCRIPTION
During user feedback, the screen caused a lot of confusion. This is an attempt to improve things. It might not be the final answer but addresses a bunch of concerns.

* Title updated
* Tooltip converted to description text that is visible by default
* Term "Activate" replaced with "Show/hide"
* Minor layout adjustments
* Mnemonic converted into prop in order to allow setting it in storybook

## Before

<img width="388" alt="Bildschirmfoto 2019-08-27 um 09 11 00" src="https://user-images.githubusercontent.com/2603011/63751968-aa642580-c8b0-11e9-9719-89c13da6c196.png">
<img width="388" alt="Bildschirmfoto 2019-08-27 um 09 11 07" src="https://user-images.githubusercontent.com/2603011/63751969-aa642580-c8b0-11e9-9ab8-466a666356c8.png">
<img width="388" alt="Bildschirmfoto 2019-08-27 um 09 22 30" src="https://user-images.githubusercontent.com/2603011/63751971-aafcbc00-c8b0-11e9-91e7-d46766bb933e.png">

## After

<img width="388" alt="Bildschirmfoto 2019-08-27 um 09 45 38" src="https://user-images.githubusercontent.com/2603011/63751990-b223ca00-c8b0-11e9-9546-06c557ad508a.png">
<img width="388" alt="Bildschirmfoto 2019-08-27 um 09 45 45" src="https://user-images.githubusercontent.com/2603011/63751991-b223ca00-c8b0-11e9-8f16-e063aea5685a.png">

