### PR TITLE
Fix – Use separate error messges for fraction format and fraction value

### DIFF
--- a/packages/sil-governance/src/routes/create-proposal/components/FormOptions/index.tsx
+++ b/packages/sil-governance/src/routes/create-proposal/components/FormOptions/index.tsx
@@ -33,11 +33,15 @@ export const isFraction = (value: FieldInputValue): string | undefined => {
   const numerator = parseInt(members[0], 10);
   const denominator = parseInt(members[1], 10);
 
-  if (Number.isInteger(numerator) && Number.isInteger(denominator) && numerator <= denominator) {
-    return undefined;
-  } else {
-    return "Must be a valid fraction";
+  if (!Number.isInteger(numerator) || !Number.isInteger(denominator)) {
+    return "Must be a valid fraction in the form a/b";
   }
+
+  if (numerator > denominator) {
+    return "Fraction must be less than or equal to 1";
+  }
+
+  return undefined; // valid
 };
 
 interface Props {


### PR DESCRIPTION
Creates more helpful error messages separate for

1. Format of the input
2. Value of the input

Closes #677