### PR TITLE
Fix – Fix storybook build by simplifying dependency

### DIFF
--- a/packages/bierzo-wallet/package.json
+++ b/packages/bierzo-wallet/package.json
@@ -16,7 +16,6 @@
     "@material-ui/core": "^4.3.1",
     "@material-ui/icons": "^4.2.1",
     "@material-ui/styles": "^4.3.0",
-    "babel-polyfill": "^6.16.0",
     "clipboard-copy": "^3.1.0",
     "concurrently": "^4.1.0",
     "file-saver": "^2.0.2",
@@ -30,6 +29,7 @@
     "react-router": "^5.0.1",
     "react-router-dom": "^5.0.0",
     "redux": "^4.0.1",
+    "regenerator-runtime": "^0.13.3",
     "ui-logic": "^0.4.5"
   },
   "devDependencies": {

--- a/packages/bierzo-wallet/src/communication/ledgerRpcEndpoint.ts
+++ b/packages/bierzo-wallet/src/communication/ledgerRpcEndpoint.ts
@@ -1,4 +1,4 @@
-import "babel-polyfill"; // required by @ledgerhq/hw-transport-webusb
+import "regenerator-runtime"; // required by @ledgerhq/hw-transport-webusb
 
 import {
   Algorithm,

--- a/packages/valdueza-storybook/.gitignore
+++ b/packages/valdueza-storybook/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+storybook-static/

--- a/scripts/bnsd/genesis_app_state.json
+++ b/scripts/bnsd/genesis_app_state.json
@@ -17,6 +17,12 @@
       "coins": ["4000 BASH"]
     }
   ],
+  "username": [
+    {
+      "owner": "bech32:tiov1l678408y7a64cj66s8j64fevmspyfxdmv38cxw",
+      "username": "ledger-dev*iov"
+    }
+  ],
   "currencies": [
     {
       "ticker": "CASH",

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -66,6 +66,10 @@ fold_start "yarn-build"
 yarn build
 fold_end
 
+fold_start "yarn-build-storybook"
+yarn build-storybook
+fold_end
+
 #
 # Sanity
 #

--- a/yarn.lock
+++ b/yarn.lock
@@ -4908,7 +4908,7 @@ babel-plugin-transform-undefined-to-void@^6.9.4:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz#be241ca81404030678b748717322b89d0c8fe280"
   integrity sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=
 
-babel-polyfill@6.16.0, babel-polyfill@^6.16.0:
+babel-polyfill@6.16.0:
   version "6.16.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.16.0.tgz#2d45021df87e26a374b6d4d1a9c65964d17f2422"
   integrity sha1-LUUCHfh+JqN0ttTRqcZZZNF/JCI=
@@ -16118,7 +16118,7 @@ regenerator-runtime@^0.12.0, regenerator-runtime@^0.12.1:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
-regenerator-runtime@^0.13.2:
+regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==


### PR DESCRIPTION
As pointed out by @albertandrejev, the storybook build broke due to a new dependency introduced recently for Ledger. It turns out we can use the much simpler `regenerator-runtime` instead of the full `babel-polyfill`, such that the missing `core-js/shim` is not required anymore. This change is better anyways and solves the problem as well.

Next time we detect this kind of errors earlies because we now run `yarn build-storybook` in CI, which would have cought this bug.