### PR TITLE
Let wallet and governance inherit root TS config

### DIFF
--- a/packages/bierzo-wallet/src/routes/registerName/index.tsx
+++ b/packages/bierzo-wallet/src/routes/registerName/index.tsx
@@ -49,6 +49,7 @@ function getBnsIdentity(identities: ReadonlyMap<ChainId, ExtendedIdentity>): Ide
       return identity;
     }
   }
+  return undefined;
 }
 
 async function getPersonalizedAddressRegistrationFee(

--- a/packages/bierzo-wallet/tsconfig.json
+++ b/packages/bierzo-wallet/tsconfig.json
@@ -1,13 +1,11 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "typeRoots": ["./node_modules/@types", "../../node_modules/@types", "./custom_types"],
     "allowJs": true,
     "skipLibCheck": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "moduleResolution": "node",

--- a/packages/sil-governance/tsconfig.json
+++ b/packages/sil-governance/tsconfig.json
@@ -1,12 +1,10 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
This lets wallet and governance inherit root tsconfig.json (like the other packages do already). This enables `noImplicitReturns`, which makes the code change necessary.