### PR TITLE
Fix – Improve block explorers type

### DIFF
--- a/packages/sanes-browser-extension/config/development.json
+++ b/packages/sanes-browser-extension/config/development.json
@@ -1,7 +1,5 @@
 {
   "blockExplorers": {
-    "local-iov-devnet": null,
-    "lisk-198f2b61a8": null,
     "ethereum-eip155-5777": "http://localhost:8546/api?module=proxy&action=eth_getTransactionByHash&txhash="
   },
   "chains": [

--- a/packages/sanes-browser-extension/config/development.json
+++ b/packages/sanes-browser-extension/config/development.json
@@ -1,6 +1,6 @@
 {
   "blockExplorers": {
-    "ethereum-eip155-5777": "http://localhost:8546/api?module=proxy&action=eth_getTransactionByHash&txhash="
+    "ethereum-eip155-5777": "http://localhost:8546/api?module=proxy&action=eth_getTransactionByHash&txhash=%id"
   },
   "chains": [
     {

--- a/packages/sanes-browser-extension/config/production.json
+++ b/packages/sanes-browser-extension/config/production.json
@@ -1,7 +1,7 @@
 {
   "blockExplorers": {
-    "lisk-ed14889723": "https://explorer.lisk.io/tx/",
-    "ethereum-eip155-1": "https://etherscan.io/tx/"
+    "lisk-ed14889723": "https://explorer.lisk.io/tx/%id",
+    "ethereum-eip155-1": "https://etherscan.io/tx/%id"
   },
   "chains": [
     {

--- a/packages/sanes-browser-extension/config/production.json
+++ b/packages/sanes-browser-extension/config/production.json
@@ -1,6 +1,5 @@
 {
   "blockExplorers": {
-    "bns-antnet": null,
     "lisk-ed14889723": "https://explorer.lisk.io/tx/",
     "ethereum-eip155-1": "https://etherscan.io/tx/"
   },

--- a/packages/sanes-browser-extension/config/staging.json
+++ b/packages/sanes-browser-extension/config/staging.json
@@ -1,7 +1,7 @@
 {
   "blockExplorers": {
-    "lisk-da3ed6a454": "https://testnet-explorer.lisk.io/tx/",
-    "ethereum-eip155-4": "https://rinkeby.etherscan.io/tx/"
+    "lisk-da3ed6a454": "https://testnet-explorer.lisk.io/tx/%id",
+    "ethereum-eip155-4": "https://rinkeby.etherscan.io/tx/%id"
   },
   "chains": [
     {

--- a/packages/sanes-browser-extension/config/staging.json
+++ b/packages/sanes-browser-extension/config/staging.json
@@ -1,6 +1,5 @@
 {
   "blockExplorers": {
-    "iov-clapnet": null,
     "lisk-da3ed6a454": "https://testnet-explorer.lisk.io/tx/",
     "ethereum-eip155-4": "https://rinkeby.etherscan.io/tx/"
   },

--- a/packages/sanes-browser-extension/src/extension/background/model/persona/config/configurationfile.ts
+++ b/packages/sanes-browser-extension/src/extension/background/model/persona/config/configurationfile.ts
@@ -16,7 +16,7 @@ export interface ChainConfig {
 }
 
 export interface BlockExplorers {
-  readonly [key: string]: string | null;
+  readonly [key: string]: string | undefined;
 }
 
 export interface ConfigurationFile {

--- a/packages/sanes-browser-extension/src/extension/background/model/persona/index.ts
+++ b/packages/sanes-browser-extension/src/extension/background/model/persona/index.ts
@@ -223,9 +223,9 @@ export class Persona {
     }
 
     const config: ConfigurationFile = await getConfigurationFile();
-    const blockExplorerBaseUrl = config.blockExplorers[t.transaction.creator.chainId];
+    const blockExplorerPattern = config.blockExplorers[t.transaction.creator.chainId];
     const transactionId = t.postResponse.transactionId;
-    const blockExplorerUrl = blockExplorerBaseUrl ? `${blockExplorerBaseUrl}${transactionId}` : null;
+    const blockExplorerUrl = blockExplorerPattern ? blockExplorerPattern.replace("%id", transactionId) : null;
 
     return {
       time: new ReadonlyDate(ReadonlyDate.now()).toLocaleString(),

--- a/packages/sanes-browser-extension/src/extension/background/model/persona/index.ts
+++ b/packages/sanes-browser-extension/src/extension/background/model/persona/index.ts
@@ -33,7 +33,6 @@ import {
   algorithmForCodec,
   chainConnector,
   codecTypeFromString,
-  ConfigurationFile,
   getConfigurationFile,
   pathBuilderForCodec,
 } from "./config";
@@ -222,7 +221,7 @@ export class Persona {
       return null;
     }
 
-    const config: ConfigurationFile = await getConfigurationFile();
+    const config = await getConfigurationFile();
     const blockExplorerPattern = config.blockExplorers[t.transaction.creator.chainId];
     const transactionId = t.postResponse.transactionId;
     const blockExplorerUrl = blockExplorerPattern ? blockExplorerPattern.replace("%id", transactionId) : null;

--- a/packages/sanes-browser-extension/src/extension/background/model/persona/index.ts
+++ b/packages/sanes-browser-extension/src/extension/background/model/persona/index.ts
@@ -223,9 +223,9 @@ export class Persona {
     }
 
     const config: ConfigurationFile = await getConfigurationFile();
-    const blockExplorer = config.blockExplorers[t.transaction.creator.chainId];
+    const blockExplorerBaseUrl = config.blockExplorers[t.transaction.creator.chainId];
     const transactionId = t.postResponse.transactionId;
-    const blockExplorerUrl = blockExplorer ? blockExplorer + transactionId : null;
+    const blockExplorerUrl = blockExplorerBaseUrl ? `${blockExplorerBaseUrl}${transactionId}` : null;
 
     return {
       time: new ReadonlyDate(ReadonlyDate.now()).toLocaleString(),


### PR DESCRIPTION
1. I want to avoid updating the chain IDs for block explorere that do not exist (`null` -> `undefined`)
2. The position of the transaction ID in the URL should be explicit (`%id` placeholder introduced)