### PR TITLE
Feature #668 - Improve Title Validation

### DIFF
--- a/packages/sil-governance/src/routes/create-proposal/components/ProposalForm.tsx
+++ b/packages/sil-governance/src/routes/create-proposal/components/ProposalForm.tsx
@@ -233,8 +233,10 @@ const ProposalForm = (): JSX.Element => {
     <Block flexGrow={1} margin={2}>
       <Typography>Create Proposal</Typography>
       <Form onSubmit={handleSubmit}>
-        <Block display="flex" justifyContent="space-between" marginTop={2}>
-          <TitleField form={form} />
+        <Block display="flex" marginTop={2}>
+          <Block flexGrow={1} marginRight={2}>
+            <TitleField form={form} />
+          </Block>
           <WhenField form={form} />
         </Block>
         <ProposalTypeSelect form={form} changeProposalType={setProposalType} />

--- a/packages/sil-governance/src/routes/create-proposal/components/TitleField.tsx
+++ b/packages/sil-governance/src/routes/create-proposal/components/TitleField.tsx
@@ -2,6 +2,8 @@ import { FormApi } from "final-form";
 import {
   Block,
   composeValidators,
+  FieldInputValue,
+  longerThan,
   notLongerThan,
   required,
   TextField,
@@ -11,14 +13,29 @@ import React from "react";
 
 export const TITLE_FIELD = "Title";
 const TITLE_PLACEHOLDER = "Enter Title";
-const TITLE_MAX_LENGTH = 30;
+const TITLE_MIN_LENGTH = 10;
+const TITLE_MAX_LENGTH = 50;
 
 interface Props {
   readonly form: FormApi;
 }
 
 const TitleField = ({ form }: Props): JSX.Element => {
-  const validator = composeValidators(required, notLongerThan(TITLE_MAX_LENGTH));
+  const charsetValidator = (value: FieldInputValue): string | undefined => {
+    if (typeof value !== "string") throw new Error("Input must be a string");
+
+    const isCharsetValid = !!value.match(/^[a-zA-Z0-9 _.-]*$/);
+
+    if (isCharsetValid) return undefined;
+    return `Symbols supported: ".", "-", "_"`;
+  };
+
+  const validator = composeValidators(
+    required,
+    longerThan(TITLE_MIN_LENGTH),
+    notLongerThan(TITLE_MAX_LENGTH),
+    charsetValidator,
+  );
 
   return (
     <Block>

--- a/packages/sil-governance/src/routes/dashboard/components/Proposal/Title.tsx
+++ b/packages/sil-governance/src/routes/dashboard/components/Proposal/Title.tsx
@@ -1,19 +1,24 @@
-import { Block, Typography } from "medulas-react-components";
+import { Block, makeStyles, Typography } from "medulas-react-components";
 import React from "react";
-import { ellipsify } from "ui-logic";
 
-const TITLE_MAX_LENGTH = 30;
+const useStyles = makeStyles({
+  title: {
+    wordBreak: "break-all",
+  },
+});
 
 interface Props {
   readonly title: string;
 }
 
 const Title = ({ title }: Props): JSX.Element => {
-  const shortTitle = ellipsify(title, TITLE_MAX_LENGTH);
+  const classes = useStyles();
 
   return (
     <Block display="flex" alignItems="center">
-      <Typography variant="h6">{shortTitle}</Typography>
+      <Typography className={classes.title} variant="h6">
+        {title}
+      </Typography>
     </Block>
   );
 };


### PR DESCRIPTION
**Description**
This PR adds the following validation for the title field of Create Proposal:
- Longer max title length of 50 characters
- Arbitrary min title length of 10 characters
- Validation accepts alphanumeric characters and the following symbols: ".", "-", "_"

It also makes the input field bigger to better accommodate the new max title length and adds support for 2 line titles in the Dashboard view.

Closes #668.

**Screenshots**
![imagen](https://user-images.githubusercontent.com/44572727/65587975-0640cd80-df87-11e9-90f3-5949e9127921.png)
![imagen](https://user-images.githubusercontent.com/44572727/65587986-0b058180-df87-11e9-9dad-798b6f145f5d.png)