### PR TITLE
Feature #622 - Rename "New wallet" to "Create wallet"

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@types/storybook__react": "^4.0.2",
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
-    "core-js": "^2.4.0",
     "eslint-config-prettier": "^4.1.0",
     "eslint-config-react-app": "^4.0.1",
     "eslint-plugin-prettier": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/storybook__react": "^4.0.2",
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
+    "core-js": "^2.4.0",
     "eslint-config-prettier": "^4.1.0",
     "eslint-config-react-app": "^4.0.1",
     "eslint-plugin-prettier": "^3.0.1",

--- a/packages/sanes-browser-extension/src/routes/welcome/index.dom.spec.ts
+++ b/packages/sanes-browser-extension/src/routes/welcome/index.dom.spec.ts
@@ -27,8 +27,8 @@ describe("DOM > Feature > Welcome", () => {
     await whenOnNavigatedToRoute(UNLOCK_ROUTE);
   }, 60000);
 
-  it('has a "New Wallet" button that redirects to the Sign Up view when clicked', async () => {
-    expect(newWalletButton.textContent).toBe("New Wallet");
+  it('has a "Create Wallet" button that redirects to the Sign Up view when clicked', async () => {
+    expect(newWalletButton.textContent).toBe("Create Wallet");
     click(newWalletButton);
     await whenOnNavigatedToRoute(SIGNUP_ROUTE);
   }, 60000);

--- a/packages/sanes-browser-extension/src/routes/welcome/index.tsx
+++ b/packages/sanes-browser-extension/src/routes/welcome/index.tsx
@@ -40,7 +40,7 @@ const Welcome = (): JSX.Element => {
       </Button>
       <Block marginTop={2} />
       <Button variant="contained" fullWidth onClick={createNewWallet}>
-        New Wallet
+        Create Wallet
       </Button>
       <Block marginTop={2} />
       <Button variant="contained" fullWidth onClick={importWallet}>

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -9514,7 +9514,7 @@ exports[`Storyshots Extension Welcome page 1`] = `
       <span
         className="MuiButton-label"
       >
-        New Wallet
+        Create Wallet
       </span>
     </button>
     <div


### PR DESCRIPTION
**Description**
This PR will rename "New wallet" button to "Create wallet"  button.

Closes #622.