### PR TITLE
Feature - Rename signed TXs

### DIFF
--- a/packages/sanes-browser-extension/src/routes/wallet/index.tsx
+++ b/packages/sanes-browser-extension/src/routes/wallet/index.tsx
@@ -131,7 +131,7 @@ const AccountView = (): JSX.Element => {
         )}
         <Hairline space={2} />
         <Block>
-          <ListTxs title="Transactions" txs={personaProvider.txs} />
+          <ListTxs title="Signed Transactions" txs={personaProvider.txs} />
         </Block>
       </PageLayout>
     </Drawer>

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -10848,7 +10848,7 @@ exports[`Storyshots Extension/Wallet Status page Empty 1`] = `
                     <p
                       className="MuiTypography-root MuiTypography-body1"
                     >
-                      Transactions
+                      Signed Transactions
                     </p>
                   </div>
                 </li>
@@ -10867,7 +10867,7 @@ exports[`Storyshots Extension/Wallet Status page Empty 1`] = `
                   className="MuiListItemIcon-root makeStyles-empty"
                 >
                   <img
-                    alt="No Transactions"
+                    alt="No Signed Transactions"
                     className="makeStyles-root"
                     height="42"
                     src="uptodate.svg"
@@ -10879,7 +10879,7 @@ exports[`Storyshots Extension/Wallet Status page Empty 1`] = `
                   <span
                     className="MuiTypography-root MuiListItemText-primary MuiTypography-body1"
                   >
-                    No Transactions
+                    No Signed Transactions
                   </span>
                 </div>
               </li>
@@ -11007,7 +11007,7 @@ exports[`Storyshots Extension/Wallet Status page Txs 1`] = `
                     <p
                       className="MuiTypography-root MuiTypography-body1"
                     >
-                      Transactions
+                      Signed Transactions
                     </p>
                   </div>
                 </li>


### PR DESCRIPTION
**Description**
This PR updates the box's title in order to specify it will contain only signed txs.

It closes #546

<img width="402" alt="Screenshot 2019-08-29 15 39 58" src="https://user-images.githubusercontent.com/4266059/63945427-961c5600-ca73-11e9-949d-8cceefa2bf28.png">
