### PR TITLE
Add chain ids to the wallet's production config

### DIFF
--- a/packages/bierzo-wallet/src/config/production.json
+++ b/packages/bierzo-wallet/src/config/production.json
@@ -31,7 +31,17 @@
         "chainId": "ethereum-eip155-1",
         "name": "Ethereum Mainnet",
         "node": "https://mainnet.infura.io/v3/36cd381ebed84d9996403e5c736fd8eb",
-        "scraper": "https://api.etherscan.io/api"
+        "scraper": "https://api.etherscan.io/api",
+        "ethereumOptions": {
+          "erc20s": [
+            {
+              "contractAddress": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+              "decimals": 18,
+              "symbol": "DAI",
+              "name": "Dai Stablecoin"
+            }
+          ]
+        }
       }
     }
   ]

--- a/packages/bierzo-wallet/src/config/production.json
+++ b/packages/bierzo-wallet/src/config/production.json
@@ -7,7 +7,7 @@
       "mainnetBuild": "iov-mainnet"
     }
   },
-  "websiteName": "wallet.iov.one",
+  "websiteName": "wallet.neuma.io",
   "chains": [
     {
       "chainSpec": {


### PR DESCRIPTION
This branch started as `v1.1.0` and cherry-picked commit d6f3ba5a654e430c9b4bcd8c390fd951fce53aa3.

Steps to manually deploy new chain ids to production:

`cd ponferrada && git clean -xdf && yarn install && yarn build`
`cd packages/bierzo-wallet && yarn install`
`git cherry-pick COMMIT_HASH # make sure that this only changes src/config/production.json`
`yarn build-production`
Test locally (`cd build && caddy`)
`firebase login`
`yarn deploy-production`

Delete this PR when the master branch is tagged as the next production version and travis deploys to firebase.