### PR TITLE
Feature – Update cache settings

### DIFF
--- a/packages/bierzo-wallet/firebase.wallet-production.json
+++ b/packages/bierzo-wallet/firebase.wallet-production.json
@@ -8,6 +8,16 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      },
+      {
+        "source": "static/**",
+        "headers": [{ "key": "Cache-Control", "value": "max-age=31536000" }]
+      }
     ]
   }
 }

--- a/packages/bierzo-wallet/firebase.wallet-staging.json
+++ b/packages/bierzo-wallet/firebase.wallet-staging.json
@@ -8,6 +8,16 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      },
+      {
+        "source": "static/**",
+        "headers": [{ "key": "Cache-Control", "value": "max-age=31536000" }]
+      }
     ]
   }
 }

--- a/packages/bierzo-wallet/package.json
+++ b/packages/bierzo-wallet/package.json
@@ -41,9 +41,9 @@
   },
   "scripts": {
     "use-extension-config-development": "cd ../sanes-browser-extension && yarn use-config-development && yarn override-config-development && cd ../bierzo-wallet",
-    "override-config-development": "mkdir -p ./build/static/config && cp ./src/config/development.json ./build/static/config/conf.json",
-    "override-config-staging": "mkdir -p ./build/static/config && cp ./src/config/staging.json ./build/static/config/conf.json",
-    "override-config-production": "mkdir -p ./build/static/config && cp ./src/config/production.json ./build/static/config/conf.json",
+    "override-config-development": "mkdir -p ./build/config && cp ./src/config/development.json ./build/config/conf.json",
+    "override-config-staging": "mkdir -p ./build/config && cp ./src/config/staging.json ./build/config/conf.json",
+    "override-config-production": "mkdir -p ./build/config && cp ./src/config/production.json ./build/config/conf.json",
     "lint": "eslint -c .eslintrc.js --max-warnings 0 'src/**/*.ts{,x}'",
     "lint-fix": "eslint -c .eslintrc.js 'src/**/*.ts{,x}' --fix",
     "format": "prettier --write --loglevel warn './src/**/*.{ts,tsx,json,md,css}'",

--- a/packages/bierzo-wallet/src/config/index.ts
+++ b/packages/bierzo-wallet/src/config/index.ts
@@ -64,7 +64,7 @@ const loadConfigurationFile = async (): Promise<Config> => {
     return developmentConfig;
   }
 
-  const response = await fetch("/static/config/conf.json");
+  const response = await fetch("/config/conf.json");
   if (!response.ok) {
     throw new Error(`Failed to fetch URL. Response status code: ${response.status}`);
   }

--- a/packages/sil-governance/firebase.governance-production.json
+++ b/packages/sil-governance/firebase.governance-production.json
@@ -8,6 +8,16 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      },
+      {
+        "source": "static/**",
+        "headers": [{ "key": "Cache-Control", "value": "max-age=31536000" }]
+      }
     ]
   }
 }

--- a/packages/sil-governance/firebase.governance-staging.json
+++ b/packages/sil-governance/firebase.governance-staging.json
@@ -8,6 +8,16 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      },
+      {
+        "source": "static/**",
+        "headers": [{ "key": "Cache-Control", "value": "max-age=31536000" }]
+      }
     ]
   }
 }

--- a/packages/sil-governance/package.json
+++ b/packages/sil-governance/package.json
@@ -25,9 +25,9 @@
   },
   "scripts": {
     "use-extension-config-development": "cd ../sanes-browser-extension && yarn use-config-development && yarn override-config-development && cd ../sil-governance",
-    "override-config-development": "mkdir -p ./build/static/config && cp ./src/config/development.json ./build/static/config/conf.json",
-    "override-config-staging": "mkdir -p ./build/static/config && cp ./src/config/staging.json ./build/static/config/conf.json",
-    "override-config-production": "mkdir -p ./build/static/config && cp ./src/config/production.json ./build/static/config/conf.json",
+    "override-config-development": "mkdir -p ./build/config && cp ./src/config/development.json ./build/config/conf.json",
+    "override-config-staging": "mkdir -p ./build/config && cp ./src/config/staging.json ./build/config/conf.json",
+    "override-config-production": "mkdir -p ./build/config && cp ./src/config/production.json ./build/config/conf.json",
     "lint": "eslint -c .eslintrc.js --max-warnings 0 'src/**/*.ts{,x}'",
     "lint-fix": "eslint -c .eslintrc.js 'src/**/*.ts{,x}' --fix",
     "format": "prettier --write --loglevel warn './src/**/*.{ts,tsx,json,md,css}'",

--- a/packages/sil-governance/src/config/index.ts
+++ b/packages/sil-governance/src/config/index.ts
@@ -35,7 +35,7 @@ const loadConfigurationFile = async (): Promise<Config> => {
     return developmentConfig;
   }
 
-  const response = await fetch("/static/config/conf.json");
+  const response = await fetch("/config/conf.json");
   if (!response.ok) {
     throw new Error(`Failed to fetch URL. Response status code: ${response.status}`);
   }


### PR DESCRIPTION
Closes #598

**Motivation**

For the next two testnets [catnet](https://github.com/iov-one/ponferrada/issues/745) and [babynet](https://github.com/iov-one/ponferrada/issues/746) we will need to update config files. To make sure users do not load outdates configs, the default cache (1 hour) was disabled. On the other hand, files in the `static/` folder are now cached for 1 year since files in this folder have a special meaning in CRA.

**Docs**

> Using `Cache-Control: max-age=31536000` for your build/static assets, and `Cache-Control: no-cache` for everything else is a safe and effective starting point that ensures your user's browser will always check for an updated index.html file, and will cache all of the build/static files for one year. Note that you can use the one year expiration on build/static safely because the file contents hash is embedded into the filename.

https://create-react-app.dev/docs/production-build#static-file-caching