### PR TITLE
Fix #902 - Apply balance state payload without old state

### DIFF
--- a/packages/bierzo-wallet/src/logic/balances.ts
+++ b/packages/bierzo-wallet/src/logic/balances.ts
@@ -3,7 +3,7 @@ import { Dispatch } from "redux";
 import { Subscription } from "xstream";
 
 import { getConfig } from "../config";
-import { addBalancesAction, getBalances } from "../store/balances";
+import { getBalances, setBalancesAction } from "../store/balances";
 import { getCodec } from "./codec";
 import { getActiveConnections } from "./connection";
 
@@ -32,7 +32,7 @@ export async function subscribeBalance(identities: readonly Identity[], dispatch
       next: async account => {
         if (account) {
           const balances = await getBalances(identities);
-          dispatch(addBalancesAction(balances));
+          dispatch(setBalancesAction(balances));
         }
       },
     });

--- a/packages/bierzo-wallet/src/logic/balances.unit.spec.ts
+++ b/packages/bierzo-wallet/src/logic/balances.unit.spec.ts
@@ -28,7 +28,7 @@ withChainsDescribe("Logic :: balance subscriptions", () => {
   });
 
   it("fires subscription callback when account balance changes", async () => {
-    const balanceSpy = jest.spyOn(balanceActions, "addBalancesAction");
+    const balanceSpy = jest.spyOn(balanceActions, "setBalancesAction");
 
     const store = aNewStore();
     const identities = await createIdentities();

--- a/packages/bierzo-wallet/src/routes/login/index.tsx
+++ b/packages/bierzo-wallet/src/routes/login/index.tsx
@@ -16,7 +16,7 @@ import { subscribeBalance } from "../../logic/balances";
 import { establishConnection } from "../../logic/connection";
 import { drinkFaucetIfNeeded } from "../../logic/faucet";
 import { subscribeTransaction } from "../../logic/transactions";
-import { addBalancesAction, getBalances } from "../../store/balances";
+import { getBalances, setBalancesAction } from "../../store/balances";
 import { setIdentities } from "../../store/identities";
 import { setRpcEndpoint } from "../../store/rpcendpoint";
 import { addTickersAction, getTokens } from "../../store/tokens";
@@ -46,7 +46,7 @@ export const loginBootSequence = async (
   drinkFaucetIfNeeded(identities).catch(console.error);
 
   const balances = await getBalances(identities);
-  dispatch(addBalancesAction(balances));
+  dispatch(setBalancesAction(balances));
 
   await subscribeBalance(identities, dispatch);
   await subscribeTransaction(identities, dispatch);

--- a/packages/bierzo-wallet/src/store/balances/actions.ts
+++ b/packages/bierzo-wallet/src/store/balances/actions.ts
@@ -1,7 +1,7 @@
 import { Amount, Identity } from "@iov/bcp";
 
 import { getActiveConnections } from "../../logic/connection";
-import { AddBalancesActionType } from "./reducer";
+import { SetBalancesActionType } from "./reducer";
 
 export async function getBalances(identities: readonly Identity[]): Promise<{ [ticker: string]: Amount }> {
   const connections = getActiveConnections();
@@ -26,7 +26,7 @@ export async function getBalances(identities: readonly Identity[]): Promise<{ [t
   return balances;
 }
 
-export const addBalancesAction = (tokens: { [key: string]: Amount }): AddBalancesActionType => ({
-  type: "@@balances/ADD",
+export const setBalancesAction = (tokens: { [key: string]: Amount }): SetBalancesActionType => ({
+  type: "@@balances/SET",
   payload: tokens,
 });

--- a/packages/bierzo-wallet/src/store/balances/index.unit.spec.ts
+++ b/packages/bierzo-wallet/src/store/balances/index.unit.spec.ts
@@ -6,7 +6,7 @@ import { aNewStore } from "../../store";
 import { establishAllConnections } from "../../utils/test/connections";
 import { withChainsDescribe } from "../../utils/test/testExecutor";
 import { ExtendedIdentity, IdentitiesState, setIdentities } from "../identities";
-import { addBalancesAction, getBalances } from "./actions";
+import { getBalances, setBalancesAction } from "./actions";
 
 withChainsDescribe("Tokens reducer", () => {
   beforeAll(async () => {
@@ -47,7 +47,7 @@ withChainsDescribe("Tokens reducer", () => {
     const tokens = await getBalances(
       Array.from(store.getState().identities.values()).map(ext => ext.identity),
     );
-    store.dispatch(addBalancesAction(tokens));
+    store.dispatch(setBalancesAction(tokens));
 
     const balances = store.getState().balances;
     expect(balances.ETH).toBeDefined();

--- a/packages/bierzo-wallet/src/store/balances/reducer.ts
+++ b/packages/bierzo-wallet/src/store/balances/reducer.ts
@@ -4,8 +4,8 @@ import { ActionType } from "typesafe-actions";
 
 import * as actions from "./actions";
 
-export interface AddBalancesActionType extends Action {
-  type: "@@balances/ADD";
+export interface SetBalancesActionType extends Action {
+  type: "@@balances/SET";
   payload: { [key: string]: Amount };
 }
 
@@ -18,7 +18,7 @@ const initState: BalanceState = {};
 
 export function balancesReducer(state: BalanceState = initState, action: BalanceActions): BalanceState {
   switch (action.type) {
-    case "@@balances/ADD":
+    case "@@balances/SET":
       return { ...action.payload };
     default:
       return state;

--- a/packages/bierzo-wallet/src/store/balances/reducer.ts
+++ b/packages/bierzo-wallet/src/store/balances/reducer.ts
@@ -19,7 +19,7 @@ const initState: BalanceState = {};
 export function balancesReducer(state: BalanceState = initState, action: BalanceActions): BalanceState {
   switch (action.type) {
     case "@@balances/ADD":
-      return { ...state, ...action.payload };
+      return { ...action.payload };
     default:
       return state;
   }


### PR DESCRIPTION
**Description**
There is no need to apply old state to the store because new balance state contains all available balances.

Closes #902.
