### PR TITLE
Fix #640 - Add "me" badge to sender address

### DIFF
--- a/packages/bierzo-wallet/src/logic/transactions/types/BwSendTransaction/ui/SendTxRow/Details.tsx
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwSendTransaction/ui/SendTxRow/Details.tsx
@@ -1,16 +1,9 @@
 import { Address } from "@iov/bcp";
-import { makeStyles } from "@material-ui/core";
 import { Block, Typography } from "medulas-react-components";
 import * as React from "react";
 
 import BlockchainAddress from "../../../../../../components/BlockchainAddress";
 import { ProcessedSendTransaction } from "../../../../../../store/notifications";
-
-const useStyles = makeStyles({
-  sectionName: {
-    overflowWrap: "break-word",
-  },
-});
 
 interface Props {
   readonly tx: ProcessedSendTransaction;
@@ -18,8 +11,6 @@ interface Props {
 }
 
 const TxDetails = ({ userAddresses, tx }: Props): JSX.Element => {
-  const classes = useStyles();
-
   return (
     <Block paddingLeft="56px" display="flex" flexDirection="column">
       <Block margin={2} />

--- a/packages/bierzo-wallet/src/logic/transactions/types/BwSendTransaction/ui/SendTxRow/Details.tsx
+++ b/packages/bierzo-wallet/src/logic/transactions/types/BwSendTransaction/ui/SendTxRow/Details.tsx
@@ -28,14 +28,7 @@ const TxDetails = ({ userAddresses, tx }: Props): JSX.Element => {
           <Typography variant="subtitle2" weight="regular" gutterBottom>
             Sender:
           </Typography>
-          <Typography
-            variant="subtitle2"
-            weight="regular"
-            color="textSecondary"
-            className={classes.sectionName}
-          >
-            {tx.original.sender}
-          </Typography>
+          <BlockchainAddress userAddresses={userAddresses} address={tx.original.sender} />
         </Block>
         <Block width="35%">
           <Block>

--- a/packages/bierzo-wallet/src/routes/transactions/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/transactions/index.stories.tsx
@@ -94,7 +94,7 @@ const parsedTxs: readonly (ProcessedSendTransaction | ProcessedTx<RegisterUserna
     id: "tx1" as TransactionId,
     original: {
       kind: "bcp/send",
-      sender: "george*iov" as Address,
+      sender: address,
       recipient: "me" as Address,
       amount: stringToAmount("10.5", lsk),
       memo: "Sample note",


### PR DESCRIPTION
Closes #640.

**After**
![me-badge](https://user-images.githubusercontent.com/3502260/64174844-c17fb600-ce62-11e9-87bd-837c08b8f7d7.png)
