### PR TITLE
Use correct ReadonlyArrays

### DIFF
--- a/packages/sil-governance/src/routes/create-proposal/components/FormOptions/DistributeFunds/RecipientsTable.tsx
+++ b/packages/sil-governance/src/routes/create-proposal/components/FormOptions/DistributeFunds/RecipientsTable.tsx
@@ -5,7 +5,7 @@ import React, { useState } from "react";
 import { Recipient } from ".";
 
 interface Props {
-  readonly recipients: Recipient[];
+  readonly recipients: readonly Recipient[];
 }
 
 const RecipientsTable = ({ recipients }: Props): JSX.Element => {

--- a/packages/sil-governance/src/routes/create-proposal/components/FormOptions/DistributeFunds/index.tsx
+++ b/packages/sil-governance/src/routes/create-proposal/components/FormOptions/DistributeFunds/index.tsx
@@ -34,13 +34,13 @@ const useStyles = makeStyles(() => ({
 
 interface Props {
   readonly form: FormApi;
-  readonly recipientsChanged: Dispatch<SetStateAction<Readonly<Recipient[]>>>;
+  readonly recipientsChanged: Dispatch<SetStateAction<readonly Recipient[]>>;
 }
 
 const DistributeFunds = ({ form, recipientsChanged }: Props): JSX.Element => {
   const inputClasses = useStyles();
   const toast = React.useContext(ToastContext);
-  const [recipients, setRecipients] = useState<Recipient[]>([]);
+  const [recipients, setRecipients] = useState<readonly Recipient[]>([]);
 
   const updateRecipients = (event: ChangeEvent<HTMLInputElement>): void => {
     const files = event.target.files;

--- a/packages/sil-governance/src/routes/create-proposal/components/FormOptions/index.tsx
+++ b/packages/sil-governance/src/routes/create-proposal/components/FormOptions/index.tsx
@@ -48,7 +48,7 @@ interface Props {
   readonly form: FormApi;
   readonly proposalType: ProposalType;
   readonly electionRule: ElectionRule | undefined;
-  readonly recipientsChanged: Dispatch<SetStateAction<Readonly<Recipient[]>>>;
+  readonly recipientsChanged: Dispatch<SetStateAction<readonly Recipient[]>>;
 }
 
 const FormOptions = ({ form, proposalType, electionRule, recipientsChanged }: Props): JSX.Element => {

--- a/packages/sil-governance/src/routes/create-proposal/components/ProposalForm.tsx
+++ b/packages/sil-governance/src/routes/create-proposal/components/ProposalForm.tsx
@@ -78,9 +78,9 @@ export const getAllElectionRules = async (governor: Governor): Promise<readonly 
 const ProposalForm = (): JSX.Element => {
   const toast = React.useContext(ToastContext);
   const [proposalType, setProposalType] = useState(ProposalType.AmendProtocol);
-  const [electionRules, setElectionRules] = useState<Readonly<ElectionRule[]>>([]);
+  const [electionRules, setElectionRules] = useState<readonly ElectionRule[]>([]);
   const [electionRule, setElectionRule] = useState<ElectionRule>();
-  const [recipients, setRecipients] = useState<Readonly<Recipient[]>>([]);
+  const [recipients, setRecipients] = useState<readonly Recipient[]>([]);
 
   const governor = ReactRedux.useSelector((state: RootState) => state.extension.governor);
   const dispatch = ReactRedux.useDispatch();

--- a/packages/sil-governance/src/routes/create-proposal/index.tsx
+++ b/packages/sil-governance/src/routes/create-proposal/index.tsx
@@ -21,7 +21,7 @@ const CreateProposal = (): JSX.Element => {
   const blockchain = useSelector((state: RootState) => state.blockchain);
 
   const address = governor ? governor.address : ("" as Address);
-  const [electorates, setElectorates] = useState<Readonly<Electorate[]>>([]);
+  const [electorates, setElectorates] = useState<readonly Electorate[]>([]);
 
   useEffect(() => {
     const updateElectorates = async (): Promise<void> => {

--- a/packages/sil-governance/src/routes/dashboard/index.tsx
+++ b/packages/sil-governance/src/routes/dashboard/index.tsx
@@ -16,7 +16,7 @@ import { DASHBOARD_ROUTE } from "../paths";
 import ProposalsList from "./components/ProposalsList";
 
 interface Props {
-  filter: ElectionFilter;
+  readonly filter: ElectionFilter;
 }
 
 const Dashboard = ({ filter }: Props): JSX.Element => {
@@ -26,7 +26,7 @@ const Dashboard = ({ filter }: Props): JSX.Element => {
   const blockchain = useSelector((state: RootState) => state.blockchain);
 
   const address = governor ? governor.address : ("" as Address);
-  const [electorates, setElectorates] = useState<Readonly<Electorate[]>>([]);
+  const [electorates, setElectorates] = useState<readonly Electorate[]>([]);
 
   useEffect(() => {
     dispatch(requireUpdateProposalsAction(true));


### PR DESCRIPTION
The `Readonly` type just makes all properties readonly, which is not what we usually want. ReadonlyArrays don't have array mutating methods. See this for new syntax:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#improvements-for-readonlyarray-and-readonly-tuples