### PR TITLE
Fix – Remove link style and extra space from vote transaction

### DIFF
--- a/packages/sanes-browser-extension/src/routes/wallet/components/Tx/MsgVoteTx.tsx
+++ b/packages/sanes-browser-extension/src/routes/wallet/components/Tx/MsgVoteTx.tsx
@@ -36,11 +36,10 @@ const MsgVoteTx = ({ error, selection }: MsgVoteTxProps): JSX.Element => {
         <Typography weight="light" inline>
           You have voted{" "}
         </Typography>
-        <Typography weight="semibold" inline link>
+        <Typography weight="semibold" inline>
           {selection}
         </Typography>
         <Typography weight="light" inline>
-          {" "}
           .
         </Typography>
       </React.Fragment>

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -13437,14 +13437,13 @@ exports[`Storyshots Extension/Wallet Status page Txs 1`] = `
                          
                       </p>
                       <p
-                        className="MuiTypography-root makeStyles-weight makeStyles-weight makeStyles-inline makeStyles-link MuiTypography-body1"
+                        className="MuiTypography-root makeStyles-weight makeStyles-weight makeStyles-inline MuiTypography-body1"
                       >
                         Yes
                       </p>
                       <p
                         className="MuiTypography-root makeStyles-weight makeStyles-weight makeStyles-inline MuiTypography-body1"
                       >
-                         
                         .
                       </p>
                     </span>


### PR DESCRIPTION
**Before**

<img width="320" alt="Bildschirmfoto 2019-09-12 um 17 58 33" src="https://user-images.githubusercontent.com/2603011/64802381-ce9b5400-d58a-11e9-8469-ef3c00a06607.png">

**After**

<img width="320" alt="Bildschirmfoto 2019-09-12 um 18 20 47" src="https://user-images.githubusercontent.com/2603011/64802386-d22edb00-d58a-11e9-8894-55c03a713dc4.png">
