### PR TITLE
Feature #988 - Adds extension policy link

### DIFF
--- a/packages/sanes-browser-extension/src/routes/paths.ts
+++ b/packages/sanes-browser-extension/src/routes/paths.ts
@@ -4,6 +4,7 @@ export const UNLOCK_ROUTE = "/unlock";
 export const RESTORE_WALLET = "/restore-wallet";
 export const WALLET_STATUS_ROUTE = "/wallet";
 export const COLLECTIBLES_ROUTE = "/collectibles";
+export const POLICY_URL = "https://www.neuma.io/policy";
 export const TERMS_URL = "https://support.iov.one/hc/en-us";
 export const SUPPORT_CENTER_URL = "https://support.iov.one/hc/en-us/requests/new?ticket_form_id=360000387040";
 

--- a/packages/sanes-browser-extension/src/routes/welcome/index.dom.spec.ts
+++ b/packages/sanes-browser-extension/src/routes/welcome/index.dom.spec.ts
@@ -2,7 +2,7 @@ import TestUtils from "react-dom/test-utils";
 
 import { click } from "../../utils/test/dom";
 import { travelToWelcome, whenOnNavigatedToRoute } from "../../utils/test/navigation";
-import { CREATE_WALLET_ROUTE, RESTORE_WALLET, UNLOCK_ROUTE } from "../paths";
+import { CREATE_WALLET_ROUTE, POLICY_URL, RESTORE_WALLET, UNLOCK_ROUTE } from "../paths";
 
 describe("DOM > Feature > Welcome", () => {
   let welcomeDom: React.Component;
@@ -43,5 +43,10 @@ describe("DOM > Feature > Welcome", () => {
     expect(importAccountButton.textContent).toBe("Import Wallet");
     click(importAccountButton);
     await whenOnNavigatedToRoute(RESTORE_WALLET);
+  }, 60000);
+
+  it("has a link to privacy policy", async () => {
+    const policyLink = TestUtils.findRenderedDOMComponentWithTag(welcomeDom, "a");
+    expect(policyLink.getAttribute("href")).toBe(POLICY_URL);
   }, 60000);
 });

--- a/packages/sanes-browser-extension/src/routes/welcome/index.tsx
+++ b/packages/sanes-browser-extension/src/routes/welcome/index.tsx
@@ -1,11 +1,11 @@
-import { Block, Button, ToastContext, ToastVariant, Typography } from "medulas-react-components";
+import { Block, Button, Link, ToastContext, ToastVariant, Typography } from "medulas-react-components";
 import * as React from "react";
 
 import NeumaPageLayout from "../../components/NeumaPageLayout";
 import { PersonaContext } from "../../context/PersonaProvider";
 import { getConfigurationFile } from "../../extension/background/model/persona/config";
 import { history } from "../../utils/history";
-import { CREATE_WALLET_ROUTE, RESTORE_WALLET, UNLOCK_ROUTE, WELCOME_ROUTE } from "../paths";
+import { CREATE_WALLET_ROUTE, POLICY_URL, RESTORE_WALLET, UNLOCK_ROUTE, WELCOME_ROUTE } from "../paths";
 
 export const UNLOCK_WALLET_ID = "welcome-unlock-wallet";
 export const CREATE_WALLET_ID = "welcome-create-wallet";
@@ -54,6 +54,13 @@ const Welcome = (): JSX.Element => {
       <Button variant="contained" fullWidth onClick={importWallet} id={IMPORT_WALLET_ID}>
         Import Wallet
       </Button>
+      <Block marginTop={8} display="flex" justifyContent="center">
+        <Link to={POLICY_URL}>
+          <Typography variant="subtitle2" color="primary" link>
+            Privacy policy
+          </Typography>
+        </Link>
+      </Block>
     </NeumaPageLayout>
   );
 };

--- a/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
+++ b/packages/valdueza-storybook/src/__snapshots__/Storyshots.test.js.snap
@@ -12808,6 +12808,22 @@ exports[`Storyshots Sanes Browser Extension/Welcome page With persona 1`] = `
         Import Wallet
       </span>
     </button>
+    <div
+      className="MuiBox-root MuiBox-root"
+    >
+      <a
+        href="https://www.neuma.io/policy"
+        onClick={[Function]}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <h6
+          className="MuiTypography-root makeStyles-link MuiTypography-subtitle2 MuiTypography-colorPrimary"
+        >
+          Privacy policy
+        </h6>
+      </a>
+    </div>
   </div>
   <div
     className="MuiBox-root MuiBox-root"
@@ -12912,6 +12928,22 @@ exports[`Storyshots Sanes Browser Extension/Welcome page Without persona 1`] = `
         Import Wallet
       </span>
     </button>
+    <div
+      className="MuiBox-root MuiBox-root"
+    >
+      <a
+        href="https://www.neuma.io/policy"
+        onClick={[Function]}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <h6
+          className="MuiTypography-root makeStyles-link MuiTypography-subtitle2 MuiTypography-colorPrimary"
+        >
+          Privacy policy
+        </h6>
+      </a>
+    </div>
   </div>
   <div
     className="MuiBox-root MuiBox-root"


### PR DESCRIPTION
Part of #988: "add the Policy's page link to the Welcome screen of the extension. Text should be: Privacy policy"

**Screenshot:**
![imagen](https://user-images.githubusercontent.com/44572727/73165700-94bf8a00-40f4-11ea-8275-93b5831d845f.png)