### PR TITLE
Show formatted JSON for governance transactions

### DIFF
--- a/packages/bierzo-wallet/src/utils/test/persona.ts
+++ b/packages/bierzo-wallet/src/utils/test/persona.ts
@@ -16,8 +16,8 @@ export const submitExtensionSignupForm = async (page: Page, password: string): P
   await clickCreatePersona(page);
 
   // Fill the form
-  await page.type(`input[name="${PASSWORD_FIELD}`, password);
-  await page.type(`input[name="${PASSWORD_CONFIRM_FIELD}`, password);
+  await page.type(`input[name="${PASSWORD_FIELD}"]`, password);
+  await page.type(`input[name="${PASSWORD_CONFIRM_FIELD}"]`, password);
   await page.click(`input[name="${TERMS_ACCEPT_FIELD}"]`);
   await page.click('button[type="submit"]');
   await sleep(1000);

--- a/packages/sanes-browser-extension/src/routes/tx-request/components/ShowRequest/ReqCreateProposalTx.tsx
+++ b/packages/sanes-browser-extension/src/routes/tx-request/components/ShowRequest/ReqCreateProposalTx.tsx
@@ -1,18 +1,32 @@
 import { CreateProposalTx } from "@iov/bns";
-import { Typography } from "medulas-react-components";
+import { makeStyles } from "@material-ui/core";
+import { List, ListItem } from "medulas-react-components";
 import * as React from "react";
 
 export const REQ_CREATE_PROPOSAL = "req-create-proposal-tx";
+
+const useStyles = makeStyles({
+  txContent: {
+    margin: "0",
+    fontSize: "1.2rem",
+    overflowX: "scroll",
+  },
+});
 
 interface Props {
   readonly tx: CreateProposalTx;
 }
 
 const ReqCreateProposalTx = ({ tx }: Props): JSX.Element => {
+  const classes = useStyles();
+
+  const content = JSON.stringify(tx, null, 2);
   return (
-    <React.Fragment>
-      <Typography id={REQ_CREATE_PROPOSAL}>{JSON.stringify(tx)}</Typography>
-    </React.Fragment>
+    <List id={REQ_CREATE_PROPOSAL}>
+      <ListItem>
+        <pre className={classes.txContent}>{content}</pre>
+      </ListItem>
+    </List>
   );
 };
 

--- a/packages/sanes-browser-extension/src/routes/tx-request/components/ShowRequest/ReqVoteTx.tsx
+++ b/packages/sanes-browser-extension/src/routes/tx-request/components/ShowRequest/ReqVoteTx.tsx
@@ -1,18 +1,32 @@
 import { VoteTx } from "@iov/bns";
-import { Typography } from "medulas-react-components";
+import { makeStyles } from "@material-ui/core";
+import { List, ListItem } from "medulas-react-components";
 import * as React from "react";
 
 export const REQ_VOTE = "req-vote-tx";
+
+const useStyles = makeStyles({
+  txContent: {
+    margin: "0",
+    fontSize: "1.2rem",
+    overflowX: "auto",
+  },
+});
 
 interface Props {
   readonly tx: VoteTx;
 }
 
 const ReqVoteTx = ({ tx }: Props): JSX.Element => {
+  const classes = useStyles();
+
+  const content = JSON.stringify(tx, null, 2);
   return (
-    <React.Fragment>
-      <Typography id={REQ_VOTE}>{JSON.stringify(tx)}</Typography>
-    </React.Fragment>
+    <List id={REQ_VOTE}>
+      <ListItem>
+        <pre className={classes.txContent}>{content}</pre>
+      </ListItem>
+    </List>
   );
 };
 

--- a/packages/sil-governance/src/utils/test/persona.ts
+++ b/packages/sil-governance/src/utils/test/persona.ts
@@ -15,8 +15,8 @@ export const submitExtensionSignupForm = async (page: Page, password: string): P
   await clickCreatePersona(page);
 
   // Fill the form
-  await page.type(`input[name="${PASSWORD_FIELD}`, password);
-  await page.type(`input[name="${PASSWORD_CONFIRM_FIELD}`, password);
+  await page.type(`input[name="${PASSWORD_FIELD}"]`, password);
+  await page.type(`input[name="${PASSWORD_CONFIRM_FIELD}"]`, password);
   await page.click(`input[name="${TERMS_ACCEPT_FIELD}"]`);
   await page.click('button[type="submit"]');
   await sleep(1000);

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -9743,12 +9743,79 @@ exports[`Storyshots Extension/Transaction Request Create Proposal 1`] = `
          wants you to sign:
       </p>
     </div>
-    <p
-      className="MuiTypography-root MuiTypography-body1"
+    <ul
+      className="MuiList-root MuiList-padding"
       id="req-create-proposal-tx"
     >
-      {"kind":"bns/create_proposal","creator":{"chainId":"some-chain","pubkey":{"algo":"ed25519","data":{"0":113,"1":150,"2":196,"3":101,"4":228,"5":201,"6":91,"7":61,"8":206,"9":66,"10":87,"11":132,"12":245,"13":25,"14":54,"15":185,"16":93,"17":166,"18":188,"19":88,"20":179,"21":33,"22":38,"23":72,"24":205,"25":202,"26":100,"27":238,"28":113,"29":152,"30":223,"31":71}}},"fee":{"tokens":{"quantity":"1000000001","fractionalDigits":9,"tokenTicker":"CASH"}},"title":"Just an idea","description":"Try a centralized approach instead?","electionRuleId":2,"startTime":1566383301091,"author":"tiov1k898u78hgs36uqw68dg7va5nfkgstu5z0fhz3f","action":{"kind":"gov_create_text_resolution","resolution":"Stop all this blockchain stuff"}}
-    </p>
+      <li
+        className="MuiListItem-root MuiListItem-gutters"
+        disabled={false}
+      >
+        <pre
+          className="makeStyles-txContent"
+        >
+          {
+  "kind": "bns/create_proposal",
+  "creator": {
+    "chainId": "some-chain",
+    "pubkey": {
+      "algo": "ed25519",
+      "data": {
+        "0": 113,
+        "1": 150,
+        "2": 196,
+        "3": 101,
+        "4": 228,
+        "5": 201,
+        "6": 91,
+        "7": 61,
+        "8": 206,
+        "9": 66,
+        "10": 87,
+        "11": 132,
+        "12": 245,
+        "13": 25,
+        "14": 54,
+        "15": 185,
+        "16": 93,
+        "17": 166,
+        "18": 188,
+        "19": 88,
+        "20": 179,
+        "21": 33,
+        "22": 38,
+        "23": 72,
+        "24": 205,
+        "25": 202,
+        "26": 100,
+        "27": 238,
+        "28": 113,
+        "29": 152,
+        "30": 223,
+        "31": 71
+      }
+    }
+  },
+  "fee": {
+    "tokens": {
+      "quantity": "1000000001",
+      "fractionalDigits": 9,
+      "tokenTicker": "CASH"
+    }
+  },
+  "title": "Just an idea",
+  "description": "Try a centralized approach instead?",
+  "electionRuleId": 2,
+  "startTime": 1566383301091,
+  "author": "tiov1k898u78hgs36uqw68dg7va5nfkgstu5z0fhz3f",
+  "action": {
+    "kind": "gov_create_text_resolution",
+    "resolution": "Stop all this blockchain stuff"
+  }
+}
+        </pre>
+      </li>
+    </ul>
     <div
       className="MuiBox-root MuiBox-root"
     />
@@ -10666,12 +10733,72 @@ exports[`Storyshots Extension/Transaction Request Vote 1`] = `
          wants you to sign:
       </p>
     </div>
-    <p
-      className="MuiTypography-root MuiTypography-body1"
+    <ul
+      className="MuiList-root MuiList-padding"
       id="req-vote-tx"
     >
-      {"kind":"bns/vote","creator":{"chainId":"some-chain","pubkey":{"algo":"ed25519","data":{"0":113,"1":150,"2":196,"3":101,"4":228,"5":201,"6":91,"7":61,"8":206,"9":66,"10":87,"11":132,"12":245,"13":25,"14":54,"15":185,"16":93,"17":166,"18":188,"19":88,"20":179,"21":33,"22":38,"23":72,"24":205,"25":202,"26":100,"27":238,"28":113,"29":152,"30":223,"31":71}}},"fee":{"tokens":{"quantity":"1000000001","fractionalDigits":9,"tokenTicker":"CASH"}},"proposalId":666,"selection":0}
-    </p>
+      <li
+        className="MuiListItem-root MuiListItem-gutters"
+        disabled={false}
+      >
+        <pre
+          className="makeStyles-txContent"
+        >
+          {
+  "kind": "bns/vote",
+  "creator": {
+    "chainId": "some-chain",
+    "pubkey": {
+      "algo": "ed25519",
+      "data": {
+        "0": 113,
+        "1": 150,
+        "2": 196,
+        "3": 101,
+        "4": 228,
+        "5": 201,
+        "6": 91,
+        "7": 61,
+        "8": 206,
+        "9": 66,
+        "10": 87,
+        "11": 132,
+        "12": 245,
+        "13": 25,
+        "14": 54,
+        "15": 185,
+        "16": 93,
+        "17": 166,
+        "18": 188,
+        "19": 88,
+        "20": 179,
+        "21": 33,
+        "22": 38,
+        "23": 72,
+        "24": 205,
+        "25": 202,
+        "26": 100,
+        "27": 238,
+        "28": 113,
+        "29": 152,
+        "30": 223,
+        "31": 71
+      }
+    }
+  },
+  "fee": {
+    "tokens": {
+      "quantity": "1000000001",
+      "fractionalDigits": 9,
+      "tokenTicker": "CASH"
+    }
+  },
+  "proposalId": 666,
+  "selection": 0
+}
+        </pre>
+      </li>
+    </ul>
     <div
       className="MuiBox-root MuiBox-root"
     />


### PR DESCRIPTION
This is a baby step towards #551, making the JSON content from the transaction a bit better readable.

**Before**

<img width="372" alt="Bildschirmfoto 2019-08-29 um 17 30 58" src="https://user-images.githubusercontent.com/2603011/63954381-52c9e380-ca83-11e9-95be-19bf911ec05e.png">
<img width="372" alt="Bildschirmfoto 2019-08-29 um 17 31 06" src="https://user-images.githubusercontent.com/2603011/63954382-52c9e380-ca83-11e9-8ea5-ff50e31d63cd.png">

**After**

<img width="372" alt="create-proposal" src="https://user-images.githubusercontent.com/2603011/63954442-66754a00-ca83-11e9-87a7-f87ef2313780.png">
<img width="372" alt="vote1" src="https://user-images.githubusercontent.com/2603011/63954444-670de080-ca83-11e9-8aaa-2f43dd663a26.png">
<img width="372" alt="vote2" src="https://user-images.githubusercontent.com/2603011/63954447-670de080-ca83-11e9-9acf-19d28d68d3bf.png">
