### PR TITLE
Fix #851 - Support Base64 Pubkeys

### DIFF
--- a/packages/sil-governance/src/routes/create-proposal/components/ProposalForm.tsx
+++ b/packages/sil-governance/src/routes/create-proposal/components/ProposalForm.tsx
@@ -44,9 +44,18 @@ const getCommitteeIdFromForm = (formValue: string): CommitteeId =>
   parseInt(formValue.substring(0, formValue.indexOf(":")), 10) as CommitteeId;
 
 const getPubkeyBundleFromForm = (formValue: string): PubkeyBundle => {
+  function tryEncodeData(): PubkeyBytes {
+    // Hex length for 32 bytes pubkey = 64
+    if (formValue.length === 64) {
+      return Encoding.fromHex(formValue) as PubkeyBytes;
+    }
+
+    return Encoding.fromBase64(formValue) as PubkeyBytes;
+  }
+
   return {
     algo: Algorithm.Ed25519,
-    data: Encoding.fromHex(formValue) as PubkeyBytes,
+    data: tryEncodeData(),
   };
 };
 

--- a/packages/sil-governance/src/routes/dashboard/components/Proposal/CollapsingData/DisplayOptions/SetValidators.tsx
+++ b/packages/sil-governance/src/routes/dashboard/components/Proposal/CollapsingData/DisplayOptions/SetValidators.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const SetValidators = ({ action }: Props): JSX.Element => {
   const validators = Object.entries(action.validatorUpdates).map(([validator, props]) => {
-    const validatorLabel = `Validator ${ellipsifyMiddle(validator, 6)} -`;
+    const validatorLabel = `Validator ${ellipsifyMiddle(validator, 40)} -`;
 
     return (
       <Block key={validator} marginTop={0.5} marginBottom={1}>

--- a/packages/sil-governance/src/routes/dashboard/test/operateDashboard.ts
+++ b/packages/sil-governance/src/routes/dashboard/test/operateDashboard.ts
@@ -225,7 +225,7 @@ export const checkSetValidatorsFields = async (proposal: Element, id: number): P
   expect(paragraphs[1].textContent).toBe("Updates validators:");
   const [expectedAddress, { power: expectedPower }] = Object.entries(expected.action.validatorUpdates)[0];
   expect(paragraphs[2].textContent).toBe(
-    `Validator ${ellipsifyMiddle(expectedAddress, 6)} - Power ${expectedPower}`,
+    `Validator ${ellipsifyMiddle(expectedAddress, 40)} - Power ${expectedPower}`,
   );
 
   const readLessButton = paragraphs[3];


### PR DESCRIPTION
Closes #851.

This PR adds support for Base64 formatted validator pubkeys, also keeping the current functionality of accepting hexadecimal validator pubkeys.