### PR TITLE
Feature/#737 show ledger address prompt

### DIFF
--- a/packages/bierzo-wallet/src/communication/extensionRpcEndpoint.ts
+++ b/packages/bierzo-wallet/src/communication/extensionRpcEndpoint.ts
@@ -40,7 +40,7 @@ export const extensionRpcEndpoint: RpcEndpoint = {
   authorizeSignAndPostMessage: "Please authorize request in Neuma to continue.",
   notAvailableMessage: "You need to install the Neuma browser extension.",
   noMatchingIdentityMessage: "Please unlock Neuma to continue.",
-  rpcEndpointType: "extension",
+  type: "extension",
   sendGetIdentitiesRequest: async (request: JsonRpcRequest): Promise<GetIdentitiesResponse | undefined> => {
     if (!isExtensionContext()) return undefined;
 

--- a/packages/bierzo-wallet/src/communication/extensionRpcEndpoint.ts
+++ b/packages/bierzo-wallet/src/communication/extensionRpcEndpoint.ts
@@ -40,6 +40,7 @@ export const extensionRpcEndpoint: RpcEndpoint = {
   authorizeSignAndPostMessage: "Please authorize request in Neuma to continue.",
   notAvailableMessage: "You need to install the Neuma browser extension.",
   noMatchingIdentityMessage: "Please unlock Neuma to continue.",
+  rpcEndpointType: "extension",
   sendGetIdentitiesRequest: async (request: JsonRpcRequest): Promise<GetIdentitiesResponse | undefined> => {
     if (!isExtensionContext()) return undefined;
 

--- a/packages/bierzo-wallet/src/communication/ledgerRpcEndpoint.ts
+++ b/packages/bierzo-wallet/src/communication/ledgerRpcEndpoint.ts
@@ -39,7 +39,7 @@ export const ledgerRpcEndpoint: RpcEndpoint = {
   authorizeSignAndPostMessage: "Please sign transaction on Ledger device to continue.",
   notAvailableMessage: "Please connect your Ledger Nano S, open the IOV app and try again.",
   noMatchingIdentityMessage: "No matching identity found. Did you open the correct app?",
-  rpcEndpointType: "ledger",
+  type: "ledger",
 
   sendGetIdentitiesRequest: async (request: JsonRpcRequest): Promise<GetIdentitiesResponse | undefined> => {
     if (

--- a/packages/bierzo-wallet/src/communication/ledgerRpcEndpoint.ts
+++ b/packages/bierzo-wallet/src/communication/ledgerRpcEndpoint.ts
@@ -39,6 +39,7 @@ export const ledgerRpcEndpoint: RpcEndpoint = {
   authorizeSignAndPostMessage: "Please sign transaction on Ledger device to continue.",
   notAvailableMessage: "Please connect your Ledger Nano S, open the IOV app and try again.",
   noMatchingIdentityMessage: "No matching identity found. Did you open the correct app?",
+  rpcEndpointType: "ledger",
 
   sendGetIdentitiesRequest: async (request: JsonRpcRequest): Promise<GetIdentitiesResponse | undefined> => {
     if (

--- a/packages/bierzo-wallet/src/communication/rpcEndpoint.ts
+++ b/packages/bierzo-wallet/src/communication/rpcEndpoint.ts
@@ -15,11 +15,14 @@ export type GetIdentitiesResponse = readonly Identity[];
  */
 export type SignAndPostResponse = TransactionId | null;
 
+export type RpcEndpointType = "ledger" | "extension";
+
 export interface RpcEndpoint {
   readonly authorizeGetIdentitiesMessage: string;
   readonly authorizeSignAndPostMessage: string;
   readonly notAvailableMessage: string;
   readonly noMatchingIdentityMessage: string;
+  readonly rpcEndpointType: RpcEndpointType;
 
   /**
    * @returns a response or `undefined` if the endpoint was not available

--- a/packages/bierzo-wallet/src/communication/rpcEndpoint.ts
+++ b/packages/bierzo-wallet/src/communication/rpcEndpoint.ts
@@ -22,7 +22,7 @@ export interface RpcEndpoint {
   readonly authorizeSignAndPostMessage: string;
   readonly notAvailableMessage: string;
   readonly noMatchingIdentityMessage: string;
-  readonly rpcEndpointType: RpcEndpointType;
+  readonly type: RpcEndpointType;
 
   /**
    * @returns a response or `undefined` if the endpoint was not available

--- a/packages/bierzo-wallet/src/routes/balance/components/index.tsx
+++ b/packages/bierzo-wallet/src/routes/balance/components/index.tsx
@@ -5,6 +5,7 @@ import { Block, Hairline, Image, Typography } from "medulas-react-components";
 import React from "react";
 import { amountToString } from "ui-logic";
 
+import { RpcEndpointType } from "../../../communication/rpcEndpoint";
 import { ADDRESSES_ROUTE, PAYMENT_ROUTE, REGISTER_PERSONALIZED_ADDRESS_ROUTE } from "../../paths";
 import receive from "../assets/transactionReceive.svg";
 import send from "../assets/transactionSend.svg";
@@ -15,6 +16,7 @@ interface Props {
   readonly onSendPayment: () => void;
   readonly onReceivePayment: () => void;
   readonly onRegisterUsername: () => void;
+  readonly rpcEndpointType: RpcEndpointType | undefined;
 }
 
 interface CardProps {
@@ -55,9 +57,24 @@ const Card = ({ id, text, logo, onAction }: CardProps): JSX.Element => {
 
 interface GetAddressProps {
   readonly onRegisterUsername: () => void;
+  readonly rpcEndpointType: RpcEndpointType | undefined;
 }
 
-const GetYourAddress = ({ onRegisterUsername }: GetAddressProps): JSX.Element => (
+const GetYourAddress = ({ rpcEndpointType, onRegisterUsername }: GetAddressProps): JSX.Element => {
+  switch (rpcEndpointType) {
+    case undefined:
+    case "extension":
+      return <GetYourAddressWithExtension onRegisterUsername={onRegisterUsername} />;
+    case "ledger":
+      return <GetYourAddressWithLedger />;
+  }
+};
+
+interface GetAddressExtensionProps {
+  readonly onRegisterUsername: () => void;
+}
+
+const GetYourAddressWithExtension = ({ onRegisterUsername }: GetAddressExtensionProps): JSX.Element => (
   <React.Fragment>
     <Typography variant="h5" align="center" weight="light" inline>
       Get your human readable
@@ -77,12 +94,38 @@ const GetYourAddress = ({ onRegisterUsername }: GetAddressProps): JSX.Element =>
   </React.Fragment>
 );
 
+const GetYourAddressWithLedger = (): JSX.Element => (
+  <React.Fragment>
+    <Typography variant="h5" align="center" weight="light">
+      You can not register
+    </Typography>
+    <Typography
+      id={REGISTER_PERSONALIZED_ADDRESS_ROUTE}
+      variant="h5"
+      align="center"
+      color="primary"
+      weight="light"
+    >
+      personalized address
+    </Typography>
+    <Block textAlign="center">
+      <Typography variant="h5" weight="light" inline>
+        using{" "}
+      </Typography>
+      <Typography variant="h5" weight="semibold" inline>
+        Ledger Nano S
+      </Typography>
+    </Block>
+  </React.Fragment>
+);
+
 const BalanceLayout = ({
   iovAddress,
   balances,
   onSendPayment,
   onReceivePayment,
   onRegisterUsername,
+  rpcEndpointType,
 }: Props): JSX.Element => {
   const tickersList = Object.keys(balances).sort();
   const hasTokens = tickersList.length > 0;
@@ -105,7 +148,7 @@ const BalanceLayout = ({
               {iovAddress}
             </Typography>
           ) : (
-            <GetYourAddress onRegisterUsername={onRegisterUsername} />
+            <GetYourAddress onRegisterUsername={onRegisterUsername} rpcEndpointType={rpcEndpointType} />
           )}
           <Hairline space={4} />
           <Typography variant="subtitle2" align="center">

--- a/packages/bierzo-wallet/src/routes/balance/components/index.tsx
+++ b/packages/bierzo-wallet/src/routes/balance/components/index.tsx
@@ -16,7 +16,7 @@ interface Props {
   readonly onSendPayment: () => void;
   readonly onReceivePayment: () => void;
   readonly onRegisterUsername: () => void;
-  readonly rpcEndpointType: RpcEndpointType | undefined;
+  readonly rpcEndpointType: RpcEndpointType;
 }
 
 interface CardProps {
@@ -57,12 +57,11 @@ const Card = ({ id, text, logo, onAction }: CardProps): JSX.Element => {
 
 interface GetAddressProps {
   readonly onRegisterUsername: () => void;
-  readonly rpcEndpointType: RpcEndpointType | undefined;
+  readonly rpcEndpointType: RpcEndpointType;
 }
 
 const GetYourAddress = ({ rpcEndpointType, onRegisterUsername }: GetAddressProps): JSX.Element => {
   switch (rpcEndpointType) {
-    case undefined:
     case "extension":
       return <GetYourAddressWithExtension onRegisterUsername={onRegisterUsername} />;
     case "ledger":

--- a/packages/bierzo-wallet/src/routes/balance/index.dom.spec.ts
+++ b/packages/bierzo-wallet/src/routes/balance/index.dom.spec.ts
@@ -3,6 +3,8 @@ import { Encoding } from "@iov/encoding";
 import TestUtils from "react-dom/test-utils";
 import { DeepPartial, Store } from "redux";
 
+import { extensionRpcEndpoint } from "../../communication/extensionRpcEndpoint";
+import { ledgerRpcEndpoint } from "../../communication/ledgerRpcEndpoint";
 import { TRANSACTIONS_TEXT } from "../../components/Header/components/LinksMenu";
 import { aNewStore } from "../../store";
 import { BalanceState } from "../../store/balances";
@@ -67,6 +69,7 @@ describe("The /balance route", () => {
         identities: identities,
         balances: balancesAmount,
         usernames: usernames,
+        rpcEndpoint: extensionRpcEndpoint,
       });
       balanceDom = await travelToBalance(store);
     });
@@ -117,9 +120,12 @@ describe("The /balance route", () => {
     });
   });
 
-  describe("without balance and username", () => {
+  describe("without balance and username with extension RPC Endpoint", () => {
     beforeEach(async () => {
-      store = aNewStore({ identities });
+      store = aNewStore({
+        identities,
+        rpcEndpoint: extensionRpcEndpoint,
+      });
       balanceDom = await travelToBalance(store);
     });
 
@@ -133,6 +139,22 @@ describe("The /balance route", () => {
       const noUsernameMessage = getIovUsername(TestUtils.scryRenderedDOMComponentsWithTag(balanceDom, "h5"));
 
       expect(noUsernameMessage).toBe("Get your human readable");
+    });
+  });
+
+  describe("without balance and username with Ledger RPC Endpoint", () => {
+    beforeEach(async () => {
+      store = aNewStore({
+        identities,
+        rpcEndpoint: ledgerRpcEndpoint,
+      });
+      balanceDom = await travelToBalance(store);
+    });
+
+    it("should show that there is no bns username available", async () => {
+      const noUsernameMessage = getIovUsername(TestUtils.scryRenderedDOMComponentsWithTag(balanceDom, "h5"));
+
+      expect(noUsernameMessage).toBe("You can not register");
     });
   });
 });

--- a/packages/bierzo-wallet/src/routes/balance/index.stories.tsx
+++ b/packages/bierzo-wallet/src/routes/balance/index.stories.tsx
@@ -41,6 +41,7 @@ storiesOf(BALANCE_STORY_PATH, module)
       <PageMenu>
         <Layout
           iovAddress={ACCOUNT_NAME}
+          rpcEndpointType="extension"
           balances={BALANCE}
           onSendPayment={linkTo(PAYMENT_STORY_PATH, PAYMENT_STORY_PAYMENT_PATH)}
           onReceivePayment={linkTo(WALLET_ROOT, RECEIVE_PAYMENT_STORY_PATH)}
@@ -54,6 +55,21 @@ storiesOf(BALANCE_STORY_PATH, module)
       <PageMenu>
         <Layout
           iovAddress={undefined}
+          rpcEndpointType="extension"
+          balances={NO_BALANCE}
+          onSendPayment={linkTo(PAYMENT_STORY_PATH, PAYMENT_STORY_PAYMENT_PATH)}
+          onReceivePayment={linkTo(WALLET_ROOT, RECEIVE_PAYMENT_STORY_PATH)}
+          onRegisterUsername={linkTo(REGISTER_USERNAME_STORY_PATH, REGISTER_USERNAME_REGISTRATION_STORY_PATH)}
+        />
+      </PageMenu>
+    </DecoratedStorybook>
+  ))
+  .add("View on ledger and without name", () => (
+    <DecoratedStorybook>
+      <PageMenu>
+        <Layout
+          iovAddress={undefined}
+          rpcEndpointType="ledger"
           balances={NO_BALANCE}
           onSendPayment={linkTo(PAYMENT_STORY_PATH, PAYMENT_STORY_PAYMENT_PATH)}
           onReceivePayment={linkTo(WALLET_ROOT, RECEIVE_PAYMENT_STORY_PATH)}

--- a/packages/bierzo-wallet/src/routes/balance/index.tsx
+++ b/packages/bierzo-wallet/src/routes/balance/index.tsx
@@ -4,6 +4,7 @@ import * as ReactRedux from "react-redux";
 import { history } from "..";
 import PageMenu from "../../components/PageMenu";
 import { RootState } from "../../store/reducers";
+import { getRpcEndpointType } from "../../store/rpcendpoint/selectors";
 import { getFirstUsername } from "../../store/usernames/selectors";
 import { ADDRESSES_ROUTE, PAYMENT_ROUTE, REGISTER_PERSONALIZED_ADDRESS_ROUTE } from "../paths";
 import Layout from "./components";
@@ -23,6 +24,7 @@ function onRegisterUsername(): void {
 const Balance = (): JSX.Element => {
   const tokens = ReactRedux.useSelector((state: RootState) => state.balances);
   const bnsUsername = ReactRedux.useSelector(getFirstUsername);
+  const rpcEndpointType = ReactRedux.useSelector(getRpcEndpointType);
   const iovAddress = bnsUsername ? bnsUsername.username : undefined;
 
   return (
@@ -33,6 +35,7 @@ const Balance = (): JSX.Element => {
         onReceivePayment={onReceivePayment}
         iovAddress={iovAddress}
         balances={tokens}
+        rpcEndpointType={rpcEndpointType}
       />
     </PageMenu>
   );

--- a/packages/bierzo-wallet/src/routes/payment/index.dom.spec.ts
+++ b/packages/bierzo-wallet/src/routes/payment/index.dom.spec.ts
@@ -3,6 +3,7 @@ import { Encoding } from "@iov/encoding";
 import TestUtils from "react-dom/test-utils";
 import { DeepPartial, Store } from "redux";
 
+import { extensionRpcEndpoint } from "../../communication/extensionRpcEndpoint";
 import { aNewStore } from "../../store";
 import { BalanceState } from "../../store/balances";
 import { RootState } from "../../store/reducers";
@@ -45,6 +46,7 @@ describe("The /payment route", () => {
     store = aNewStore({
       identities,
       balances: balancesAmount,
+      rpcEndpoint: extensionRpcEndpoint,
     });
     paymentDom = await travelToPayment(store);
   });

--- a/packages/bierzo-wallet/src/store/rpcendpoint/selectors.ts
+++ b/packages/bierzo-wallet/src/store/rpcendpoint/selectors.ts
@@ -4,7 +4,7 @@ import { RootState } from "../reducers";
 export const getRpcEndpointType = (state: RootState): RpcEndpointType => {
   const rpcEndpoint = state.rpcEndpoint;
   if (!rpcEndpoint) {
-    throw new Error("RPC Endpoint type should be set at this point. Something wrong!");
+    throw new Error("RPC Endpoint should be set at this point. Something wrong!");
   }
   return rpcEndpoint.type;
 };

--- a/packages/bierzo-wallet/src/store/rpcendpoint/selectors.ts
+++ b/packages/bierzo-wallet/src/store/rpcendpoint/selectors.ts
@@ -1,7 +1,10 @@
 import { RpcEndpointType } from "../../communication/rpcEndpoint";
 import { RootState } from "../reducers";
 
-export const getRpcEndpointType = (state: RootState): RpcEndpointType | undefined => {
-  const rpcEndpointType = state.rpcEndpoint;
-  return rpcEndpointType ? rpcEndpointType.rpcEndpointType : undefined;
+export const getRpcEndpointType = (state: RootState): RpcEndpointType => {
+  const rpcEndpoint = state.rpcEndpoint;
+  if (!rpcEndpoint) {
+    throw new Error("RPC Endpoint type should be set at this point. Something wrong!");
+  }
+  return rpcEndpoint.type;
 };

--- a/packages/bierzo-wallet/src/store/rpcendpoint/selectors.ts
+++ b/packages/bierzo-wallet/src/store/rpcendpoint/selectors.ts
@@ -1,0 +1,7 @@
+import { RpcEndpointType } from "../../communication/rpcEndpoint";
+import { RootState } from "../reducers";
+
+export const getRpcEndpointType = (state: RootState): RpcEndpointType | undefined => {
+  const rpcEndpointType = state.rpcEndpoint;
+  return rpcEndpointType ? rpcEndpointType.rpcEndpointType : undefined;
+};

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -2281,6 +2281,293 @@ exports[`Storyshots Bierzo wallet/Balance View 1`] = `
 </div>
 `;
 
+exports[`Storyshots Bierzo wallet/Balance View on ledger and without name 1`] = `
+<div
+  className="MuiBox-root MuiBox-root"
+>
+  <div
+    className="MuiBox-root MuiBox-root makeStyles-root"
+  >
+    <img
+      alt="Logo"
+      className="makeStyles-root"
+      src="logoBlack.svg"
+    />
+    <div
+      className="MuiBox-root MuiBox-root"
+    />
+    <div
+      className="MuiBox-root MuiBox-root makeStyles-root"
+    >
+      <div
+        className="MuiBox-root MuiBox-root makeStyles-item"
+      >
+        <div
+          className="MuiBox-root MuiBox-root"
+        >
+          <div
+            className="MuiBox-root MuiBox-root"
+          >
+            <h6
+              className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextPrimary"
+              id="Balance"
+              onClick={[Function]}
+            >
+              Balance
+            </h6>
+          </div>
+        </div>
+        <div
+          className="MuiBox-root MuiBox-root makeStyles-line"
+        />
+      </div>
+      <div
+        className="MuiBox-root MuiBox-root makeStyles-item"
+      >
+        <div
+          className="MuiBox-root MuiBox-root"
+        >
+          <div
+            className="MuiBox-root MuiBox-root"
+          >
+            <h6
+              className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextPrimary"
+              id="Payments"
+              onClick={[Function]}
+            >
+              Payments
+            </h6>
+          </div>
+        </div>
+        <div
+          className="MuiBox-root MuiBox-root makeStyles-line"
+        />
+      </div>
+      <div
+        className="MuiBox-root MuiBox-root makeStyles-item"
+      >
+        <div
+          className="MuiBox-root MuiBox-root"
+        >
+          <div
+            className="MuiBox-root MuiBox-root"
+          >
+            <h6
+              className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextPrimary"
+              id="Addresses"
+              onClick={[Function]}
+            >
+              Addresses
+            </h6>
+          </div>
+        </div>
+        <div
+          className="MuiBox-root MuiBox-root makeStyles-line"
+        />
+      </div>
+      <div
+        className="MuiBox-root MuiBox-root makeStyles-item"
+      >
+        <div
+          className="MuiBox-root MuiBox-root"
+        >
+          <div
+            className="MuiBox-root MuiBox-root"
+          >
+            <h6
+              className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-colorTextPrimary"
+              id="Transactions"
+              onClick={[Function]}
+            >
+              Transactions
+            </h6>
+          </div>
+        </div>
+        <div
+          className="MuiBox-root MuiBox-root makeStyles-line"
+        />
+      </div>
+    </div>
+    <div
+      className="MuiBox-root MuiBox-root"
+    />
+    <div
+      className="makeStyles-root"
+      onClick={[Function]}
+    >
+      <div
+        className="MuiBox-root MuiBox-root"
+      >
+        <span
+          className="MuiBadge-root"
+        >
+          <img
+            alt="Transactions Menu"
+            className="makeStyles-root"
+            src="bell.svg"
+          />
+          <span
+            className="MuiBadge-badge makeStyles-dot MuiBadge-invisible MuiBadge-dot"
+          >
+            
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      className="makeStyles-root"
+      id="hi-menu"
+      onClick={[Function]}
+    >
+      <div
+        className="MuiBox-root MuiBox-root makeStyles-root"
+      >
+        <h6
+          className="MuiTypography-root MuiTypography-h6"
+        >
+          Hi!
+        </h6>
+        <button
+          className="MuiButtonBase-root MuiIconButton-root"
+          disabled={false}
+          onBlur={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="MuiIconButton-label"
+          >
+            <img
+              alt="Open"
+              className="makeStyles-root"
+              src="chevronDown.svg"
+            />
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root"
+  >
+    <div
+      className="MuiBox-root MuiBox-root"
+    >
+      <div
+        className="MuiBox-root MuiBox-root"
+      />
+      <div
+        className="MuiBox-root MuiBox-root"
+      >
+        <div
+          className="MuiBox-root MuiBox-root makeStyles-root"
+          id="/payment"
+          onClick={[Function]}
+        >
+          <img
+            alt="Send payment"
+            className="makeStyles-root"
+            height={36}
+            src="transactionSend.svg"
+            width={36}
+          />
+          <p
+            className="MuiTypography-root MuiTypography-body1"
+          >
+            Send payment
+          </p>
+        </div>
+        <div
+          className="MuiBox-root MuiBox-root"
+        />
+        <div
+          className="MuiBox-root MuiBox-root makeStyles-root"
+          id="/addresses"
+          onClick={[Function]}
+        >
+          <img
+            alt="Receive Payment"
+            className="makeStyles-root"
+            height={36}
+            src="transactionReceive.svg"
+            width={36}
+          />
+          <p
+            className="MuiTypography-root MuiTypography-body1"
+          >
+            Receive Payment
+          </p>
+        </div>
+      </div>
+      <div
+        className="MuiBox-root MuiBox-root"
+      />
+      <div
+        className="MuiBox-root MuiBox-root"
+      />
+      <div
+        className="MuiBox-root MuiBox-root"
+      >
+        <div
+          className="MuiBox-root MuiBox-root"
+        >
+          <h5
+            className="MuiTypography-root makeStyles-weight makeStyles-weight MuiTypography-h5 MuiTypography-alignCenter"
+          >
+            You can not register
+          </h5>
+          <h5
+            className="MuiTypography-root makeStyles-weight makeStyles-weight MuiTypography-h5 MuiTypography-colorPrimary MuiTypography-alignCenter"
+            id="/register-personalized-address"
+          >
+            personalized address
+          </h5>
+          <div
+            className="MuiBox-root MuiBox-root"
+          >
+            <h5
+              className="MuiTypography-root makeStyles-weight makeStyles-weight makeStyles-inline MuiTypography-h5"
+            >
+              using
+               
+            </h5>
+            <h5
+              className="MuiTypography-root makeStyles-weight makeStyles-weight makeStyles-inline MuiTypography-h5"
+            >
+              Ledger Nano S
+            </h5>
+          </div>
+          <div
+            className="MuiBox-root MuiBox-root"
+          />
+          <h6
+            className="MuiTypography-root MuiTypography-subtitle2 MuiTypography-alignCenter"
+          >
+            No funds available
+          </h6>
+          <div
+            className="MuiBox-root MuiBox-root"
+          />
+          <div
+            className="MuiBox-root MuiBox-root"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Bierzo wallet/Balance View without tokens and without name 1`] = `
 <div
   className="MuiBox-root MuiBox-root"


### PR DESCRIPTION
**Description**
This PR will separate personalized name creation messages on balance page based on rpc endpoint type (extension or ledger). Closes #737.

**Before**
N/A

**After**
![username-can-not-reg](https://user-images.githubusercontent.com/3502260/65619246-79b6ff00-dfc8-11e9-9c74-790ffb26f1b1.png)
