### PR TITLE
Simplify CodecType in config

### DIFF
--- a/packages/bierzo-wallet/src/config/index.ts
+++ b/packages/bierzo-wallet/src/config/index.ts
@@ -5,6 +5,13 @@ import { getCodecForChainId } from "../logic/codec";
 import { ExtendedIdentity } from "../store/identities";
 import developmentConfig from "./development.json";
 
+/** The string value must match the codec type in the config file */
+export enum CodecType {
+  Bns = "bns",
+  Ethereum = "eth",
+  Lisk = "lsk",
+}
+
 export interface Config {
   readonly extensionId: string;
   readonly extensionLink: string;
@@ -45,7 +52,7 @@ export function isChainConfigWithFaucet(chain: ChainConfig): chain is ChainConfi
 }
 
 export interface ChainSpec {
-  readonly codecType: string;
+  readonly codecType: CodecType;
   readonly chainId: string;
   readonly name: string;
   readonly node: string;

--- a/packages/bierzo-wallet/src/logic/codec.ts
+++ b/packages/bierzo-wallet/src/logic/codec.ts
@@ -3,23 +3,19 @@ import { bnsCodec } from "@iov/bns";
 import { ethereumCodec } from "@iov/ethereum";
 import { liskCodec } from "@iov/lisk";
 
-import { ChainSpec, getConfig } from "../config";
-import { isBnsSpec, isEthSpec, isLskSpec } from "./connection";
+import { ChainSpec, CodecType, getConfig } from "../config";
 
 export function getCodec(spec: ChainSpec): TxCodec {
-  if (isEthSpec(spec)) {
-    return ethereumCodec;
+  switch (spec.codecType) {
+    case CodecType.Bns:
+      return bnsCodec;
+    case CodecType.Ethereum:
+      return ethereumCodec;
+    case CodecType.Lisk:
+      return liskCodec;
+    default:
+      throw new Error("Unsupported codecType for chain spec");
   }
-
-  if (isBnsSpec(spec)) {
-    return bnsCodec;
-  }
-
-  if (isLskSpec(spec)) {
-    return liskCodec;
-  }
-
-  throw new Error("Unsupported codecType for chain spec");
 }
 
 export async function getCodecForChainId(chainId: ChainId): Promise<TxCodec> {

--- a/packages/bierzo-wallet/src/routes/payment/components/index.tsx
+++ b/packages/bierzo-wallet/src/routes/payment/components/index.tsx
@@ -3,8 +3,7 @@ import { Back, Block, Button, Form, useForm } from "medulas-react-components";
 import React from "react";
 import * as ReactRedux from "react-redux";
 
-import { ConfigErc20Options, getConfig } from "../../../config";
-import { isEthSpec } from "../../../logic/connection";
+import { CodecType, ConfigErc20Options, getConfig } from "../../../config";
 import { RootState } from "../../../store/reducers";
 import CurrencyToSend from "./CurrencyToSend";
 import ReceiverAddress from "./ReceiverAddress";
@@ -33,7 +32,7 @@ const Layout = ({
 
   const onTokenSelectionControl = async (ticker: TokenTicker): Promise<void> => {
     const chains = (await getConfig()).chains;
-    const ethChain = chains.find(chain => isEthSpec(chain.chainSpec));
+    const ethChain = chains.find(chain => chain.chainSpec.codecType === CodecType.Ethereum);
     const erc20s = ethChain?.chainSpec?.ethereumOptions?.erc20s;
     if (erc20s) {
       const erc20Tokens = erc20s as ConfigErc20Options[];

--- a/packages/sanes-browser-extension/src/extension/background/model/persona/config/codec.ts
+++ b/packages/sanes-browser-extension/src/extension/background/model/persona/config/codec.ts
@@ -6,26 +6,7 @@ import { HdPaths } from "@iov/keycontrol";
 import { createLiskConnector } from "@iov/lisk";
 
 import { getErc20TokensConfig } from "../../../../../utils/tokens";
-import { ChainSpec, CodecString } from "./configurationfile";
-
-export enum CodecType {
-  Bns,
-  Lisk,
-  Ethereum,
-}
-
-export function codecTypeFromString(input: CodecString): CodecType {
-  switch (input) {
-    case "bns":
-      return CodecType.Bns;
-    case "lsk":
-      return CodecType.Lisk;
-    case "eth":
-      return CodecType.Ethereum;
-    default:
-      throw new Error(`Codec '${input}' not supported`);
-  }
-}
+import { ChainSpec, CodecType } from "./configurationfile";
 
 export function algorithmForCodec(codec: CodecType): Algorithm {
   switch (codec) {
@@ -55,8 +36,8 @@ export function pathBuilderForCodec(codecType: CodecType): (derivation: number) 
   return pathBuilder;
 }
 
-export function chainConnector(codec: CodecType, chainSpec: ChainSpec): ChainConnector {
-  switch (codec) {
+export function chainConnector(chainSpec: ChainSpec): ChainConnector {
+  switch (chainSpec.codecType) {
     case CodecType.Bns:
       return createBnsConnector(chainSpec.node, chainSpec.chainId);
     case CodecType.Lisk:

--- a/packages/sanes-browser-extension/src/extension/background/model/persona/config/configurationfile.ts
+++ b/packages/sanes-browser-extension/src/extension/background/model/persona/config/configurationfile.ts
@@ -3,7 +3,12 @@ import { singleton } from "ui-logic";
 
 import { getBnsRpc } from "../../../../../utils/localstorage/bnsRpc";
 
-export type CodecString = "bns" | "lsk" | "eth";
+/** The string value must match the codec type in the config file */
+export enum CodecType {
+  Bns = "bns",
+  Ethereum = "eth",
+  Lisk = "lsk",
+}
 
 export interface ConfigErc20Options {
   readonly name?: string;
@@ -17,7 +22,7 @@ export interface ConfigEthereumOptions {
 }
 
 export interface ChainSpec {
-  readonly codecType: CodecString;
+  readonly codecType: CodecType;
   readonly node: string;
   readonly name: string;
   readonly chainId: ChainId;

--- a/packages/sanes-browser-extension/src/extension/background/model/persona/index.ts
+++ b/packages/sanes-browser-extension/src/extension/background/model/persona/index.ts
@@ -34,13 +34,7 @@ import {
   SoftwareAccountManagerChainConfig,
 } from "../accountManager/softwareAccountManager";
 import { StringDb } from "../backgroundscript/db";
-import {
-  algorithmForCodec,
-  chainConnector,
-  codecTypeFromString,
-  getChains,
-  pathBuilderForCodec,
-} from "./config";
+import { algorithmForCodec, chainConnector, getChains, pathBuilderForCodec } from "./config";
 import { createTwoWalletProfile } from "./userprofilehelpers";
 
 function isNonUndefined<T>(t: T | undefined): t is T {
@@ -158,15 +152,14 @@ export class Persona {
     const managerChains: SoftwareAccountManagerChainConfig[] = [];
 
     for (const chainSpec of (await getChains()).map(chain => chain.chainSpec)) {
-      const codecType = codecTypeFromString(chainSpec.codecType);
-      const connector = chainConnector(codecType, chainSpec);
+      const connector = chainConnector(chainSpec);
 
       try {
         const { connection } = await signer.addChain(connector);
         managerChains.push({
           chainId: connection.chainId,
-          algorithm: algorithmForCodec(codecType),
-          derivePath: pathBuilderForCodec(codecType),
+          algorithm: algorithmForCodec(chainSpec.codecType),
+          derivePath: pathBuilderForCodec(chainSpec.codecType),
         });
       } catch (e) {
         console.error("Could not add chain. " + e);

--- a/packages/sil-governance/src/config/development.json
+++ b/packages/sil-governance/src/config/development.json
@@ -2,7 +2,6 @@
   "extensionId": "dafekhlcpidfaopcimocbcpciholgkkb",
   "bnsChain": {
     "chainSpec": {
-      "codecType": "bns",
       "node": "ws://localhost:23456/",
       "chainId": "local-iov-devnet",
       "name": "IOV Devnet"

--- a/packages/sil-governance/src/config/index.ts
+++ b/packages/sil-governance/src/config/index.ts
@@ -14,7 +14,6 @@ export interface ChainConfig {
 }
 
 export interface ChainSpec {
-  readonly codecType: string;
   readonly node: string;
   readonly name: string;
   readonly chainId: string;

--- a/packages/sil-governance/src/config/production.json
+++ b/packages/sil-governance/src/config/production.json
@@ -2,7 +2,6 @@
   "extensionId": "gegmganblgchemddleocdoadmljledcj",
   "bnsChain": {
     "chainSpec": {
-      "codecType": "bns",
       "node": "wss://rpc-private-a-vip-mainnet.iov.one/",
       "chainId": "iov-mainnet",
       "name": "IOV Mainnet"

--- a/packages/sil-governance/src/config/staging.json
+++ b/packages/sil-governance/src/config/staging.json
@@ -2,7 +2,6 @@
   "extensionId": "ililemcipflfijjbkniehikepfpdgail",
   "bnsChain": {
     "chainSpec": {
-      "codecType": "bns",
       "node": "wss://rpc-private-a-x-dancenet.iov.one/",
       "chainId": "iov-dancenet",
       "name": "IOV Dancenet"


### PR DESCRIPTION
Instead of having a string value and and enum separately, use an enum with explicit string values.

This makes it easier to add new chains since only the one enum needs to be extended.