### PR TITLE
Feature – Use new name for the extension

### DIFF
--- a/packages/sanes-browser-extension/src/routes/welcome/index.tsx
+++ b/packages/sanes-browser-extension/src/routes/welcome/index.tsx
@@ -31,7 +31,7 @@ const Welcome = (): JSX.Element => {
   return (
     <PageLayout id={WELCOME_ROUTE} primaryTitle="Welcome" title="to NEUMA">
       <Typography variant="body1" inline>
-        This plugin lets you manage all your accounts in one place.
+        This extension lets you manage all your accounts in one place.
       </Typography>
       <Block marginTop={2} />
       <Button variant="contained" fullWidth onClick={login}>

--- a/packages/sanes-browser-extension/src/routes/welcome/index.tsx
+++ b/packages/sanes-browser-extension/src/routes/welcome/index.tsx
@@ -29,7 +29,7 @@ const Welcome = (): JSX.Element => {
   };
 
   return (
-    <PageLayout id={WELCOME_ROUTE} primaryTitle="Welcome" title="to your IOV manager">
+    <PageLayout id={WELCOME_ROUTE} primaryTitle="Welcome" title="to NEUMA">
       <Typography variant="body1" inline>
         This plugin lets you manage all your accounts in one place.
       </Typography>

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -8157,7 +8157,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
       className="MuiTypography-root makeStyles-inline MuiTypography-h4"
     >
        
-      to your IOV manager
+      to NEUMA
     </h4>
   </div>
   <div

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -8166,7 +8166,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
     <p
       className="MuiTypography-root makeStyles-inline MuiTypography-body1"
     >
-      This plugin lets you manage all your accounts in one place.
+      This extension lets you manage all your accounts in one place.
     </p>
     <div
       className="MuiBox-root MuiBox-root"


### PR DESCRIPTION
Based on #623 (last 2 commits are new)

**Before**

<img width="372" alt="Bildschirmfoto 2019-08-29 um 14 57 41" src="https://user-images.githubusercontent.com/2603011/63942276-b6491680-ca6d-11e9-903e-863ceeeff3fc.png">

**After**

<img width="372" alt="Bildschirmfoto 2019-08-29 um 14 55 38" src="https://user-images.githubusercontent.com/2603011/63942285-bd702480-ca6d-11e9-9732-b42de78e6f44.png">
